### PR TITLE
Adds disabling service worker generation

### DIFF
--- a/src/docs/tooling/config.md
+++ b/src/docs/tooling/config.md
@@ -349,3 +349,12 @@ export interface EmulateViewport {
 
 }
 ```
+
+## Disable service worker
+
+If you do not want a service worker to be generated during the build, this can be turned off. To disable this feature, set a `serviceWorker` property with a simple value of `null` or `false`.
+
+```tsx
+
+serviceWorker: null
+```


### PR DESCRIPTION
Helping users know how to use Stencil Config to disable the automatic generation of a service worker file.

Please let me know if the way I worded this seems helpful and consistent with other docs.