### PR TITLE
docs(decorators): typo and pluralization

### DIFF
--- a/src/docs-content/basics/decorators.html
+++ b/src/docs-content/basics/decorators.html
@@ -8,7 +8,7 @@
 <li><a href="#method">method</a></li>
 <li><a href="#element">element</a></li>
 </ul>
-<p><a href="component"></a></p>
+<p><a name="component"></a></p>
 <h2 id="component-decorator">Component Decorator</h2>
 <p>Each Stencil Component must be decorated with an <code>@Component()</code> decorator from the <code>@stencil/core</code> package. In the simplest case, developer&#39;s must provide a HTML <code>tag</code> name for the component. Often times, a <code>styleUrl</code> is used as well, or even <code>styleUrls</code>, where multiple different style sheets can be provided for different application modes/themes.</p>
 <p>Use a relative url to the <code>.scss</code> file for the styleUrl(s).</p>
@@ -37,9 +37,9 @@
 <p>When this component is used it will now have both the <code>todo</code> class and the <code>role</code> attribute automatically added.</p>
 <pre><code class="lang-html">&lt;todo-list <span class="hljs-class"><span class="hljs-keyword">class</span></span>=<span class="hljs-string">'todo'</span> role=<span class="hljs-string">'list'</span>&gt;<span class="xml"><span class="hljs-tag">&lt;/<span class="hljs-name">todo-list</span>&gt;</span></span>
 </code></pre>
-<p><a href="prop"></a></p>
+<p><a name="prop"></a></p>
 <h2 id="prop-decorator">Prop Decorator</h2>
-<p>Props are custom attribute/properties exposed publicly on the element that developers can provide values for. Children components should not know about or reference parent components, so Props should be used to pass data down from the parent to the child. Components need to explicitly declare the Props it expects to receive using the <code>@Prop()</code> decorator. Props can be a <code>number</code>, <code>string</code>, <code>boolean</code>, or even an <code>Object</code> or <code>Array</code>. By default, when a member decorated with a <code>@Prop()</code> decorator is set, the component will efficiently re-render.</p>
+<p>Props are custom attribute/properties exposed publicly on the element that developers can provide values for. Children components should not know about or reference parent components, so Props should be used to pass data down from the parent to the child. Components need to explicitly declare the Props they expect to receive using the <code>@Prop()</code> decorator. Props can be a <code>number</code>, <code>string</code>, <code>boolean</code>, or even an <code>Object</code> or <code>Array</code>. By default, when a member decorated with a <code>@Prop()</code> decorator is set, the component will efficiently re-render.</p>
 <pre><code class="lang-typescript"><span class="hljs-keyword">import</span> { Prop } from <span class="hljs-string">'@stencil/core'</span>;
 ...
 export <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">TodoList</span> {</span>
@@ -68,7 +68,7 @@ export <span class="hljs-class"><span class="hljs-keyword">class</span> <span cl
 </code></pre>
 <h3 id="prop-value-mutability">Prop value mutability</h3>
 <p>It&#39;s important to know, that <code>@Prop</code> is <em>by default</em> immutable from inside the component logic. Once a value is set by a user, the component cannot update it internally.</p>
-<p>However, it&#39;s possible to explicitly allow a <code>@Prop</code> to be mutated from inside the component, by declaring it as <strong>mutable</strong>, as in example blow:</p>
+<p>However, it&#39;s possible to explicitly allow a <code>@Prop</code> to be mutated from inside the component, by declaring it as <strong>mutable</strong>, as in the example below:</p>
 <pre><code class="lang-typescript"><span class="hljs-keyword">import</span> { Prop } <span class="hljs-keyword">from</span> <span class="hljs-string">'@stencil/core'</span>;
 ...
 <span class="hljs-keyword">export</span> <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">NameElement</span> {</span>
@@ -108,7 +108,7 @@ export <span class="hljs-class"><span class="hljs-keyword">class</span> <span cl
 <span class="hljs-attr">  reflectToAttr:</span> <span class="hljs-literal">true</span>
 <span class="hljs-string">})</span>
 </code></pre>
-<p><a href="watch"></a></p>
+<p><a name="watch"></a></p>
 <h2 id="watch-decorator">Watch Decorator</h2>
 <p>When a user updates a property, <code>Watch</code> will fire what ever method they&#39;re attached to.</p>
 <pre><code class="lang-typescript"><span class="hljs-keyword">import</span> { Prop, Watch } from <span class="hljs-string">'@stencil/core'</span>;
@@ -140,7 +140,7 @@ export <span class="hljs-class"><span class="hljs-keyword">class</span> <span cl
   }
 }
 </code></pre>
-<p><a href="method"></a></p>
+<p><a name="method"></a></p>
 <h2 id="method-decorator">Method Decorator</h2>
 <p>The <code>@Method()</code> decorator is used to expose methods on the public API. Functions decorated with the <code>@Method()</code> decorator can be called directly from the element.</p>
 <pre><code class="lang-typescript"><span class="hljs-keyword">import</span> { Method } <span class="hljs-keyword">from</span> <span class="hljs-string">'@stencil/core'</span>;
@@ -158,7 +158,7 @@ export <span class="hljs-class"><span class="hljs-keyword">class</span> <span cl
 <pre><code class="lang-typescript"><span class="hljs-keyword">const</span> todoListElement = <span class="hljs-built_in">document</span>.<span class="hljs-built_in">querySelector</span>(<span class="hljs-string">'todo-list'</span>);
 todoListElement.showPrompt();
 </code></pre>
-<p><a href="element"></a></p>
+<p><a name="element"></a></p>
 <h2 id="element-decorator">Element Decorator</h2>
 <p>The <code>@Element()</code> decorator is how to get access to the host element within the class instance. This returns an instance of an <code>HTMLElement</code>, so standard DOM methods/events can be used here.</p>
 <pre><code><span class="hljs-keyword">import</span> { Element } <span class="hljs-keyword">from</span> <span class="hljs-string">'@stencil/core'</span>;

--- a/src/docs-md/basics/decorators.md
+++ b/src/docs-md/basics/decorators.md
@@ -52,7 +52,7 @@ When this component is used it will now have both the `todo` class and the `role
 <a name="prop"></a>
 ## Prop Decorator
 
-Props are custom attribute/properties exposed publicly on the element that developers can provide values for. Children components should not know about or reference parent components, so Props should be used to pass data down from the parent to the child. Components need to explicitly declare the Props it expects to receive using the `@Prop()` decorator. Props can be a `number`, `string`, `boolean`, or even an `Object` or `Array`. By default, when a member decorated with a `@Prop()` decorator is set, the component will efficiently re-render.
+Props are custom attribute/properties exposed publicly on the element that developers can provide values for. Children components should not know about or reference parent components, so Props should be used to pass data down from the parent to the child. Components need to explicitly declare the Props they expect to receive using the `@Prop()` decorator. Props can be a `number`, `string`, `boolean`, or even an `Object` or `Array`. By default, when a member decorated with a `@Prop()` decorator is set, the component will efficiently re-render.
 
 ```typescript
 import { Prop } from '@stencil/core';
@@ -99,7 +99,7 @@ console.log(todoListElement.color); // blue
 
 It's important to know, that `@Prop` is _by default_ immutable from inside the component logic. Once a value is set by a user, the component cannot update it internally.
 
-However, it's possible to explicitly allow a `@Prop` to be mutated from inside the component, by declaring it as **mutable**, as in example blow:
+However, it's possible to explicitly allow a `@Prop` to be mutated from inside the component, by declaring it as **mutable**, as in the example below:
 
 ```typescript
 import { Prop } from '@stencil/core';


### PR DESCRIPTION
Small typo "blow" changed to "below". Added a definite article for clarity/structure.

Modified pronoun so that it agreed with its antecedent in number. Components (plural) specify which props _they_ expect to receive. One component would specify which props _it_ expects to receive.