### PR TITLE
Update mocking.md

### DIFF
--- a/src/docs/testing/mocking.md
+++ b/src/docs/testing/mocking.md
@@ -122,7 +122,10 @@ import { Foo } from './components/foo/foo';
 
 describe('Foo', () => {
 	it('bar()', async () => {
-		const page = await newSpecPage({ components: [Foo] });
+		const page = await newSpecPage({
+			components: [Foo],
+			html: '<foo-component></foo-component>',
+		});
 		const foo = page.body.querySelector('foo-component');
 
 		if (!foo) {


### PR DESCRIPTION
When using newSpecPage, you must either set the element on the html property of the options, or use page.setContent() instead.