### PR TITLE
Stop using test-components name

### DIFF
--- a/src/docs/framework-integration/angular.md
+++ b/src/docs/framework-integration/angular.md
@@ -50,7 +50,7 @@ import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';
 
-import { defineCustomElements } from 'test-components/dist/loader';
+import { defineCustomElements } from '@ionic/core/dist/esm';
 
 if (environment.production) {
   enableProdMode();
@@ -68,20 +68,20 @@ Once included, components could be referenced in your code using `ViewChild` and
 ```
 import {Component, ElementRef, ViewChild} from '@angular/core';
 
-import 'test-components';
+import 'ionic-button';
 
 @Component({
     selector: 'app-home',
-    template: `<test-components #test></test-components>`,
+    template: `<ionic-button>Hello world</ionic-button>`,
     styleUrls: ['./home.component.scss'],
 })
 export class HomeComponent {
 
-    @ViewChild('test') myTestComponent: ElementRef<HTMLTestComponentElement>;
-    
+    @ViewChild('test') myIonicButton: ElementRef<HTMLIonicButtonElement>;
+
     async onAction() {
-        await this.myTestComponent.nativeElement.testComponentMethod();
+        await this.myIonicButton.nativeElement.ionicButtonMethod();
     }
 }
 
-``` 
+```

--- a/src/docs/framework-integration/javascript.md
+++ b/src/docs/framework-integration/javascript.md
@@ -16,10 +16,10 @@ Integrating a component built with Stencil to a project without a JavaScript fra
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <script src="https://unpkg.com/test-components/latest/dist/test-components.js"></script>
+  <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
 </head>
 <body>
-  <test-component></test-component>
+  <ion-button>Hello World</ion-button>
 </body>
 </html>
 ```
@@ -31,12 +31,12 @@ Alternatively, if you wanted to take advantage of ES Modules, you could include 
 <html lang="en">
 <head>
   <script type="module">
-    import { defineCustomElements } from 'https://unpkg.com/test-components/latest/dist/esm/es2017/test-components.define.js';
+    import { defineCustomElements } from 'https://unpkg.com/@ionic/core@latest/dist/esm';
     defineCustomElements(window);
   </script>
 </head>
 <body>
-  <test-component></test-component>
+  <ion-button>Hello World</ion-button>
 </body>
 </html>
 ```

--- a/src/docs/framework-integration/react.md
+++ b/src/docs/framework-integration/react.md
@@ -19,9 +19,8 @@ import './index.css';
 import App from './App';
 import registerServiceWorker from './registerServiceWorker';
 
-// test-component is the name of our made up Web Component that we have
-// published to npm:
-import { defineCustomElements } from 'test-components/dist/loader';
+// We can fetch a package from npm:
+import { defineCustomElements } from '@ionic/core/dist/esm';
 
 ReactDOM.render(<App />, document.getElementById('root'));
 registerServiceWorker();

--- a/src/docs/framework-integration/vue.md
+++ b/src/docs/framework-integration/vue.md
@@ -15,7 +15,7 @@ In order to use the custom element library within the Vue app, the application m
 ```tsx
 import Vue from 'vue';
 import App from './App.vue';
-import { defineCustomElements } from 'test-components/dist/loader';
+import { defineCustomElements } from '@ionic/core/dist/esm';
 
 Vue.config.productionTip = false;
 Vue.config.ignoredElements = [/test-\w*/];


### PR DESCRIPTION
1. `test-components` is actually an unrelated npm package https://www.npmjs.com/package/test-components
1. it sucks when you copy paste a demo code to jsbin/local env and it spews an error

Issues with this PR:

- had to use the `/esm` path to expose `defineCustomElements` https://github.com/ionic-team/ionic/issues/14925
- fixing `@latest` in unpkg url is bad, but v4 is RC only, so can't do `@4`