### PR TITLE
 Fix typo in `componentDidUpdate` docs

### DIFF
--- a/src/docs-md/reference/component-lifecycle.md
+++ b/src/docs-md/reference/component-lifecycle.md
@@ -55,7 +55,7 @@ export class MyComponent {
    * Called multiple times throughout the life of
    * the component as it updates.
    *
-   * componentWillUpdate is not called on the
+   * componentDidUpdate is not called on the
    * first render.
    */
   componentDidUpdate() {


### PR DESCRIPTION
`componentDidUpdate` docs erroneously refer to `componentWillUpdate` (copy-paste error).