### PR TITLE
Fix(): Revealjs link not working

### DIFF
--- a/src/components/resources-page/resources-page.tsx
+++ b/src/components/resources-page/resources-page.tsx
@@ -71,7 +71,7 @@ export class ResourcesPage {
           <p>
             A forkable presentation for your next meetup or conference
             talk on Stencil.
-            Built with <a href="lab.hakim.se/reveal-js/">Reveal.js</a>
+            Built with <a href="https://github.com/hakimel/reveal.js">Reveal.js</a>
           </p>
           <a target="_blank" href="https://ionic-team.github.io/stencil-present/">Stencil Presentation</a>
           <br />


### PR DESCRIPTION
I saw that the revealjs link on the resources page was not workng, trying to get this:

>https://stenciljs.com/lab.hakim.se/reveal-js/

I thought to make it point to the presentation link, but it is http:

>http://lab.hakim.se/reveal-js/#/

So i think its better to point it to the github repo using http:

>https://github.com/hakimel/reveal.js

