### PR TITLE
Fix doc sample inputChanged TS type-check error

### DIFF
--- a/docs-md/basics/learning-jsx.md
+++ b/docs-md/basics/learning-jsx.md
@@ -71,7 +71,7 @@ Here's another of listening to input `change`. Note the use of the [Arrow functi
 ...
 export class MyComponent {
   inputChanged(event: UIEvent) {
-    console.log('input changed: ', event.target.value);
+    console.log('input changed: ', (event.target as any).value);
   }
 
   render() {


### PR DESCRIPTION
In the sample `event` is declared `UIEvent` , this type has a property `target` of type `TargetEvent` that doesn't define the `value` property so Typescript complains / signal and error when you try to console.log(event.target.`value`);
Casting as any is a quick and simple solution, but if you prefer a more Strict typed solution the code maybe this:
```jsx
interface InputEvent extends UIEvent {
  target: EventTarget & { value: string }
}
...
export class MyComponent {
  inputChanged(event: InputEvent) {
    console.log('input changed: ', event.target.value);
  }

  render() {
    return (
      <input onChange={ (event: InputEvent) => this.inputChanged(event)}>
    );
  }
}
```

Notice the use of a custom interface to correctly define `target.value` type.