### PR TITLE
Update styling.md

### DIFF
--- a/src/docs/components/styling.md
+++ b/src/docs/components/styling.md
@@ -79,7 +79,7 @@ In browsers that do not currently support Shadow DOM, web components built with 
 
 ### What are CSS Variables?
 
-[CSS Variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_variables) are a lot like [Sass Variables](https://ionicframework.com/docs/theming/sass-variables/), but built into the browser. CSS Variables allow you to specify CSS properties that can be used across your app.
+[CSS Variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_variables) are a lot like [Less Variables](http://lesscss.org/#variables), but built into the browser. CSS Variables allow you to specify CSS properties that can be used across your app.
 
 ### Use Case
 


### PR DESCRIPTION
CSS Custom properties are much more like Less variables than Sass variables, as Less vars (like CSS vars) are declarative and have a value per scope, and Sass variables are imperative and can change values mid-scope (and can also be re-defined as themselves, whereas neither Less nor CSS Variables can be). So Less / CSS have a shared property / variable paradigm, whereas Sass uses something more like a Ruby paradigm, using CSS-like syntax.