### PR TITLE
add project context

### DIFF
--- a/src/docs/guides/local-assets.md
+++ b/src/docs/guides/local-assets.md
@@ -16,12 +16,14 @@ Lets dive in and look at an example of how to use local assets:
 Below is an example of your Component's folder structure containing the component, the stylesheet, and an assets directory. 
 
 ```bash
-stencil-asset/
-  assets/
-    sunset.jpg
-    beach.jpg
-  stencil-asset.css
-  stencil-asset.tsx
+src/
+  components/
+    stencil-asset/
+      assets/
+        sunset.jpg
+        beach.jpg
+      stencil-asset.css
+      stencil-asset.tsx
 ```
 
 Below is the `stencil-asset.tsx` file which will correctly load the assets based on a property called `src`. 


### PR DESCRIPTION
Hey guys,

I was totally missing the project context when looking at the example folder hierarchy. I was mixing up `assets` with a folder `assets` in the root of my Stencil project.

Not sure if this for everyone but it would have helped me.

Matt