### PR TITLE
Fix docs: Clarify use of @Prop as attribute

### DIFF
--- a/docs-md/basics/building-components.md
+++ b/docs-md/basics/building-components.md
@@ -47,8 +47,12 @@ colorChanged(newColor: string) {
 
 Externally, Props are accessed directly on the element.
 
+```html
+<todo-list color="blue" favorite-number="24" is-selected="true"></todo-list>
 ```
-<todo-list color="blue" favoriteNumber="24" isSelected="true"></todo-list>
+Note: you need to hyphenated the propName to set it as an attribute in the HTML, but inside JSX template you can use propName:
+```jsx
+<todo-list color="blue" isSelected={true}></todo-list>
 ```
 
 They can also be accessed via JS from the element.


### PR DESCRIPTION
I noticed that if you have a "composed" `propName` and want to set is inside HTML (as an attribute) you need to hyphenated it as `prop-name` or it'll not be set, but inside JSX you can use directly the `propName` if you want.
The `prop-name` syntax works in both cases, so maybe it'll be preferred.