### PR TITLE
Fixes loops example

### DIFF
--- a/docs-md/basics/templating.md
+++ b/docs-md/basics/templating.md
@@ -134,12 +134,12 @@ In the example below, we're going to assume the component has a local property c
 render() {
   return (
     <div>
-      {this.todos.map((todo) => {
+      {this.todos.map((todo) => 
         <div>
           <div>{todo.taskName}</div>
           <div>{todo.isCompleted}</div>
         </div>
-      })}
+      )}
     </div>
   )
 }


### PR DESCRIPTION
This PR fixes the templating loops example, as the original doesn't return the inner body of the map function.