### PR TITLE
 (#205) Fixed typo on getting started page. Components -> Component

### DIFF
--- a/src/docs-content/introduction/getting-started.html
+++ b/src/docs-content/introduction/getting-started.html
@@ -4,7 +4,7 @@
 <h3 id="reusable-components">Reusable Components</h3>
 <p>Stencil can be used to create standalone components, or entire apps.</p>
 <p>To build standalone components, such as a reusable UI element or library, you can use the component starter:</p>
-<pre><code class="lang-bash">npm init stencil <span class="hljs-built_in">components</span> my-<span class="hljs-built_in">components</span>
+<pre><code class="lang-bash">npm init stencil <span class="hljs-built_in">component</span> my-<span class="hljs-built_in">components</span>
 </code></pre>
 <p>Then, to start a live-reload server complete with HMR for development, run:</p>
 <pre><code class="lang-bash"><span class="hljs-built_in">npm</span> start


### PR DESCRIPTION
npm init stencil components throws an error, the correct command is singular 'component'

This fixes #205 