### PR TITLE
Fix wrong link to router docs

### DIFF
--- a/src/docs-content/introduction/getting-started.html
+++ b/src/docs-content/introduction/getting-started.html
@@ -22,7 +22,7 @@ npm install
 <p>Then, to start a live-reload server for development, run:</p>
 <pre><code class="lang-bash"><span class="hljs-built_in">npm</span> start
 </code></pre>
-<p>This will give you a project with everything needed to build a fast, modern web app using Web Components. This project comes with the <a href="/docs/routing">stencil-router</a> pre-installed.</p>
+<p>This will give you a project with everything needed to build a fast, modern web app using Web Components. This project comes with the <a href="/docs/router">stencil-router</a> pre-installed.</p>
 <h3 id="updating-stencil">Updating Stencil</h3>
 <p>To get the latest version of @stencil/core you can run <code>npm install @stencil/core@latest --save-exact</code>.</p>
 <p><stencil-route-link url="/docs/introduction" router="#router" custom="true">


### PR DESCRIPTION
Link to __router docs__ points to `/docs/routing` instead of `/docs/router` which results in effects like shown in #35 