### PR TITLE
docs: update templating link

### DIFF
--- a/src/docs/introduction/my-first-component.md
+++ b/src/docs/introduction/my-first-component.md
@@ -60,7 +60,7 @@ This is where you'll write the bulk of your code to bring your Stencil component
 Here is where you'd write functions or provide business logic.
 
 In order for the component to render something to the screen, we must declare a render function that returns JSX.
-If you're not sure what JSX is, don't worry, we'll go over it in detail in the <stencil-route-link url="/docs/templating">Templating Docs</stencil-router-link>.
+If you're not sure what JSX is, don't worry, we'll go over it in detail in the <stencil-route-link url="/docs/templating-jsx">Templating Docs</stencil-router-link>.
 
 The quick idea is that our render function needs to return a representation of the HTML we want to push to the DOM.
 


### PR DESCRIPTION
Link currently goes to a page that doesn't exist