### PR TITLE
docs(unit-testing): remove async from example

### DIFF
--- a/src/docs/testing/unit-testing.md
+++ b/src/docs/testing/unit-testing.md
@@ -24,7 +24,7 @@ in order to test them.
 ```typescript
 import { MyToggle } from '../my-toggle.tsx';
 
-it('should toggle the checked property', async () => {
+it('should toggle the checked property', () => {
   const toggle = new MyToggle();
 
   expect(toggle.checked).toBe(false);

--- a/src/docs/testing/unit-testing.md
+++ b/src/docs/testing/unit-testing.md
@@ -5,6 +5,7 @@ url: /docs/unit-testing
 contributors:
   - adamdbradley
   - mattdsteele
+  - bassettsj
 ---
 
 # Unit Testing


### PR DESCRIPTION
- remove async from code example that doesn't use any await keywords