### PR TITLE
docs(distribution): correction in import statement for importing published component

### DIFF
--- a/src/docs-content/guides/distribution.html
+++ b/src/docs-content/guides/distribution.html
@@ -47,7 +47,7 @@
 <h3 id="in-a-stencil-app-starter-app">In a stencil-app-starter app</h3>
 <ul>
 <li>Run <code>npm install my-name --save</code></li>
-<li>Add an import to the npm packages: <code>import my-component</code>;</li>
+<li>Add an import to the npm packages: <code>import &#39;my-name&#39;;</code></li>
 <li>Then you can use the element anywhere in your template, JSX, html etc.</li>
 </ul>
 <p><stencil-route-link url="/docs/config" router="#router" custom="true">


### PR DESCRIPTION
import my-component isn't a proper statement. It emphasizes that we are importing any component instead of published project/lib.