### PR TITLE
docs: Correct `globals` -> `global`

### DIFF
--- a/src/docs/config/overview.md
+++ b/src/docs/config/overview.md
@@ -70,14 +70,14 @@ Below is an example folder structure containing a webapp's global css file, name
 ```bash
 src/
   components/
-  globals/
+  global/
     app.css
 ```
 
 The global style config takes a file path as a string. The output from this build will go to the `buildDir`. In this example it would be saved to `www/build/app.css`.
 
 ```tsx
-globalStyle: 'src/globals/app.css'
+globalStyle: 'src/global/app.css'
 ```
 
 


### PR DESCRIPTION
imo, "global" is more conventional, and in fact, is referenced as such in other areas of the site:
https://stenciljs.com/docs/styling#using-css-variables-in-stencil

(we could go the other way as well, just as long as the docs are consistent)