### PR TITLE
add info for using a `.vscode/launch.json`

### DIFF
--- a/src/docs/testing/overview.md
+++ b/src/docs/testing/overview.md
@@ -54,3 +54,36 @@ export const config: Config = {
   }
 };
 ```
+
+## Running and Debugging Tests in VS Code
+
+Adding the following configurations to `.vscode/launch.json` will allow you to run the Stencil test runner for the currently active file in your editor.
+
+```tsx
+{
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "E2E Test Current File",
+      "cwd": "${workspaceFolder}",
+      "program": "${workspaceFolder}/node_modules/.bin/stencil",
+      "args": ["test", "--e2e", "${relativeFile}"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "disableOptimisticBPs": true
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Spec Test Current File",
+      "cwd": "${workspaceFolder}",
+      "program": "${workspaceFolder}/node_modules/.bin/stencil",
+      "args": ["test", "--spec", "${relativeFile}"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "disableOptimisticBPs": true
+    }
+  ]
+}
+```

--- a/src/docs/testing/overview.md
+++ b/src/docs/testing/overview.md
@@ -57,7 +57,7 @@ export const config: Config = {
 
 ## Running and Debugging Tests in VS Code
 
-Adding the following configurations to `.vscode/launch.json` will allow you to run the Stencil test runner for the currently active file in your editor.
+Adding the following configurations to `.vscode/launch.json` will allow you to use the VS Code Debugger to run the Stencil test runner for the currently active file in your editor. Just make sure you're in the test file you want to run, then select the debug configuration respectively (depending on whether it's a spec or e2e test), and hit the play button.
 
 ```tsx
 {


### PR DESCRIPTION
This has been asked and referenced on Slack multiple times, and I already posted this config like four times, so I thought it's time to add it to the docs.

![image](https://user-images.githubusercontent.com/3410759/63431014-33e1a680-c41e-11e9-8d99-1daad1acceb4.png)

The config should probably be tested by someone on Windows, and I can't remember why I set `disableOptimisticBPs`. The tooltip says

> Don't set breakpoints in any file until a sourcemap has been loaded for that file.

and @manucorporat is/was working on getting the sourcemaps working for testing, so we can probably leave it in.