### PR TITLE
Make it clearer that the Watch decorator don't fire during the initial component load.

### DIFF
--- a/src/docs/components/reactive-data.md
+++ b/src/docs/components/reactive-data.md
@@ -18,7 +18,7 @@ When a component updates because a state change (props or state change), the [`r
 
 ## Watch Decorator
 
-When a user updates a property, `Watch` will fire what ever method it's attached to and pass that method the new value of the prop along with the old value. `Watch` is useful for validating props or handling side effects.
+When a user updates a property, `Watch` will fire what ever method it's attached to and pass that method the new value of the prop along with the old value. `Watch` is useful for validating props or handling side effects. `Watch` decorator does not fire when a component initially loads.
 
 
 ```tsx


### PR DESCRIPTION
Clarifies that this decorator won't fire during the initial load.