### PR TITLE
docs: Correct fields in `package.json` example

### DIFF
--- a/src/docs/guides/distribution.md
+++ b/src/docs/guides/distribution.md
@@ -46,8 +46,8 @@ You also need to add the following to your `package.json`:
 
 ```json
 {
-  "main": "dist/myname.js",
-  "types": "dist/types/index.d.ts",
+  "main": "dist/index.js",
+  "types": "dist/types/components.d.ts",
   "collection": "dist/collection/collection-manifest.json",
   "files": [
     "dist/"


### PR DESCRIPTION
The `main` and `types` field were not accurate to what is actually generated by the `stencil-component-starter`.

I'm not _absolutely_ sure which is correct, but I know, following the documentation, and publishing to NPM... my `dist` definitely does not have a `dist/myname.js` or a `dist/types/index.d.ts`...