### PR TITLE
Fix inline js not marked as expression in jsx

### DIFF
--- a/docs-md/basics/templating.md
+++ b/docs-md/basics/templating.md
@@ -83,12 +83,12 @@ In the example below, we're going to assume the component has a local property c
 render() {
   return (
     <div>
-      this.todos.map( todo => {
+      {this.todos.map( todo => {
         <div>
           <div>{todo.taskName}</div>
           <div>{todo.isCompleted}</div>
         </div>
-      })
+      })}
     </div>
   )
 }


### PR DESCRIPTION
As reported in https://github.com/ionic-team/stencil/issues/143 the map statement is laking the braces to mark them as an expression statement in jsx.