### PR TITLE
docs(advanced): correct script tag syntax error

### DIFF
--- a/docs-md/advanced/distribution/index.md
+++ b/docs-md/advanced/distribution/index.md
@@ -55,7 +55,7 @@ The first step for all three of these strategies is to
 
 ### Node Modules
 - Run `npm install my-name --save`
-- Put a script tag similar to this `<script src='node_modules/my-name/dist/myname.js></script>` in the head of your index.html
+- Put a script tag similar to this `<script src='node_modules/my-name/dist/myname.js'></script>` in the head of your index.html
 - Then you can use the element anywhere in your template, JSX, html etc.
 
 ### In a stencil-app-starter app


### PR DESCRIPTION
Related: #96