### PR TITLE
docs(copy): add better description to copy config

### DIFF
--- a/docs-md/basics/stencil-config.md
+++ b/docs-md/basics/stencil-config.md
@@ -23,9 +23,8 @@ exports.config = {
     ]
   },
   copy: [
-    {
-       image: 'image.jpg'
-    }
+    { src: 'images' },
+    { src: 'styles', dest: 'css' }
   ]
 };
 ```
@@ -55,8 +54,8 @@ set any of the values listed [here in the Workbox documentation](https://workbox
 
 -  `copy`
 
-The `copy` config specifies any files that you would like to
-get copied over to your `buildDir` when a build is performed.
+The `copy` config is an array of objects that define any files or folders that you would like to
+get copied over to your `buildDir` when a build is performed. Each object in the array must include a `src` property which can be either an `absolute path`, a `relative path` or a `glob pattern`. You can also provide the optional `dest` property which can be either an `absolute path` or a path `relative` to your `buildDir`.
 
 <stencil-route-link url="/docs/testing" router="#router" custom="true" class="backButton">
   Back


### PR DESCRIPTION
Expand the documentation regarding the copy part of the configuration section on the website. Refers to #73 