### PR TITLE
docs(distribution) update required package keys

### DIFF
--- a/docs-md/advanced/distribution/index.md
+++ b/docs-md/advanced/distribution/index.md
@@ -30,13 +30,12 @@ You also need to add the following to your `package.json`:
 
 ```
 {
-  "main": "dist/collection/index.js",
-  "types": "dist/collection/index.d.ts",
+  "main": "dist/myname.js",
+  "types": "dist/types/components.d.ts",
   "collection": "dist/collection/collection-manifest.json",
   "files": [
     "dist/"
-  ],
-  "browser": "dist/myname.js",
+  ]
   ...
 }
 ```


### PR DESCRIPTION
👋 

I've been creating a distribution and it seems like those docs are outdated. Specifically, the keys that are required in `package.json` for a distribution look outdated:

```json
{
  "main": "dist/collection/index.js",
  "types": "dist/collection/index.d.ts",
  "collection": "dist/collection/collection-manifest.json",
  "files": [
    "dist/"
  ],
  "browser": "dist/myname.js"
}
```
The compiler actually threw a helpful error letting me know what needed updating. Here's what I think we want:

```json
"main": "dist/myname.js",
"types": "dist/types/components.d.ts",
"collection": "dist/collection/collection-manifest.json",
"files": [
  "dist/"
]
```

Also, I don't believe we need the `browser` key anymore if it's the same as `main`.