### PR TITLE
Proposal: add note for Stencil ready custom event

### DIFF
--- a/src/docs/framework-integration/javascript.md
+++ b/src/docs/framework-integration/javascript.md
@@ -94,3 +94,20 @@ export class TodoList {
 ```tsx
 <todo-list my-object="{}" my-array="[]"></todo-list>
 ```
+
+### Waiting for render
+
+To perform an action once Stencil is done rendering, you can use the
+`appload` window event to listen for when it’s ready:
+
+```js
+window.addEventListener('appload', event => {
+  console.log(event.detail);
+  // { namespace: 'my-namespace' }
+});
+```
+
+This is a
+[CustomEvent](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent)
+Stencil emits when ready, along with namespace details (useful if you’re
+working with multiple Stencil bundles).


### PR DESCRIPTION
I wanted to propose an addition to the docs to solve a problem I encountered. I wanted a way to know when Stencil was ready, and Anthony Johnston from the [Slack channel](https://stencil-worldwide.slack.com/archives/C79EANFL7/p1549876428005900?thread_ts=1549659988.094200&cid=C79EANFL7) shared this snippet with me.

I wanted to add a note, as this was the best method I could find to wait for Stencil to render. Feel free to propose adding this to a different section, or any edits. I just wanted it to be in the docs _somewhere_!