### PR TITLE
Fix properties table for Component decorator

### DIFF
--- a/src/docs/components/decorators.md
+++ b/src/docs/components/decorators.md
@@ -26,16 +26,17 @@ export class TodoList {
 }
 ```
 
-| name | type | description
-tag: string;
-styleUrl?: string;
-styleUrls?: string[] | d.ModeStyles;
-styles?: string;
-scoped?: boolean;
-shadow?: boolean;
-host?: d.HostMeta;
-assetsDir?: string;
-assetsDirs?: string[];
+| Property   | Type                       | Description |
+| ---------- | -------------------------- | ----------- |
+| tag        | `string`                   |             |
+| styleUrl   | `string`                   | (Optional)  |
+| styleUrls  | `string[]` \| `ModeStyles` | (Optional)  |
+| styles     | `string`                   | (Optional)  |
+| scoped     | `boolean`                  | (Optional)  |
+| shadow     | `boolean`                  | (Optional)  |
+| host       | `HostMeta`                 | (Optional)  |
+| assetsDir  | `string`                   | (Optional)  |
+| assetsDirs | `string[]`                 | (Optional)  |
 
 ## Prop Decorator
 
@@ -160,16 +161,6 @@ export class LoadingIndicator {
   watchHandler(newValue: boolean, oldValue: boolean) {
     console.log('The new value of activated is: ', newValue);
   }
-}
-```
-
-The @Watch decorator does not fire when a component initially loads.
-
-To get the method to run when the component loads, invoke it inside a `componentWillLoad` lifecycle hook:
-
-```tsx
-componentWillLoad() {
- this.watchHandler(this.newValue);
 }
 ```
 

--- a/src/docs/components/decorators.md
+++ b/src/docs/components/decorators.md
@@ -164,6 +164,16 @@ export class LoadingIndicator {
 }
 ```
 
+The @Watch decorator does not fire when a component initially loads.
+
+To get the method to run when the component loads, invoke it inside a `componentWillLoad` lifecycle hook:
+
+```tsx
+componentWillLoad() {
+ this.watchHandler(this.newValue);
+}
+```
+
 ## State Decorator
 
 The `@State()` decorator can be used to manage internal data for a component. This means that a user cannot modify this data from outside the component, but the component can modify it however it sees fit. Any changes to a `@State()` property will cause the components `render` function to be called again.


### PR DESCRIPTION
Hello! 👋

I was browsing the docs and noticed that the `@Component` decorator properties were being displayed as inline text in TypeScript syntax, so I took the liberty to reformat them as a table (which looking at the code seemed that was the intention).

I'm not sure how you'd like to fill the description column, so I skipped it.

Thanks!
Rodrigo