### PR TITLE
Server side rendering example not functional

### DIFF
--- a/docs-md/advanced/ssr/index.md
+++ b/docs-md/advanced/ssr/index.md
@@ -46,15 +46,15 @@ app.get('/*', function (req, res, next) {
       html: html,
       req: req,
       config: {}
-    }, function(err, html) {
-      if (err) {
+    }, function(results) {
+      if (results.diagnostics.length) {
         // Handle the error hydrating
-        console.error(err);
+        console.error(results.diagnostics);
         return res.sendStatus(500);
       }
 
       // Send the hydrated data back
-      res.send(html);
+      res.send(results.html);
     });
   });
 


### PR DESCRIPTION
The Node.js example at https://stenciljs.com/docs/server-side-rendering implements a callback that accepts an `err` and `html` argument, but looking at the actual invocation of the callback in the `@stencil/core` codebase, it appears that the callback should always accept one argument, representing a HydateResults object.

We should update the example to be functional, and handle errors properly by checking if diagnostics is not empty before returning rendered HTML.

Sources:
Callback invocation in case of error: https://github.com/ionic-team/stencil/blob/d1e129eb718333ae631253c81c1ba5ca1921e2d2/src/server/renderer.ts#L62
Callback invocation in case of success: https://github.com/ionic-team/stencil/blob/d1e129eb718333ae631253c81c1ba5ca1921e2d2/src/server/hydrate-html.ts#L23
HydateResults interface: https://github.com/ionic-team/stencil/blob/d1e129eb718333ae631253c81c1ba5ca1921e2d2/src/util/interfaces.ts#L1130