### PR TITLE
docs(config): Add preamble doc

### DIFF
--- a/src/docs/tooling/config.md
+++ b/src/docs/tooling/config.md
@@ -215,6 +215,17 @@ export const config: Config = {
 - [@stencil/stylus](https://www.npmjs.com/package/@stencil/stylus)
 
 
+## preamble
+
+*default: `undefined`*
+
+The `preamble` configuration is a `string` that represents a preamble in the main file of the build. Help to persist a banner or add relevant information about the resulting build.
+
+```tsx
+  preamble: "Built with Stencil"
+```
+
+
 ## srcDir
 
 *default: `src`*

--- a/src/docs/tooling/config.md
+++ b/src/docs/tooling/config.md
@@ -10,6 +10,7 @@ contributors:
   - matteobortolazzo
   - mattcosta7
   - BDav24
+  - jeanbenitez
 ---
 
 # Stencil Config


### PR DESCRIPTION
I needed this and I figured out thanks to the declarations file.

/cc @adamdbradley 