### PR TITLE
docs(host-element): add host element docs page

### DIFF
--- a/src/components/site-menu/site-menu.tsx
+++ b/src/components/site-menu/site-menu.tsx
@@ -74,6 +74,12 @@ export class SiteMenu {
               </li>
 
               <li>
+                <stencil-route-link url='/docs/host-element' onClick={() => this.toggleMenu()}>
+                  Host Element
+                </stencil-route-link>
+              </li>
+
+              <li>
                 <stencil-route-link url='/docs/reactive-data' onClick={() => this.toggleMenu()}>
                   Reactive Data
                 </stencil-route-link>

--- a/src/components/stencil-site/stencil-site.tsx
+++ b/src/components/stencil-site/stencil-site.tsx
@@ -81,6 +81,7 @@ export class App {
                     'component-lifecycle': 'reference/component-lifecycle.html',
                     'decorators': 'reference/decorators.html',
                     'events': 'reference/events.html',
+                    'host-element': 'reference/host-element.html',
                     'reactive-data': 'reference/reactive-data.html',
                     'templating-jsx': 'reference/templating-and-jsx.html',
                     'styling': 'reference/styling.html',

--- a/src/docs-content/reference/host-element.html
+++ b/src/docs-content/reference/host-element.html
@@ -1,0 +1,30 @@
+<h1 id="working-with-host-elements">Working with host elements</h1>
+<p>Stencil components render their children declaratively in their <code>render</code> method <a href="/docs/templating-jsx">using JSX</a>. However, sometimes you will need to set properties on the host element itself. Stencil provides a couple of ways to access and update the host element.</p>
+<h2 id="element-decorator">Element Decorator</h2>
+<p>The <a href="/docs/decorators#element">Element decorator</a> provides direct access to the host element, an instance of <code>HTMLElement</code>. This is useful if you need access to underlying DOM methods or properties.</p>
+<p>If you need to update the host element in response to prop or state changes, you should do so using the <code>hostData</code> method.</p>
+<pre><code class="lang-tsx"><span class="hljs-keyword">import</span> { Element } from <span class="hljs-string">'@stencil/core'</span>;
+
+...
+export <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">TodoList</span> </span>{
+
+  <span class="hljs-meta">@Element()</span> el: HTMLElement;
+
+  getListHeight(): number {
+    <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>.el.getBoundingClientRect().height;
+  }
+}
+</code></pre>
+<h2 id="hostdata">hostData</h2>
+<p>The <code>hostData</code> method can be implemented by any Stencil component and provides a way to declaratively set properties on the host element during rendering. The <code>hostData</code> method is called whenever <code>render</code> is, so it is useful for reacting to state and prop changes.</p>
+<pre><code class="lang-tsx">...
+export <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">TodoList</span> </span>{
+
+  hostData() {
+    <span class="hljs-keyword">return</span> {
+      <span class="hljs-string">'class'</span>: { <span class="hljs-string">'is-open'</span>: <span class="hljs-keyword">this</span>.isOpen },
+      <span class="hljs-string">'aria-hidden'</span>: <span class="hljs-keyword">this</span>.isOpen ? <span class="hljs-string">'false'</span> : <span class="hljs-string">'true'</span>
+    };
+  }
+}
+</code></pre>

--- a/src/docs-md/reference/host-element.md
+++ b/src/docs-md/reference/host-element.md
@@ -1,0 +1,40 @@
+# Working with host elements
+
+Stencil components render their children declaratively in their `render` method [using JSX](/docs/templating-jsx). However, sometimes you will need to set properties on the host element itself. Stencil provides a couple of ways to access and update the host element.
+
+## Element Decorator
+
+The [Element decorator](/docs/decorators#element) provides direct access to the host element, an instance of `HTMLElement`. This is useful if you need access to underlying DOM methods or properties.
+
+If you need to update the host element in response to prop or state changes, you should do so using the `hostData` method.
+
+```tsx
+import { Element } from '@stencil/core';
+
+...
+export class TodoList {
+
+  @Element() el: HTMLElement;
+
+  getListHeight(): number {
+    return this.el.getBoundingClientRect().height;
+  }
+}
+```
+
+## hostData
+
+The `hostData` method can be implemented by any Stencil component and provides a way to declaratively set properties on the host element during rendering. The `hostData` method is called whenever `render` is, so it is useful for reacting to state and prop changes.
+
+```tsx
+...
+export class TodoList {
+
+  hostData() {
+    return {
+      'class': { 'is-open': this.isOpen },
+      'aria-hidden': this.isOpen ? 'false' : 'true'
+    };
+  }
+}
+```


### PR DESCRIPTION
This adds a dedicated page to the Stencil docs for handling the host element. There's not a ton there, but I think it's an important page for people coming from something like React, where there isn't really a notion of host elements.

Totally open to style changes and content suggestions.