### PR TITLE
docs(several pages): fix typos and spelling errors

### DIFF
--- a/docs-md/addons/stencil-router.md
+++ b/docs-md/addons/stencil-router.md
@@ -35,7 +35,7 @@ exports.config = {
   You should have one single stencil-router component in your project.  This component controls all interactions with the browser history and it aggregates updates through an event system.
 
 - **stencil-route**
-  
+
   This component renders based on whether the supplied url matches the current location.
 
   *properties*:
@@ -127,7 +127,7 @@ The key part in this route is the `:pageNum` syntax. This means that we can now 
 <stencil-route-link url={`/show/${someData}`} />
 ```
 
-Now lets go over how to access this data from the `show-page` component we are routing too.
+Now let's go over how to access this data from the `show-page` component we are routing too.
 
 
 First, we need to pass the `match` prop to our `show-page` component:

--- a/docs-md/advanced/service-worker/index.md
+++ b/docs-md/advanced/service-worker/index.md
@@ -1,6 +1,6 @@
 # Service Workers
 
-[Service workers](https://developers.google.com/web/fundamentals/getting-started/primers/service-workers) are a very powerful api that is essential for [PWAs](https://blog.ionic.io/what-is-a-progressive-web-app/), but can be hard to use. To help with this, we decided to build support for Service Workers into Stencil itself using [Workbox](https://workboxjs.org/). 
+[Service workers](https://developers.google.com/web/fundamentals/getting-started/primers/service-workers) are a very powerful api that is essential for [PWAs](https://blog.ionic.io/what-is-a-progressive-web-app/), but can be hard to use. To help with this, we decided to build support for Service Workers into Stencil itself using [Workbox](https://workboxjs.org/).
 
 ### Usage
 
@@ -44,7 +44,7 @@ exports.config = {
 
 Already have a service worker or want to include some custom code? We support that too.
 
-Lets go through the steps needed for this functionality:
+Let's go through the steps needed for this functionality:
 
 - First we need to pass the path to our custom service worker to the `swSrc` command in the serviceWorker config. Here is an example:
 

--- a/docs-md/basics/forms.md
+++ b/docs-md/basics/forms.md
@@ -2,7 +2,7 @@
 
 ### Basic forms
 
-Here is an example of a component with a basic form: 
+Here is an example of a component with a basic form:
 
 ```
 @Component({
@@ -37,7 +37,7 @@ export class MyName {
 }
 ```
 
-Lets go over what is happening here. First we bind the value of the input to a state variable, in this case `this.value`. We then set our state variable to the new value of the input with the `handleChange` method we have bound to `onInput`. `onInput` will fire every keystroke that the user types into the input.
+Let's go over what is happening here. First we bind the value of the input to a state variable, in this case `this.value`. We then set our state variable to the new value of the input with the `handleChange` method we have bound to `onInput`. `onInput` will fire every keystroke that the user types into the input.
 
 
 ### Advanced forms

--- a/docs-md/basics/my-first-component.md
+++ b/docs-md/basics/my-first-component.md
@@ -63,8 +63,8 @@ We set this property like so:
 ```html
 <my-first-component name="Max"></my-first-component>
 ```
-Any property decorated with `@Props()` is also automatically watched for changes.
-If a user of our component were to change the element's `name` property, our component would fire it's `render` function again, updating the displayed content.
+Any property decorated with `@Prop()` is also automatically watched for changes.
+If a user of our component were to change the element's `name` property, our component would fire its `render` function again, updating the displayed content.
 
 <stencil-route-link url="/docs/getting-started" router="#router" custom="true">
   <button class="backButton">


### PR DESCRIPTION
This is the fix for issue #98.

Other than the expected changes, my editor (VS Code) has automatically stripped a few blanks at the end of lines, which should have no effect.