### PR TITLE
Setting headers to empty array before pushing host data.

### DIFF
--- a/scripts/host-to-firebase.js
+++ b/scripts/host-to-firebase.js
@@ -11,6 +11,7 @@ fs.readFile('www/host.config.json', 'utf-8', (err, data) => {
         console.log(`Something went wrong: ${err}`);
       } else {
         const firebaseData = JSON.parse(data);
+        firebaseData.hosting.headers = [];
         headerData.map((entry) => {
 
           const newHeaderObject = {


### PR DESCRIPTION
Without this line, the firebase.json file would keep getting larger (with duplicate data) every time the script is ran.