### PR TITLE
docs() update state management examples for clarity

### DIFF
--- a/docs-md/basics/decorators.md
+++ b/docs-md/basics/decorators.md
@@ -96,7 +96,7 @@ export class TodoList {
 
   completeTodo(todo: Todo) {
     // This will cause our render function to be called again
-    this.completedTodos = this.completedTodos.concat([]).push(todo);
+    this.completedTodos = [...this.completedTodos, todo]; 
   }
 
   render() {
@@ -180,15 +180,13 @@ export class TodoList {
   @State() completedTodos: Todo[];
 
   completeTodo(todo: Todo) {
-    const completedTodos = this.completedTodos.concat([]);
-    completedTodos.push(todo);
-    // by setting the value, Stencil re-renders
-    this.completedTodos = completedTodos;
+    this.completedTodos = [...this.completedTodos, todo];
   }
 }
 ```
 
-In the above example, the key line is `this.completedTodos = completedTodos;`.
+In the above example, we set `this.completedTodos` to a new array made up of the existing `completedTodos` and our new `todo`.
+
 This calls the `completedTodos` setter, which triggers the re-render.
 
 


### PR DESCRIPTION
This updates the code examples in "Managing Component State" to use spread instead of `concat()`. In my opinion, spread makes it clearer that you're assembling a new array. Plus, you don't have to rely on the knowledge that `concat()` doesn't mutate. Definitely open to counter-points.