### PR TITLE
Add example passing external values to page.$eval

### DIFF
--- a/src/docs/testing/e2e-testing.md
+++ b/src/docs/testing/e2e-testing.md
@@ -112,6 +112,30 @@ await page.$eval('prop-cmp', (elm: any) => {
 await page.waitForChanges();
 ```
 
+#### Set a @Prop() on a component using an external reference
+
+Because `page.$eval` has an isolated scope, you’ll have to explicity pass in outside references otherwise you’ll an encounter an `undefined` error. This is useful in case you’d like to import data from another file, or re-use mock data across multiple tests in the same file.
+
+```typescript
+const props = {
+  first: 'Marty',
+  lastName: 'McFly',
+};
+
+await page.setContent(`<prop-cmp></prop-cmp>`);
+
+await page.$eval('prop-cmp',
+  (elm: any, { first, lastName }) => {
+    elm.first = first;
+    elm.lastName = lastName;
+  },
+  props 
+);
+
+await page.waitForChanges();
+```
+
+
 #### Call a @Method() on a component
 
 ```typescript


### PR DESCRIPTION
This was a head-scratcher for me for weeks! Until someone in the Stencil Slack channel kindly pointed me in the right direction. I had read this page so many times looking for this answer, and found others in the Slack group asking the same.

Adding it here, because at least on our team this was a common complaint against the E2E tests. Some of our components have pretty deep-nested data structures, which means the tests are almost worthless without good mock data.

Open to feedback!