### PR TITLE
type(docs): update h1 to match title & menu

### DIFF
--- a/src/docs/components/styling.md
+++ b/src/docs/components/styling.md
@@ -7,13 +7,15 @@ contributors:
   - shreeshbhat
 ---
 
-# Shadow DOM
+# Styling Components
 
-## What is Shadow DOM
+## Shadow DOM
+
+### What is Shadow DOM
 
 [Shadow DOM](https://developers.google.com/web/fundamentals/web-components/shadowdom) is an API built into the browser that allows for DOM encapsulation and style encapsulation. Shadow DOM shields our component from its surrounding environment. This means that we do not need to be concerned about scoping our CSS correctly, nor worry about our internal DOM being interfered with by anything outside our component.
 
-## Browser Support
+### Browser Support
 
 Shadow DOM is currently natively supported in the following browsers:
 
@@ -26,7 +28,7 @@ In browsers which do not support Shadow DOM we fall back to scoped CSS. This giv
 
 > Confused about what scoped CSS is? Don't worry, we will [explain this later](#scoped-css) in detail.
 
-## Shadow DOM in Stencil
+### Shadow DOM in Stencil
 
 Shadow DOM is not currently turned on by default for web components built with Stencil. To turn on Shadow DOM in a web component built with Stencil, you can use the `shadow` param in the component decorator. Below is an example of this:
 
@@ -41,7 +43,7 @@ export class ShadowComponent {
 }
 ```
 
-## Things to remember with Shadow DOM
+### Things to remember with Shadow DOM
 
 - QuerySelector: When using Shadow DOM and you want to query an element inside your web component you must use `this.el.shadowRoot.querySelector()`. This is because all of your DOM inside your web component is in a shadowRoot that Shadow DOM creates.
 
@@ -69,7 +71,7 @@ div {
 }
 ```
 
-## Scoped CSS
+### Scoped CSS
 
 In browsers that do not currently support Shadow DOM, web components built with Stencil will fall back to using scoped CSS instead of loading a large Shadow DOM polyfill. Scoped CSS automatically scopes CSS to an element by appending each of your styles with a data attribute at run time.
 


### PR DESCRIPTION
When following links to the page about "styling" or "styling components" you end up on a page with an h1 "Shadow DOM". This is confusing. The page is about "Styling (Components)" as the title and description in this markdown file also state. The page has two main topics "Shadow DOM" and "CSS Variables", so those should be the h2 level headings. The other sections on Shadow DOM are therefore changed to h3 level headings.