### PR TITLE
docs(distribution): fix paths in package.json

### DIFF
--- a/docs-md/advanced/distribution/index.md
+++ b/docs-md/advanced/distribution/index.md
@@ -30,8 +30,8 @@ You also need to add the following to your `package.json`:
 
 ```
 {
-  "main": "dist/collection/index.js",
-  "types": "dist/collection/index.d.ts",
+  "main": "dist/myname.js",
+  "types": "dist/types/components.d.ts",
   "collection": "dist/collection/collection-manifest.json",
   "files": [
     "dist/"


### PR DESCRIPTION
Right now the paths are wrong (outdated?) and this wouldn't build. 