### PR TITLE
Fix docs: Add Listen keycode docs

### DIFF
--- a/docs-md/basics/using-events.md
+++ b/docs-md/basics/using-events.md
@@ -56,3 +56,10 @@ export class TodoList {
   }
 }
 ```
+
+There is another keyup events that can be registered such as
+
+- Enter
+- Escape
+- Space
+- Tab


### PR DESCRIPTION
Updated events doc with a list with the available keycodes.

From issue https://github.com/ionic-team/stencil-site/issues/30