### PR TITLE
Adds Usage Considerations about webcomponents in React

### DIFF
--- a/src/docs/framework-integration/react.md
+++ b/src/docs/framework-integration/react.md
@@ -27,3 +27,46 @@ ReactDOM.render(<App />, document.getElementById('root'));
 registerServiceWorker();
 defineCustomElements(window);
 ```
+
+## Usage Considerations
+
+Note that React doesn't support custom properties and custom events by [nature](https://reactjs.org/docs/web-components.html).
+So, consider adding [this react component]() into your project to enable web components in it.
+After that, you can use any of your web components in your JSX markup passing custom properties to it.
+
+```tsx
+export const ExamplePage = (props) => {
+  return (
+    <WebComponent
+      component="your-component-tag"
+      myCustomProp={props.customProp}
+      onMyCustomEvent={props.customEvent}
+    >
+  );
+}
+```
+
+However, you can use webcomponents without that script. But note that all the custom properties need to be defined programmatically  `componentDidMount` and `componentDidUpdate`, accessing the component by a `ref` or getting the node by `document.querySelector`.
+
+```tsx
+import React, { Component } from 'react';
+
+export class ExamplePage extends Component {
+  myRef = React.createRef();
+  
+  componentDidMount() {
+    this.myRef.current.myCustomProp = this.props.customProp;
+    this.myRef.current.addEventListener('myCustomEvent', this.props.customEvent);
+  }
+  
+  componentDidUpdate() {
+    this.myRef.current.myCustomProp = this.props.customProp;
+  }
+  
+  render() {
+    return (
+      <your-component-tag id="myComponent" ref={this.myRef} />
+    );
+  }
+}
+```

--- a/src/docs/framework-integration/react.md
+++ b/src/docs/framework-integration/react.md
@@ -7,6 +7,7 @@ contributors:
   - adamdbradley
   - kensodemann
   - erikschierboom
+  - menosprezzi
 ---
 # React
 
@@ -31,7 +32,7 @@ defineCustomElements(window);
 ## Usage Considerations
 
 Note that React doesn't support custom properties and custom events by [nature](https://reactjs.org/docs/web-components.html).
-So, consider adding [this react component]() into your project to enable web components in it.
+So, consider adding [this react component](https://gist.github.com/menosprezzi/82daad2653f04d4d128ca3c4bd05d118) into your project to enable web components in it.
 After that, you can use any of your web components in your JSX markup passing custom properties to it.
 
 ```tsx


### PR DESCRIPTION
The actual docs about React integration lacks of information about the usage. Many developers think that they can pass custom properties to webcomponents as they do with React Components, but they don't. This info is only accessible by reading the docs from React. And following the [Ionic 4's React integration](https://github.com/ionic-team/ionic/blob/master/react/src/components/createComponent.tsx), some developers found a custom solution to it.

This PR expose this info to the docs, providing that optional util to the developers.

@jthoms1 