### PR TITLE
docs: improve event documentation

### DIFF
--- a/src/docs/components/events.md
+++ b/src/docs/components/events.md
@@ -28,6 +28,39 @@ export class TodoList {
 
 The code above will dispatch a custom DOM event called `todoCompleted`.
 
+The `Event()` decorator optionally accepts an options object to shape the behavior of dispatched events. The options and defaults are described below
+
+```tsx
+import { Event, EventEmitter } from '@stencil/core';
+
+...
+export class TodoList {
+
+  @Event({
+    /*
+     * A string custom event name to override the default
+     */
+    eventName: 'todoCompleted',
+    /*
+     * A Boolean value indicating whether or not the event can bubble across the boundary between the shadow DOM and the regular DOM.
+     */
+    composed: true,
+    /*
+     * A Boolean indicating whether the event is cancelable
+     */
+    cancelable: true,
+    /*
+     * A Boolean indicating whether the event bubbles up through the DOM or not.
+     */
+    bubbles: true,
+  }) todoCompleted: EventEmitter;
+
+  todoCompletedHandler(todo: Todo) {
+    this.todoCompleted.emit(todo);
+  }
+}
+```
+
 ## Listening for Events
 
 The `Listen()` decorator is for handling events dispatched from `@Events`.
@@ -78,7 +111,6 @@ handleKeyDown(ev){
 handleUpArrow(ev){
   console.log('will fire when up arrow is pressed');
 }
-
 ```
 
 Stencil provides constants for the following keys, accessible via `keydown.<CONSTANT>`
@@ -94,7 +126,7 @@ Stencil provides constants for the following keys, accessible via `keydown.<CONS
 
 ## Using events in JSX
 
-You can also bind listeners to events directly in JSX. This works very similar to normal DOM events such as `onClick`.
+Within a stencil compiled application or component you can also bind listeners to events directly in JSX. This works very similar to normal DOM events such as `onClick`.
 
 Lets use our TodoList component from above:
 
@@ -115,5 +147,5 @@ export class TodoList {
 We can now listen to this event directly on the component in our JSX using the following syntax:
 
 ```tsx
-<todo-list onTodoCompleted={ev => this.someMethod(ev)}></todo-list>
+<todo-list onTodoCompleted={ev => this.someMethod(ev)} />
 ```


### PR DESCRIPTION
Adds description of the options object accepted by the Event decorator, and specifies that usage in jsx applies to stencil compiled code

fix #218 