### PR TITLE
docs(watch): add watch usage recommendation

### DIFF
--- a/src/docs-md/reference/decorators.md
+++ b/src/docs-md/reference/decorators.md
@@ -158,7 +158,7 @@ In some cases it may be useful to keep a property in sync with an attribute. In 
 <a name="watch"></a>
 ## Watch Decorator
 
-When a user updates a property, `Watch` will fire what ever method it's attached to and pass that methd the new value of the prop along with the old value.
+When a user updates a property, `Watch` will fire what ever method it's attached to and pass that methd the new value of the prop along with the old value. `Watch` is useful for validating props or handling side effects.
 
 
 ```typescript


### PR DESCRIPTION
I've seen a few examples of users using `Watch` to operate on the DOM:

```ts
@Watch('someProp')
doSomething(newVal, oldVal) {
    someChild.classList.toggle('has-some-prop', newVal);
}
```

When they should be handling that in render:

```ts
render() {
    return <div class={{ 'has-some-prop': this.someProp }}/>;
}
```

So I thought we should mention a couple of recommended uses for `Watch`. Not sure if it's worth specifically discouraging. What do you think?