### PR TITLE
add info about component generator

### DIFF
--- a/src/docs/introduction/my-first-component.md
+++ b/src/docs/introduction/my-first-component.md
@@ -4,6 +4,7 @@ description: My First Component
 url: /docs/my-first-component
 contributors:
   - jthoms1
+  - simonhaenisch
 ---
 
 # My First Component
@@ -72,3 +73,19 @@ We set this property like so:
 ```
 Any property decorated with `@Prop()` is also automatically watched for changes.
 If a user of our component were to change the element's `name` property, our component would fire its `render` function again, updating the displayed content.
+
+## Component Generator
+
+The Stencil CLI can generate new components for you. If you used one of the starters, you can simply run the `generate` npm script in your project, which will start the interactive generator.
+
+```shell
+npm run generate
+```
+
+Or you can invoke the Stencil CLI directly with the `generate` command (`g` for short). If you don't have `stencil` installed globally, prefix the command with `npx`.
+
+```shell
+stencil generate
+```
+
+You can optionally pass the component tag name directly to the command. Remember that the component tag name needs to be lowercase and contain at least one hyphen. In the second step, the generator will ask you which files to generate. This allows you to bootstrap a stylesheet as well as spec and e2e tests along with the component file.

--- a/src/docs/introduction/my-first-component.md
+++ b/src/docs/introduction/my-first-component.md
@@ -89,3 +89,22 @@ stencil generate
 ```
 
 You can optionally pass the component tag name directly to the command. Remember that the component tag name needs to be lowercase and contain at least one hyphen. In the second step, the generator will ask you which files to generate. This allows you to bootstrap a stylesheet as well as spec and e2e tests along with the component file.
+
+All components will be generated within the `src/components` folder. Within that, a folder will be created with the same name as the component tag name you provided, and within that folder the files will be generated. It is also possible to specify one or multiple sub-folders to generate the component in.
+
+For example, if you specify `pages/page-home` as the component tag name, the files will be generated in `src/components/pages/page-home`.
+
+```shell
+stencil generate pages/page-home
+```
+
+```plain
+src
+ |- components
+     |- pages
+         |- page-home
+             |- page-home.css
+             |- page-home.e2e.ts
+             |- page-home.spec.ts
+             |- page-home.tsx
+```


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3410759/63383447-18828700-c39d-11e9-9b72-463d2f438064.png)

Will update the starters now to include said script.

**Edit:** just added another paragraph:

> All components will be generated within the `src/components` folder. Within that, a folder will be created with the same name as the component tag name you provided, and within that folder the files will be generated. It is also possible to specify one or multiple sub-folders to generate the component in.
>
> For example, if you specify `pages/page-home` as the component tag name, the files will be generated in `src/components/pages/page-home`.