### PR TITLE
docs(router): correct usage of template literals

### DIFF
--- a/docs-md/addons/stencil-router.md
+++ b/docs-md/addons/stencil-router.md
@@ -124,7 +124,7 @@ You may be familiar with the concept of URL params from [React Router](https://r
 The key part in this route is the `:pageNum` syntax. This means that we can now pass data to that route and it will be accessible through the `pageNum` variable. Below is an example of how we would pass data to this route:
 
 ```
-<stencil-route-link url=`/show/${someData}` />
+<stencil-route-link url={`/show/${someData}`} />
 ```
 
 Now lets go over how to access this data from the `show-page` component we are routing too.


### PR DESCRIPTION
The template literal usage in the documentation is not surrounded by `{}` when used in the JSX which yields a compilation error.