### PR TITLE
fix(e2e): assertion in e2e example

### DIFF
--- a/src/docs/testing/e2e-testing.md
+++ b/src/docs/testing/e2e-testing.md
@@ -5,6 +5,7 @@ url: /docs/end-to-end-testing
 contributors:
   - adamdbradley
   - mattdsteele
+  - simonhaenisch
 ---
 
 # End-to-end Testing
@@ -38,7 +39,7 @@ describe('example', () => {
     const page = await newE2EPage();
     await page.setContent(`<foo-component></foo-component>`);
     const el = await page.find('foo-component');
-    expect(el).toBeDefined();
+    expect(el).not.toBeNull();
   });
 });
 ```


### PR DESCRIPTION
```js
expect(null).toBeDefined()
```

would actually pass... `page.find()` returns `null` if it can't find the element.