### PR TITLE
Use correct case for TypeScript

### DIFF
--- a/src/components/landing-page/landing-page.tsx
+++ b/src/components/landing-page/landing-page.tsx
@@ -121,7 +121,7 @@ export class LandingPage {
           <section class="overview">
             <p>Stencil combines the best concepts of the most popular frontend frameworks and generates 100% standards-based Web Components that run in any modern browser. Built by the <a href="https://ionicframework.com/">Ionic Framework</a> team.</p>
             <ul class="small list--unstyled list--icon">
-              <li><app-icon name="checkmark"/> Typescript support</li>
+              <li><app-icon name="checkmark"/> TypeScript support</li>
               <li><app-icon name="checkmark"/> Asynchronous rendering pipeline</li>
               <li><app-icon name="checkmark"/> A tiny virtual DOM layer</li>
               <li><app-icon name="checkmark"/> One-way data binding</li>


### PR DESCRIPTION
Fix typo -- replace `Typescript` with `TypeScript` on landing page