### PR TITLE
Line up Distribution page with the Stencil Component Starter

### DIFF
--- a/src/docs-content/guides/distribution.html
+++ b/src/docs-content/guides/distribution.html
@@ -47,6 +47,7 @@
 <h3 id="in-a-stencil-app-starter-app">In a stencil-app-starter app</h3>
 <ul>
 <li>Run <code>npm install my-name --save</code></li>
+<li>Add an import to the npm packages: <code>import my-component</code>;</li>
 <li>Then you can use the element anywhere in your template, JSX, html etc</li>
 </ul>
 <p><stencil-route-link url="/docs/config" router="#router" custom="true">

--- a/src/docs-md/guides/distribution.md
+++ b/src/docs-md/guides/distribution.md
@@ -65,6 +65,7 @@ The first step for all three of these strategies is to
 
 ### In a stencil-app-starter app
 - Run `npm install my-name --save`
+- Add an import to the npm packages: `import my-component`;
 - Then you can use the element anywhere in your template, JSX, html etc
 
 


### PR DESCRIPTION
[Stencil Component Starter](https://github.com/ionic-team/stencil-component-starter/blob/master/readme.md) has a reference to the following text:

> Add an import to the npm packages `import my-component;`

Which is absent from the Stencil Docs. This PR simply adds that statement.