### PR TITLE
Added missing app-marked stylesheet

### DIFF
--- a/src/components/app-marked/app-marked.tsx
+++ b/src/components/app-marked/app-marked.tsx
@@ -2,7 +2,8 @@ import { Component, Prop, State, Watch, ComponentInterface } from '@stencil/core
 import { MarkdownContent } from '../../global/definitions';
 
 @Component({
-  tag: 'app-marked'
+  tag: 'app-marked',
+  styleUrl: 'app-marked.css'
 })
 export class AppMarked implements ComponentInterface {
 


### PR DESCRIPTION
 which caused problems with overflows on mobile devices on pages with code blocks.