### PR TITLE
docs(JSX): remove reference to hostData

### DIFF
--- a/src/docs/components/templating-and-jsx.md
+++ b/src/docs/components/templating-and-jsx.md
@@ -33,7 +33,7 @@ In this example we're returning the JSX representation of a `div`, with two chil
 
 ### Host Element
 
-If you want to modify the host element itself, such as adding a class or an attribute to the component itself, use the `hostData()` function. Check for more details [here](host-element)
+If you want to modify the host element itself, such as adding a class or an attribute to the component itself, use the `<Host>` functional component. Check for more details [here](host-element)
 
 
 ## Data Binding


### PR DESCRIPTION
`hostData` function has been replaced with the `Host` element. This updates the JSX documentation to remove reference to `hostData`. See [BREAKING_CHANGES.md](https://github.com/ionic-team/stencil/blob/master/BREAKING_CHANGES.md#hostdata) for more info.

Issue to track this here: https://github.com/ionic-team/stencil-site/issues/404