### PR TITLE
docs(): fix SSR example

### DIFF
--- a/docs-md/advanced/ssr/index.md
+++ b/docs-md/advanced/ssr/index.md
@@ -23,6 +23,10 @@ var renderer = stencil.createRenderer({
   logLevel: 'debug'
 });
 
+// host the build directory as static files
+// so the app can pull client side scripts
+app.use('/build', express.static('www/build'));
+
 // If you want to use HTML5 style routing in your client, keep the catch-all route handler here,
 // otherwise change it to a more specific route
 app.get('/*', function (req, res, next) {

--- a/docs-md/advanced/ssr/index.md
+++ b/docs-md/advanced/ssr/index.md
@@ -18,7 +18,7 @@ var stencil = require('@stencil/core');
 // Create the stencil SSR renderer
 var renderer = stencil.createRenderer({
   rootDir: path.join(__dirname, './'),
-  buildDir: path.join(__dirname, './dist/build/'),
+  buildDir: path.join(__dirname, './www/build/'),
   namespace: 'app',
   logLevel: 'debug'
 });

--- a/docs-md/advanced/ssr/index.md
+++ b/docs-md/advanced/ssr/index.md
@@ -18,8 +18,8 @@ var stencil = require('@stencil/core');
 // Create the stencil SSR renderer
 var renderer = stencil.createRenderer({
   rootDir: path.join(__dirname, './'),
-  buildDir: path.join(__dirname, './dist/'),
-  namespace: 'Ionic',
+  buildDir: path.join(__dirname, './dist/build/'),
+  namespace: 'app',
   logLevel: 'debug'
 });
 


### PR DESCRIPTION
The server compiler looks for `<namespace>.registery.json` under the build path. This means that the build path needs to be `www/build`, and the namespace needs to be `app` since that's the stencil default. 