### PR TITLE
Fix docs @Listen sample to use event.detail

### DIFF
--- a/docs-md/basics/using-events.md
+++ b/docs-md/basics/using-events.md
@@ -37,7 +37,7 @@ export class TodoApp {
 
   @Listen('todoCompleted')
   todoCompletedHandler(event: CustomEvent) {
-    console.log('Received the custom todoCompleted event: ', event.data);
+    console.log('Received the custom todoCompleted event: ', event.detail);
   }
 }
 ```


### PR DESCRIPTION
I tested the sample and noticed that the event.`data` doesn't exists! 
I found that to correctly access to the payload emitted in the CustomEvent you need to read `event.detail`