### PR TITLE
New copy and top site bar

### DIFF
--- a/scripts/markdown-renderer.ts
+++ b/scripts/markdown-renderer.ts
@@ -117,7 +117,7 @@ export function collectHeadingMetadata(renderer: marked.Renderer, metadata: Mark
 export function changeCodeCreation(renderer: marked.Renderer) {
   function highlight(code: string, lang?: string) {
     if (lang != null && languages.indexOf(lang) !== -1) {
-      return Prism.highlight(code, Prism.languages[lang]);
+      return Prism.highlight(code, Prism.languages[lang], lang);
     }
     return code;
   }

--- a/scripts/markdown-renderer.ts
+++ b/scripts/markdown-renderer.ts
@@ -117,7 +117,7 @@ export function collectHeadingMetadata(renderer: marked.Renderer, metadata: Mark
 export function changeCodeCreation(renderer: marked.Renderer) {
   function highlight(code: string, lang?: string) {
     if (lang != null && languages.indexOf(lang) !== -1) {
-      return Prism.highlight(code, Prism.languages[lang], lang);
+      return Prism.highlight(code, Prism.languages[lang]);
     }
     return code;
   }

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -81,6 +81,9 @@ export namespace Components {
     'page'?: string;
   }
 
+  interface DsPage {}
+  interface DsPageAttributes extends StencilHTMLAttributes {}
+
   interface HighlightCodeLine {
     'lines'?: string;
   }
@@ -153,6 +156,9 @@ export namespace Components {
     'selectedParent'?: SiteStructureItem;
     'siteStructureList'?: SiteStructureItem[];
   }
+
+  interface SiteTopBar {}
+  interface SiteTopBarAttributes extends StencilHTMLAttributes {}
 }
 
 declare global {
@@ -166,6 +172,7 @@ declare global {
     'DemoCard': Components.DemoCard;
     'DemosPage': Components.DemosPage;
     'DocumentComponent': Components.DocumentComponent;
+    'DsPage': Components.DsPage;
     'HighlightCodeLine': Components.HighlightCodeLine;
     'InPageNavigation': Components.InPageNavigation;
     'LandingPage': Components.LandingPage;
@@ -176,6 +183,7 @@ declare global {
     'ResourcesPage': Components.ResourcesPage;
     'SiteHeader': Components.SiteHeader;
     'SiteMenu': Components.SiteMenu;
+    'SiteTopBar': Components.SiteTopBar;
   }
 
   interface StencilIntrinsicElements {
@@ -188,6 +196,7 @@ declare global {
     'demo-card': Components.DemoCardAttributes;
     'demos-page': Components.DemosPageAttributes;
     'document-component': Components.DocumentComponentAttributes;
+    'ds-page': Components.DsPageAttributes;
     'highlight-code-line': Components.HighlightCodeLineAttributes;
     'in-page-navigation': Components.InPageNavigationAttributes;
     'landing-page': Components.LandingPageAttributes;
@@ -198,6 +207,7 @@ declare global {
     'resources-page': Components.ResourcesPageAttributes;
     'site-header': Components.SiteHeaderAttributes;
     'site-menu': Components.SiteMenuAttributes;
+    'site-top-bar': Components.SiteTopBarAttributes;
   }
 
 
@@ -253,6 +263,12 @@ declare global {
   var HTMLDocumentComponentElement: {
     prototype: HTMLDocumentComponentElement;
     new (): HTMLDocumentComponentElement;
+  };
+
+  interface HTMLDsPageElement extends Components.DsPage, HTMLStencilElement {}
+  var HTMLDsPageElement: {
+    prototype: HTMLDsPageElement;
+    new (): HTMLDsPageElement;
   };
 
   interface HTMLHighlightCodeLineElement extends Components.HighlightCodeLine, HTMLStencilElement {}
@@ -315,6 +331,12 @@ declare global {
     new (): HTMLSiteMenuElement;
   };
 
+  interface HTMLSiteTopBarElement extends Components.SiteTopBar, HTMLStencilElement {}
+  var HTMLSiteTopBarElement: {
+    prototype: HTMLSiteTopBarElement;
+    new (): HTMLSiteTopBarElement;
+  };
+
   interface HTMLElementTagNameMap {
     'app-burger': HTMLAppBurgerElement
     'app-icon': HTMLAppIconElement
@@ -325,6 +347,7 @@ declare global {
     'demo-card': HTMLDemoCardElement
     'demos-page': HTMLDemosPageElement
     'document-component': HTMLDocumentComponentElement
+    'ds-page': HTMLDsPageElement
     'highlight-code-line': HTMLHighlightCodeLineElement
     'in-page-navigation': HTMLInPageNavigationElement
     'landing-page': HTMLLandingPageElement
@@ -335,6 +358,7 @@ declare global {
     'resources-page': HTMLResourcesPageElement
     'site-header': HTMLSiteHeaderElement
     'site-menu': HTMLSiteMenuElement
+    'site-top-bar': HTMLSiteTopBarElement
   }
 
   interface ElementTagNameMap {
@@ -347,6 +371,7 @@ declare global {
     'demo-card': HTMLDemoCardElement;
     'demos-page': HTMLDemosPageElement;
     'document-component': HTMLDocumentComponentElement;
+    'ds-page': HTMLDsPageElement;
     'highlight-code-line': HTMLHighlightCodeLineElement;
     'in-page-navigation': HTMLInPageNavigationElement;
     'landing-page': HTMLLandingPageElement;
@@ -357,6 +382,7 @@ declare global {
     'resources-page': HTMLResourcesPageElement;
     'site-header': HTMLSiteHeaderElement;
     'site-menu': HTMLSiteMenuElement;
+    'site-top-bar': HTMLSiteTopBarElement;
   }
 
 

--- a/src/components/app-root/app-root.tsx
+++ b/src/components/app-root/app-root.tsx
@@ -64,6 +64,7 @@ export class AppRoot {
 
     return (
       <SiteProviderConsumer.Provider state={siteState}>
+        <site-top-bar />
         <site-header />
         <div class="root">
           <div class="container">
@@ -76,6 +77,7 @@ export class AppRoot {
                 <stencil-route url="/demos" component="demos-page" />
                 <stencil-route url="/pwa" component="pwas-page" />
                 <stencil-route url="/resources" component="resources-page" />
+                <stencil-route url="/design-systems" component="ds-page" />
                 <stencil-route component='notfound-page'></stencil-route>
               </stencil-route-switch>
             </stencil-router>

--- a/src/components/ds-page/ds-page.css
+++ b/src/components/ds-page/ds-page.css
@@ -1,3 +1,7 @@
+.ds-title {
+  font-size: 36px;
+}
+
 .ds-container {
   margin: auto;
 }
@@ -12,9 +16,36 @@
 .ds-plans {
   display: flex;
   flex-direction: row;
+  margin-top: 35px;
   margin-bottom: 60px;
 }
 
 .ds-plan {
   flex: 1;
+}
+
+.ds-plan h2 {
+  font-size: 24px;
+}
+
+.ds-plan ul a {
+  color: inherit;
+  font-weight: inherit;
+  text-decoration: none;
+  border-bottom: 1px dotted #aaa;
+}
+
+.ds-bottom-callout {
+  margin: 40px 0;
+  text-align: center;
+}
+.ds-bottom-callout .btn {
+  margin: auto;
+}
+
+.hbspt-form .actions {
+  text-align: center;
+}
+.hbspt-form .hs-button {
+  cursor: pointer;
 }

--- a/src/components/ds-page/ds-page.css
+++ b/src/components/ds-page/ds-page.css
@@ -1,0 +1,20 @@
+.ds-container {
+  margin: auto;
+}
+
+.ds-blurb {
+}
+
+.ds-cta {
+  text-align: center;
+}
+
+.ds-plans {
+  display: flex;
+  flex-direction: row;
+  margin-bottom: 60px;
+}
+
+.ds-plan {
+  flex: 1;
+}

--- a/src/components/ds-page/ds-page.tsx
+++ b/src/components/ds-page/ds-page.tsx
@@ -11,13 +11,46 @@ export class DSPage {
   }
 
   render() {
-    return [
-      <h1 class="headline measure-md">Stencil DS: Production-ready Design Systems at Scale</h1>,
-
-      <div class="measure-lg">
-        Is your company struggling to build shared components across teams using a diverse set of frontend frameworks
-        and technologies, all while enforcing brand guidelines and exceeding accessibility standards?
+    return (
+      <div class="ds-container measure-lg">
+        <div class="ds-cta">
+          <h1>Stencil DS</h1>
+          <h2>Production-ready Design Systems at Scale</h2>
+        </div>
+        <p>
+          Is your company struggling to build shared components across teams using a diverse set of frontend frameworks
+          and technologies, all while enforcing brand guidelines and exceeding accessibility standards?
+        </p>
+        <p>
+          The Stencil team is helping many large teams and enterprises build Design Systems at scale. Let us
+          help make your Design System initiative successful.
+        </p>
+        <div class="ds-plans">
+          <div class="ds-plan">
+            <h2>Stencil OSS</h2>
+            <h4>Free and OSS Forever</h4>
+            <ul>
+              <li>Web Component compiler</li>
+              <li>Lazy-loading for Components</li>
+              <li>Community support</li>
+            </ul>
+          </div>
+          <div class="ds-plan">
+            <h2>Stencil DS</h2>
+            <h4>Custom pricing</h4>
+            <ul>
+              <li><i>Everything in Stencil OSS +</i></li>
+              <li>Generate bindings for Angular, React, and Vue</li>
+              <li>Documentation generation</li>
+              <li>Visual UI testing tools</li>
+              <li>Accessibility verification tools</li>
+              <li>Premium support</li>
+              <li>Expert advisory for your next Design System project</li>
+            </ul>
+            <button class="btn btn--primary">Get in touch</button>
+          </div>
+        </div>
       </div>
-    ];
+    );
   }
 }

--- a/src/components/ds-page/ds-page.tsx
+++ b/src/components/ds-page/ds-page.tsx
@@ -1,20 +1,49 @@
-import { Component } from '@stencil/core';
+import { Component, Element } from '@stencil/core';
+
+declare var hbspt: any;
 
 @Component({
   tag: 'ds-page',
   styleUrl: 'ds-page.css'
 })
 export class DSPage {
+  @Element() el: Element;
 
   constructor() {
     document.title = `Stencil DS - Stencil for Production Design Systems`;
+  }
+
+  componentDidLoad() {
+    console.log('Injecting script');
+    let existingScript = document.querySelector('#hbs-script');
+    if (existingScript) {
+      existingScript.parentNode.removeChild(existingScript);
+    }
+    const script = document.createElement('script');
+    script.src = '//js.hsforms.net/forms/v2.js';
+    script.id = 'hbs-script';
+    script.onload = () => {
+      this.injectForm();
+    }
+    document.body.appendChild(script);
+    /*
+    */
+  }
+
+  injectForm() {
+    hbspt.forms.create({
+      portalId: "3776657",
+      formId: 'fe81d3de-e3ee-43c7-8636-e664bf53bc91',
+      css: "",
+      target: '#ds-form-target'
+    });
   }
 
   render() {
     return (
       <div class="ds-container measure-lg">
         <div class="ds-cta">
-          <h1>Stencil DS</h1>
+          <h1 class="ds-title">Stencil DS</h1>
           <h2>Production-ready Design Systems at Scale</h2>
         </div>
         <p>
@@ -28,10 +57,11 @@ export class DSPage {
         <div class="ds-plans">
           <div class="ds-plan">
             <h2>Stencil OSS</h2>
-            <h4>Free and OSS Forever</h4>
+            <h4>Free and Open Source Forever</h4>
             <ul>
               <li>Web Component compiler</li>
               <li>Lazy-loading for Components</li>
+              <li>Intelligent polyfill loading</li>
               <li>Community support</li>
             </ul>
           </div>
@@ -40,15 +70,142 @@ export class DSPage {
             <h4>Custom pricing</h4>
             <ul>
               <li><i>Everything in Stencil OSS +</i></li>
-              <li>Generate bindings for Angular, React, and Vue</li>
-              <li>Documentation generation</li>
-              <li>Visual UI testing tools</li>
-              <li>Accessibility verification tools</li>
-              <li>Premium support</li>
-              <li>Expert advisory for your next Design System project</li>
+              <li><a href="#bindings">Generate bindings for Angular, React, and Vue</a></li>
+              <li><a href="#documentation">Automated Documentation generation</a></li>
+              <li><a href="#testing">Visual Regression testing tools</a></li>
+              <li><a href="#accessibility">Accessibility verification tools</a></li>
+              <li><a href="#support">Premium support</a></li>
+              <li><a href="#advisory">Expert advisory for your next Design System project</a></li>
+              <li>Training opportunities</li>
             </ul>
-            <button class="btn btn--primary">Get in touch</button>
+            <a href="#h-form" class="btn btn--primary">Get in touch</a>
           </div>
+        </div>
+        <hr />
+        <h4>FAQ for Stencil DS</h4>
+        <ul>
+          <li>
+            <b>Is Stencil free?</b>
+            <p>
+              Yes, the official Stencil project is 100% free and open source (MIT licensed), and
+              always will be. We offer Stencil DS for teams undertaking large Design System initiatives which offers
+              additional features and tools that
+              are not free. This keeps the lights on and lets us keep making the Stencil you know and love better and better, all while
+              helping teams be successful with their Design System initiatives.
+            </p>
+          </li>
+          <li id="bindings">
+            <b>Why do Angular, React, and Vue need bindings?</b>
+            <p>
+              Stencil builds standard Web Components that run in all modern browsers, with intelligent loading of any 
+              necessary polyfills for clients with missing APIs.
+            </p>
+            <p>
+              However, certain frameworks, such as React, don't play as well with Web Components out of the box. Additionally,
+              developers often prefer a framework's conventions for naming and usage that deviates from typical Web Component usage.
+            </p>
+            <p>
+              To bring the best of both worlds, Stencil DS automatically generates up-to-date bindings for all major frameworks and smooths
+              out any rough edges in their Web Component support. This also makes using Stencil-built components feel
+              native to each framework.
+            </p>
+          </li>
+          <li id="documentation">
+            <b>What is Automated Documentation Generation?</b>
+            <p>
+              One of the greatest challenges for Design Systems is adoption. Developers will take the 
+              path of least resistance to get their work done, and that means the best documentation wins.
+            </p>
+            <p>
+              To ensure your Design System achieves mass adoption, Stencil DS generates top-quality
+              documentation automatically from your components, with rich metadata about properties and
+              events gathered directly from your component code.
+            </p>
+            <p>
+              Stencil DS generates live examples, code snippets, and an index
+              of all your components in a beautiful but easily customizable fashion, to make it
+              incredibly fast and easy for developers to find and use the components they need.
+            </p>
+            <p>
+              The team behind Stencil DS's documentation generation built <a href="http://ionicframework.com/docs">Ionic Framework's
+              documentation</a>, regarded by many as some of the best developer documentation for an open source project. We 
+              can bring that level of developer regard directly to your Design System's official documentation.
+            </p>
+          </li>
+          <li id="accessibility">
+            <b>How do you verify components meet Accessibility standards?</b>
+            <p>
+              Building a Design System with Web Component APIs that exceeds accessibility standards
+              is not straightforward. Stencil DS comes with a number of features and tools that help
+              verify and <i>enforce</i> accessibility support for your components in a continuous way that can
+              be easily integrated into your Continuous Integration workflow.
+            </p>
+            <p>
+              This goes above and beyond
+              existing Accessibility testing tools and ensures your Design System initiative meets and exceeds
+              all legal requirements for Accessibility.
+            </p>
+          </li>
+          <li id="testing">
+            <b>How do I ensure components don't have visual UI regressions or issues in specific browsers?</b>
+            <p>
+              One of the biggest challenges to building any sophisticated component kit or Design System is
+              ensuring components don't have visual regressions due to changes in styles or issues with
+              specific browsers.
+            </p>
+            <p>
+              Unfortunately, traditional unit testing or snapshot testing is not sufficient to test visual style and layout changes.
+              The Ionic team built out a set of powerful visual regression testing tools to ensure consistency between releases.
+            </p>
+            <p>
+              Stencil DS brings these powerful visual regression tools to teams building Design Systems, 
+              and helps them integrate with your existing
+              Continuous Integration workflow to provide UI verification on every single commit.
+            </p>
+          </li>
+          <li id="support">
+            <b>What do I get with Premium Support?</b>
+            <p>
+              While Stencil has an active community and is being actively maintained, there are cases
+              where certain bugs or features are not a priority due to misalignment with our open source
+              roadmap or time constraints.
+            </p>
+            <p>
+              For teams deploying major Design System initiatives, relying on open source and community support is
+              not sufficient. You'll need 
+              assurance that key issues or features are identified and communicated quickly, with potential fixes or workarounds
+              made available in a timely fashion.
+            </p>
+            <p>
+              With Stencil DS, Premium Support is provided and teams will have a dedicated account manager to
+              communicate with if anything goes wrong.
+            </p>
+          </li>
+          <li id="advisory">
+            <b>My team is new to Design Systems and we need help making our initiative successful. Do you offer Advisory Services?</b>
+            <p>
+              Yes! The Stencil team is the same team that build and deployed one of the most successful open 
+              source Design Systems ever: Ionic Framework. Today, Ionic is used by millions of developers
+              for over five million applications.
+            </p>
+            <p>
+              Not only that, but the team behind Stencil is a leader in modern Web APIs and Progressive Web Apps,
+              and has unique expertise that is difficult to find anywhere else.
+            </p>
+            <p>
+              We work with major enterprise companies and high growth startups undertaking major Design System
+              initiatives that can't afford to fail, and we're ready to help your team, too!
+            </p>
+          </li>
+        </ul>
+        <div class="ds-bottom-callout" id="h-form">
+          <h2>Want to learn more about Stencil DS?</h2>
+          <p>
+            Our team will reach out to see how we can
+            help make your Design System initiative successful.
+          </p>
+        </div>
+        <div id="ds-form-target" class="hbspt-form">
         </div>
       </div>
     );

--- a/src/components/ds-page/ds-page.tsx
+++ b/src/components/ds-page/ds-page.tsx
@@ -1,0 +1,23 @@
+import { Component } from '@stencil/core';
+
+@Component({
+  tag: 'ds-page',
+  styleUrl: 'ds-page.css'
+})
+export class DSPage {
+
+  constructor() {
+    document.title = `Stencil DS - Stencil for Production Design Systems`;
+  }
+
+  render() {
+    return [
+      <h1 class="headline measure-md">Stencil DS: Production-ready Design Systems at Scale</h1>,
+
+      <div class="measure-lg">
+        Is your company struggling to build shared components across teams using a diverse set of frontend frameworks
+        and technologies, all while enforcing brand guidelines and exceeding accessibility standards?
+      </div>
+    ];
+  }
+}

--- a/src/components/landing-page/landing-page.tsx
+++ b/src/components/landing-page/landing-page.tsx
@@ -115,11 +115,16 @@ export class LandingPage {
         <main>
           <section class="hero">
             <img id="logo" src="/assets/img/logo.png" alt="Stencil Logo"></img>
-            <h1>The magical, reusable web component compiler</h1>
+            <h1>The Magical Design System Toolchain</h1>
           </section>
 
           <section class="overview">
-            <p>Stencil combines the best concepts of the most popular frontend frameworks and generates 100% standards-based Web Components that run in any modern browser. Built by the <a href="https://ionicframework.com/">Ionic Framework</a> team.</p>
+            <p>
+              Stencil builds real-code Design Systems by taking the best concepts from popular frontend frameworks,
+              but instead generating standards-based Web Components that run in any modern browser and in any frontend framework.
+              Built to power the next generation of <a href="https://ionicframework.com/">Ionic Framework</a>, one of the most popular
+              open source Design Systems in the world.
+            </p>
             <ul class="small list--unstyled list--icon">
               <li><app-icon name="checkmark"/> TypeScript support</li>
               <li><app-icon name="checkmark"/> Asynchronous rendering pipeline</li>

--- a/src/components/landing-page/landing-page.tsx
+++ b/src/components/landing-page/landing-page.tsx
@@ -121,7 +121,7 @@ export class LandingPage {
           <section class="overview">
             <p>
               Stencil builds real-code Design Systems by taking the best concepts from popular frontend frameworks,
-              but instead generating standards-based Web Components that run in any modern browser and in any frontend framework.
+              but instead generates standards-based Web Components that run in any modern browser and in any frontend framework.
               Built to power the next generation of <a href="https://ionicframework.com/">Ionic Framework</a>, one of the most popular
               open source Design Systems in the world.
             </p>

--- a/src/components/site-header/site-header.css
+++ b/src/components/site-header/site-header.css
@@ -15,6 +15,10 @@ site-header .container {
   justify-content: space-between;
 }
 
+.header-menu .stencil-ds a {
+  font-weight: bold;
+}
+
 @media screen and (max-width: 768px) {
   site-header .container {
     padding-top: 15px;

--- a/src/components/site-header/site-header.tsx
+++ b/src/components/site-header/site-header.tsx
@@ -70,6 +70,11 @@ export class SiteHeader {
           <stencil-route-link url="/resources"  exact={true} onClick={() => { this.hideNav() }}>
             Resources
           </stencil-route-link>
+          {/*
+          <stencil-route-link url="/design-systems" exact={true} onClick={() => { this.hideNav() }} class="stencil-ds">
+            Stencil DS
+          </stencil-route-link>
+          */}
           <a rel="noopener" class="link--external" target="_blank" href="https://github.com/ionic-team/stencil">
             GitHub <app-icon name="targetblank"></app-icon>
           </a>

--- a/src/components/site-header/site-header.tsx
+++ b/src/components/site-header/site-header.tsx
@@ -70,11 +70,9 @@ export class SiteHeader {
           <stencil-route-link url="/resources"  exact={true} onClick={() => { this.hideNav() }}>
             Resources
           </stencil-route-link>
-          {/*
           <stencil-route-link url="/design-systems" exact={true} onClick={() => { this.hideNav() }} class="stencil-ds">
             Stencil DS
           </stencil-route-link>
-          */}
           <a rel="noopener" class="link--external" target="_blank" href="https://github.com/ionic-team/stencil">
             GitHub <app-icon name="targetblank"></app-icon>
           </a>

--- a/src/components/site-header/site-header.tsx
+++ b/src/components/site-header/site-header.tsx
@@ -71,7 +71,7 @@ export class SiteHeader {
             Resources
           </stencil-route-link>
           <stencil-route-link url="/design-systems" exact={true} onClick={() => { this.hideNav() }} class="stencil-ds">
-            Stencil DS
+            💎 Stencil DS
           </stencil-route-link>
           <a rel="noopener" class="link--external" target="_blank" href="https://github.com/ionic-team/stencil">
             GitHub <app-icon name="targetblank"></app-icon>

--- a/src/components/site-top-bar/site-top-bar.css
+++ b/src/components/site-top-bar/site-top-bar.css
@@ -1,0 +1,26 @@
+site-top-bar {
+  display: block;
+  background-color: #111;
+  color: white;
+  font-size: 14px;
+  font-weight: bold;
+  padding: 10px;
+  width: 100%;
+  text-align: center;
+}
+
+site-top-bar a {
+  text-decoration: none;
+  color: white;
+}
+
+site-top-bar a.btn {
+  margin-left: 15px;
+  padding: 8px;
+  border-radius: 16px;
+  background-color: white;
+  color: black;
+  font-weight: bold;
+  font-size: 13px;
+  text-decoration: none;
+}

--- a/src/components/site-top-bar/site-top-bar.tsx
+++ b/src/components/site-top-bar/site-top-bar.tsx
@@ -1,0 +1,16 @@
+import { Component } from '@stencil/core';
+
+@Component({
+  tag: 'site-top-bar',
+  styleUrl: 'site-top-bar.css'
+})
+export class SiteTopBar {
+
+  render() {
+    return (
+      <a href="https://blog.ionicframework.com/build-your-next-design-system-with-web-components/" target="_blank">
+        On the blog: <u>Build your next Design System with Web Components</u>
+      </a>
+    );
+  }
+}

--- a/src/global/style/app.css
+++ b/src/global/style/app.css
@@ -1,5 +1,6 @@
 @import './variables.css';
 
+@import './html.css';
 @import './buttons.css';
 @import './bs-chart.css';
 @import './headline.css';
@@ -14,6 +15,7 @@
 @import './card-links.css';
 @import './typography.css';
 @import './framework-icon.css';
+@import './hubspot.css';
 @import './utils.css';
 
 * {

--- a/src/global/style/html.css
+++ b/src/global/style/html.css
@@ -1,0 +1,5 @@
+hr {
+  height: 1px;
+  background-color: #eee;
+  border: none;
+}

--- a/src/global/style/hubspot.css
+++ b/src/global/style/hubspot.css
@@ -1,0 +1,101 @@
+.hbspt-form {
+  max-width: 420px;
+  margin: 40px auto;
+  font-weight: 400; }
+  .hbspt-form .hs-form-required {
+    display: none; }
+  .hbspt-form form fieldset.form-columns-2 .input {
+    margin-right: 12px; }
+  .hbspt-form form.stacked .field {
+    margin-bottom: 4px; }
+  .hbspt-form .hs-input,
+  .hbspt-form input.hs-input,
+  .hbspt-form select.hs-input {
+    border: 1px solid #e1e5ed;
+    font-weight: 500;
+    border-radius: 4px;
+    transition: border-color .2s;
+    box-shadow: none;
+    outline: none;
+    height: 30px;
+    padding: 6px 12px;
+    font-size: 14px;
+    line-height: 1.428571429; }
+    .hbspt-form .hs-input:placeholder,
+    .hbspt-form input.hs-input:placeholder,
+    .hbspt-form select.hs-input:placeholder {
+      color: #a0a5b0; }
+    .hbspt-form .hs-input:hover, .hbspt-form .hs-input:focus, .hbspt-form .hs-input:active,
+    .hbspt-form input.hs-input:hover,
+    .hbspt-form input.hs-input:focus,
+    .hbspt-form input.hs-input:active,
+    .hbspt-form select.hs-input:hover,
+    .hbspt-form select.hs-input:focus,
+    .hbspt-form select.hs-input:active {
+      outline: none;
+      border-color: #4a8bfc;
+      box-shadow: none; }
+    .hbspt-form .hs-input.hs-input.error,
+    .hbspt-form input.hs-input.hs-input.error,
+    .hbspt-form select.hs-input.hs-input.error {
+      border-color: #f8556c; }
+  .hbspt-form select.hs-input {
+    height: 44px;
+    width: calc(100% + 6px) !important; }
+  .hbspt-form textarea.hs-input {
+    padding: 12px;
+    width: calc(100% + 3px) !important;
+    min-height: 192px; }
+  .hbspt-form .hs_submit input.hs-button {
+    font-size: 13px;
+    padding: 10px 18px 10px;
+    margin-right: -14px;
+    margin-top: -36px;
+    line-height: 23px;
+    font-weight: 600;
+    letter-spacing: 0;
+    text-transform: none;
+    text-shadow: none;
+    background: var(--color-dodger-blue);
+    color: white;
+    margin-top: 25px;
+    border: 0;
+    outline: 0;
+    transition: all .2s linear;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12); }
+    .hbspt-form .hs_submit input.hs-button:hover {
+      border: 0;
+      box-shadow: 0 4px 8px rgba(0, 0, 0, 0.12);
+      background: #5995fc;
+      color: #fff;
+      outline: 0; }
+    .hbspt-form .hs_submit input.hs-button:active, .hbspt-form .hs_submit input.hs-button:active:not(.inactive):not(.link), .hbspt-form .hs_submit input.hs-button:focus:not(.inactive) {
+      border: 0;
+      color: #fff;
+      box-shadow: inset 0 1px 4px rgba(0, 0, 0, 0.2);
+      background: #5995fc;
+      outline: 0; }
+  .hbspt-form .submitted-message {
+    font-size: 18px;
+    padding: 34px 0 78px;
+    text-align: center;
+    display: -ms-flexbox;
+    display: flex;
+    -ms-flex-direction: column;
+        flex-direction: column;
+    -ms-flex-align: center;
+        align-items: center;
+    font-weight: 400;
+    color: #35af55;
+    max-width: 410px;
+    background-color: white;
+    margin: 0 auto; }
+    .hbspt-form .submitted-message:before {
+      content: '';
+      display: block;
+      background-image: url("/img/checkmark-light-green.svg");
+      background-repeat: no-repeat;
+      background-size: 100%;
+      width: 42px;
+      height: 42px;
+      margin-bottom: 12px; }


### PR DESCRIPTION
Tweaks some of the copy on the the homepage to be more Design Systems oriented, also adds persistent top bar to link to our blog about web components.

Also had to fix an issue in the markdown script, must be a change in the Prism dependency.