### PR TITLE
Update javascript.md

### DIFF
--- a/src/docs/framework-integration/javascript.md
+++ b/src/docs/framework-integration/javascript.md
@@ -32,7 +32,7 @@ Alternatively, if you wanted to take advantage of ES Modules, you could include 
 <html lang="en">
 <head>
   <script type="module">
-    import { applyPolyfills, defineCustomElements } from 'https://unpkg.com/test-components/latest/dist/esm/es2017/test-components.define.js';
+    import { applyPolyfills, defineCustomElements } from 'https://unpkg.com/test-components/loader';
     applyPolyfills().then(() => {
       defineCustomElements(window);
     });


### PR DESCRIPTION
1. Updates the path to the loader that exports `applyPolyfills` and `defineCustomElements` to be correct. This updated path matches what is found in integration documentation for other frameworks such as React: https://stenciljs.com/docs/react