### PR TITLE
Document How to Use the Hydrate App for SSR

### DIFF
--- a/src/docs/guides/prerendering.md
+++ b/src/docs/guides/prerendering.md
@@ -47,9 +47,9 @@ stencil build --prerender
 
 **Client-side Hydration**: After the HTML and inlined styles have rendered the first paint, the next step is for the same nodes within the DOM to be hydrated by the client-side JavaScript. Each component within the page will asynchronously hydrate using the initial order they were found in the DOM structure. Next, as each component lazily hydrates they're able to reuse the existing nodes found in the DOM.
 
-## Server Side Rendering
+## How to Use the Hydrate App
 
-Server side rendering (SSR) can be accomplished in a similar way to prerendering. Instead of using the `--prerender` CLI flag, you can add `{ type: 'dist-hydrate-script' }` to your `stencil.config.js`. This will generate a "hydrate" app in your root project directory that can be used by your Node server.
+Server side rendering (SSR) can be accomplished in a similar way to prerendering. Instead of using the `--prerender` CLI flag, you can add `{ type: 'dist-hydrate-script' }` to your `stencil.config.js`. This will generate a `hydrate` app in your root project directory that can be imported and used by your Node server.
 
 After publishing your component library, you can import the hydrate app into your server's code like this:
 
@@ -57,9 +57,11 @@ After publishing your component library, you can import the hydrate app into you
 import { hydrateDocument } from 'yourpackage/hydrate';
 ```
 
-You can use `hydrateDocument` as a part of your server's response logic before serving the web page. `hydrateDocument` takes two arguments, a document and a config object. The function also returns a promise with `HydrateResults`.
+The app comes with two methods, `hydrateDocument` and `renderToString`.
 
-**Example taken from Ionic Angular server**
+**hydrateDocument**: You can use `hydrateDocument` as a part of your server's response logic before serving the web page. `hydrateDocument` takes two arguments, a document and a config object. The function returns a promise with the hydrated results. The resulting html can be parsed from the `html` property in the returned results.
+
+*Example taken from Ionic Angular server*
 
  ```javascript
 import { hydrateDocument } from 'yourpackage/hydrate';
@@ -69,19 +71,53 @@ export function hydrateComponents(doc) {
     return hydrateDocument(doc)
       .then((hydrateResults) => {
         // execute logic based on results
-      })
+        console.log(hydrateResults.html);
+        return hydrateResults;
+      });
   }
 }
 ```
 
-The hydrate app also has a `renderToString` method that allows you to pass in an html string that also returns a promise of `HydrateResults`.
+#### Configuration Options
+  - `canonicalUrl` - string
+  - `constrainTimeouts` - boolean
+  - `clientHydrateAnnotations` - boolean
+  - `cookie` - string
+  - `direction` - string
+  - `language` - string
+  - `maxHydrateCount` - number
+  - `referrer` - string
+  - `removeScripts` - boolean
+  - `removeUnusedStyles` - boolean
+  - `resourcesUrl` - string
+  - `timeout` - number
+  - `title` - string
+  - `url` - string
+  - `userAgent` - string
+
+**renderToString**: The hydrate app also has a `renderToString` method that allows you to pass in an html string that also returns a promise of `HydrateResults`. The second parameter is a config object that can alter the output of the string. Like `hydrateDocument`, the resulting strin gcan be parsed from the `html` property.
+
+*Exampe taken from Ionic Core*
 
 ```javascript
 const results = await hydrate.renderToString(srcHtml, {
   prettyHtml: true,
   removeScripts: true
-})
+});
+
+console.log(results.html);
 ```
+
+#### Configuration Options
+
+  - `approximateLineWidth` - number
+  - `prettyHtml` - boolean
+  - `removeAttributeQuotes` - boolean
+  - `removeBooleanAttributeQuotes` - boolean
+  - `removeEmptyAttributes` - boolean
+  - `removeHtmlComments` - boolean
+  - `afterHydrate` - boolean
+  - `beforeHydrate` - boolean
 
 ## Things to Watch For
 

--- a/src/docs/guides/prerendering.md
+++ b/src/docs/guides/prerendering.md
@@ -51,14 +51,37 @@ stencil build --prerender
 
 Server side rendering (SSR) can be accomplished in a similar way to prerendering. Instead of using the `--prerender` CLI flag, you can add `{ type: 'dist-hydrate-script' }` to your `stencil.config.js`. This will generate a "hydrate" app in your root project directory that can be used by your Node server.
 
-After publishing your component library, You can import the hydrate app into server code.
+After publishing your component library, you can import the hydrate app into your server's code like this:
 
 ```javascript
-import  { hydrateDocument } from 'yourpackage/hydrate';
+import { hydrateDocument } from 'yourpackage/hydrate';
 ```
 
-`hydrateDocument` takes two arguments, a document and a config object. The function also returns a promise with the results of the hydration. You can use `hydrateDocument` as a part of your server's response logic before serving the web page.
+ You can use `hydrateDocument` as a part of your server's response logic before serving the web page. `hydrateDocument` takes two arguments, a document and a config object. The function also returns a promise with `HydrateResults`.
 
+**Example taken from Ionic Angular server**
+
+ ```javascript
+import { hydrateDocument } from 'yourpackage/hydrate';
+
+export function hydrateComponents(doc) {
+  return () => {
+    return hydrateDocument(doc)
+      .then((hydrateResults) => {
+        // execute logic based on results
+      })
+  }
+}
+```
+
+ The hydrate app also has a `renderToString` method that allows you to pass in an html string that also returns a promise of `HydrateResults`.
+
+```javascript
+const results = await hydrate.renderToString(srcHtml, {
+  prettyHtml: true,
+  removeScripts: true
+})
+```
 
 ## Things to Watch For
 

--- a/src/docs/guides/prerendering.md
+++ b/src/docs/guides/prerendering.md
@@ -95,7 +95,7 @@ export function hydrateComponents(doc) {
   - `url` - string
   - `userAgent` - string
 
-**renderToString**: The hydrate app also has a `renderToString` method that allows you to pass in an html string that also returns a promise of `HydrateResults`. The second parameter is a config object that can alter the output of the string. Like `hydrateDocument`, the resulting strin gcan be parsed from the `html` property.
+**renderToString**: The hydrate app also has a `renderToString` method that allows you to pass in an html string that also returns a promise of `HydrateResults`. The second parameter is a config object that can alter the output of the markup. Like `hydrateDocument`, the resulting string can be parsed from the `html` property.
 
 *Exampe taken from Ionic Core*
 

--- a/src/docs/guides/prerendering.md
+++ b/src/docs/guides/prerendering.md
@@ -47,6 +47,18 @@ stencil build --prerender
 
 **Client-side Hydration**: After the HTML and inlined styles have rendered the first paint, the next step is for the same nodes within the DOM to be hydrated by the client-side JavaScript. Each component within the page will asynchronously hydrate using the initial order they were found in the DOM structure. Next, as each component lazily hydrates they're able to reuse the existing nodes found in the DOM.
 
+## Server Side Rendering
+
+Server side rendering (SSR) can be accomplished in a similar way to prerendering. Instead of using the `--prerender` CLI flag, you can add `{ type: 'dist-hydrate-script' }` to your `stencil.config.js`. This will generate a "hydrate" app in your root project directory that can be used by your Node server.
+
+After publishing your component library, You can import the hydrate app into server code.
+
+```javascript
+import  { hydrateDocument } from 'yourpackage/hydrate';
+```
+
+`hydrateDocument` takes two arguments, a document and a config object. The function also returns a promise with the results of the hydration. You can use `hydrateDocument` as a part of your server's response logic before serving the web page.
+
 
 ## Things to Watch For
 

--- a/src/docs/guides/prerendering.md
+++ b/src/docs/guides/prerendering.md
@@ -57,7 +57,7 @@ After publishing your component library, you can import the hydrate app into you
 import { hydrateDocument } from 'yourpackage/hydrate';
 ```
 
- You can use `hydrateDocument` as a part of your server's response logic before serving the web page. `hydrateDocument` takes two arguments, a document and a config object. The function also returns a promise with `HydrateResults`.
+You can use `hydrateDocument` as a part of your server's response logic before serving the web page. `hydrateDocument` takes two arguments, a document and a config object. The function also returns a promise with `HydrateResults`.
 
 **Example taken from Ionic Angular server**
 
@@ -74,7 +74,7 @@ export function hydrateComponents(doc) {
 }
 ```
 
- The hydrate app also has a `renderToString` method that allows you to pass in an html string that also returns a promise of `HydrateResults`.
+The hydrate app also has a `renderToString` method that allows you to pass in an html string that also returns a promise of `HydrateResults`.
 
 ```javascript
 const results = await hydrate.renderToString(srcHtml, {


### PR DESCRIPTION
Addresses #519 

I wasn't sure how far we want to take the documentation. I also know that the `hydrateDocument` takes a large config object and I'm unsure which each option does. I plan on expanding this PR with more information.

Feedback is very welcome!

- [x] Document config object options. Will this be changing? How much of it is worth documenting?
- [x] Document `renderToString`