### PR TITLE
Add Ember to framework integration guide

### DIFF
--- a/src/docs-content/framework-integration/ember.html
+++ b/src/docs-content/framework-integration/ember.html
@@ -1,0 +1,11 @@
+<h1 id="ember">Ember</h1>
+<p>Working with Stencil components in Ember is really easy thanks to the <code>ember-cli-stencil</code> addon. It handles:</p>
+<ul>
+<li>Importing the required files into your <code>vendor.js</code></li>
+<li>Copying the component definitions into your <code>assets</code> directory</li>
+<li>Optionally generating a wrapper component for improved compatibility with older Ember versions</li>
+</ul>
+<p>Start off by installing the Ember addon</p>
+<pre><code class="lang-bash">ember install ember-<span class="hljs-keyword">cli</span>-stencil
+</code></pre>
+<p>Now, when you build your application, Stencil collections in your dependencies will automatically be discovered and pulled into your application. You can just start using the custom elements in your <code>hbs</code> files with no further work needed. For more information, check out the <a href="https://github.com/alexlafroscia/ember-cli-stencil"><code>ember-cli-stencil</code> documentation</a>.</p>

--- a/src/docs-content/guides/framework-integration.html
+++ b/src/docs-content/guides/framework-integration.html
@@ -79,6 +79,17 @@
 ReactDOM.render(&lt;App /&gt;, <span class="hljs-built_in">document</span>.getElementById(<span class="hljs-string">'root'</span>));
 registerServiceWorker();
 </code></pre>
+<h2 id="ember">Ember</h2>
+<p>Working with Stencil components in Ember is really easy thanks to the <code>ember-cli-stencil</code> addon. It handles:</p>
+<ul>
+<li>Importing the required files into your <code>vendor.js</code></li>
+<li>Copying the component definitions into your <code>assets</code> directory</li>
+<li>Optionally generating a wrapper component for improved compatibility with older Ember versions</li>
+</ul>
+<p>Start off by installing the Ember addon</p>
+<pre><code class="lang-bash">ember install ember-<span class="hljs-keyword">cli</span>-stencil
+</code></pre>
+<p>Now, when you build your application, Stencil collections in your dependencies will automatically be discovered and pulled into your application. You can just start using the custom elements in your <code>hbs</code> files with no further work needed. For more information, check out the <a href="https://github.com/alexlafroscia/ember-cli-stencil"><code>ember-cli-stencil</code> documentation</a>.</p>
 <p><stencil-route-link url="/docs/router" router="#router" custom="true">
   <button class="pull-left btn btn--secondary">
     Back

--- a/src/docs-md/framework-integration/ember.md
+++ b/src/docs-md/framework-integration/ember.md
@@ -1,0 +1,15 @@
+# Ember
+
+Working with Stencil components in Ember is really easy thanks to the `ember-cli-stencil` addon. It handles:
+
+- Importing the required files into your `vendor.js`
+- Copying the component definitions into your `assets` directory
+- Optionally generating a wrapper component for improved compatibility with older Ember versions
+
+Start off by installing the Ember addon
+
+```bash
+ember install ember-cli-stencil
+```
+
+Now, when you build your application, Stencil collections in your dependencies will automatically be discovered and pulled into your application. You can just start using the custom elements in your `hbs` files with no further work needed. For more information, check out the [`ember-cli-stencil` documentation](https://github.com/alexlafroscia/ember-cli-stencil).

--- a/src/docs-md/guides/framework-integration.md
+++ b/src/docs-md/guides/framework-integration.md
@@ -106,6 +106,21 @@ import 'test-components/testcomponents';
 ReactDOM.render(<App />, document.getElementById('root'));
 registerServiceWorker();
 ```
+## Ember
+
+Working with Stencil components in Ember is really easy thanks to the `ember-cli-stencil` addon. It handles:
+
+- Importing the required files into your `vendor.js`
+- Copying the component definitions into your `assets` directory
+- Optionally generating a wrapper component for improved compatibility with older Ember versions
+
+Start off by installing the Ember addon
+
+```bash
+ember install ember-cli-stencil
+```
+
+Now, when you build your application, Stencil collections in your dependencies will automatically be discovered and pulled into your application. You can just start using the custom elements in your `hbs` files with no further work needed. For more information, check out the [`ember-cli-stencil` documentation](https://github.com/alexlafroscia/ember-cli-stencil).
 
 <stencil-route-link url="/docs/router" router="#router" custom="true">
   <button class="pull-left btn btn--secondary">


### PR DESCRIPTION
I recently build [`ember-cli-stencil`](https://github.com/alexlafroscia/ember-cli-stencil) which makes it really, really easy to use Stencil components in an Ember app. With the addon installed, and at least one Stencil collection in your dependencies, it will handle all the additional work around discovering where the files are, importing them correctly and copying the lazy-loaded files into the right location in the `dist`. It also supports some "glue code" for better compatibility with older Ember versions ([see wiki for details](https://github.com/alexlafroscia/ember-cli-stencil/wiki/Ember-component-wrappers)).

I decided to just show the absolute minimal guide in the guide here and to instead redirect people to the addon README for additional details. If there's more information you want me to include on your docs site, I'm happy to elaborate more (although there really isn't much more to say besides "install the addon and it does everything else for you!")