### PR TITLE
docs(): Add more info to stencil-config example

### DIFF
--- a/docs-md/basics/stencil-config.md
+++ b/docs-md/basics/stencil-config.md
@@ -13,6 +13,19 @@ exports.config = {
   ],
   collections: [
     { name: '@stencil/router' }
+  ],
+  serviceWorker: {
+    globPatterns: [
+      '**/*.{js,css,json,html,ico,png,jpeg}'
+    ],
+    globIgnores: [
+      'build/app/svg/*.js'
+    ]
+  },
+  copy: [
+    {
+       image: 'image.jpg'
+    }
   ]
 };
 ```


### PR DESCRIPTION
Just add more info to the stencil config example:

- Added service worker custom config.
- Added copy config.