### PR TITLE
Fix docs: align sample code with description

### DIFF
--- a/docs-md/basics/my-first-component.md
+++ b/docs-md/basics/my-first-component.md
@@ -13,12 +13,12 @@ import { Component, Prop } from '@stencil/core';
 })
 export class MyComponent {
   // Indicate that name should be a public property on the component
-  @Prop() firstName: string;
+  @Prop() name: string;
 
   render() {
     return (
     <p>
-      My name is {this.firstName}
+      My name is {this.name}
     </p>
     );
   }
@@ -27,7 +27,7 @@ export class MyComponent {
 Once compiled, this component can be used in HTML just like any other tag.
 
 ```html
-<my-first-component first-name="Max"></my-first-component>
+<my-first-component name="Max"></my-first-component>
 ```
 
 When rendered, the browser will display `My name is Max`.


### PR DESCRIPTION
The sample show and use a property firstName, but in the below description you refer it as simple "name" so I fix the code to match it