### PR TITLE
fix: add local-assets guide to the menu

### DIFF
--- a/src/assets/docs-structure.json
+++ b/src/assets/docs-structure.json
@@ -228,6 +228,11 @@
         "url": "/docs/forms"
       },
       {
+        "text": "Local Assets",
+        "filePath": "/assets/docs/guides/local-assets.json",
+        "url": "/docs/local-assets"
+      },
+      {
         "text": "Style Guide",
         "filePath": "/assets/docs/guides/style-guide.json",
         "url": "/docs/style-guide"

--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -46,6 +46,7 @@
   * [Bundling](guides/module-bundling.md)
   * [Typed Components](guides/typed-components.md)
   * [Forms](guides/forms.md)
+  * [Local Assets](guides/local-assets.md)
   * [Style Guide](guides/style-guide.md)
   * [Service Workers](guides/service-workers.md)
   * [State Tunnel](guides/state-tunnel.md)

--- a/src/docs/guides/local-assets.md
+++ b/src/docs/guides/local-assets.md
@@ -1,8 +1,10 @@
 ---
 title: Local Assets
 description: Using Local Assets in your Components
+url: /docs/local-assets
 contributors:
   - splitinfinities
+  - simonhaenisch
 ---
 
 # Local Assets


### PR DESCRIPTION
Also added myself to the contributors because the examples from the guide were mostly taken from a message I posted on slack once.

BTW someone didn't commit `components.d.ts` after updating to Stencil 1.5.3 so I had quite a few changes there, but I didn't add it to this commit either (because I don't know when this is going to be merged, and wanted to prevent merge conflicts).