### PR TITLE
docs: framework integrations dist/loader

### DIFF
--- a/src/docs/framework-integration/angular.md
+++ b/src/docs/framework-integration/angular.md
@@ -53,7 +53,7 @@ import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';
 
 // Note: loader import location set using "esmLoaderPath" within the output target confg
-import { defineCustomElements } from 'test-components/loader';
+import { defineCustomElements } from 'test-components/dist/loader';
 
 if (environment.production) {
   enableProdMode();

--- a/src/docs/framework-integration/react.md
+++ b/src/docs/framework-integration/react.md
@@ -24,7 +24,7 @@ import registerServiceWorker from './registerServiceWorker';
 
 // test-component is the name of our made up Web Component that we have
 // published to npm:
-import { applyPolyfills, defineCustomElements } from 'test-components/loader';
+import { applyPolyfills, defineCustomElements } from 'test-components/dist/loader';
 
 ReactDOM.render(<App />, document.getElementById('root'));
 registerServiceWorker();

--- a/src/docs/framework-integration/vue.md
+++ b/src/docs/framework-integration/vue.md
@@ -24,7 +24,7 @@ Assuming you’ve run `npm install --save test-components` beforehand, and that 
 import Vue from 'vue';
 import App from './App.vue';
 
-import { applyPolyfills, defineCustomElements } from 'test-components/loader';
+import { applyPolyfills, defineCustomElements } from 'test-components/dist/loader';
 
 Vue.config.productionTip = false;
 


### PR DESCRIPTION
Just in case you would like to display the example of framework integrations with the default `dist/loader` aka

```
import { applyPolyfills, defineCustomElements } from 'test-components/dist/loader';
```

instead of

```
import { applyPolyfills, defineCustomElements } from 'test-components/loader';
```