### PR TITLE
docs(targets): add docs page for docs-custom

### DIFF
--- a/src/assets/docs-structure.json
+++ b/src/assets/docs-structure.json
@@ -198,6 +198,11 @@
         "url": "/docs/docs-json"
       },
       {
+        "text": "docs-custom",
+        "filePath": "/assets/docs/output-targets/docs-custom.json",
+        "url": "/docs/docs-custom"
+      },
+      {
         "text": "Copy Tasks",
         "filePath": "/assets/docs/output-targets/copy-tasks.json",
         "url": "/docs/copy-tasks"

--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -40,6 +40,7 @@
   * [dist](output-targets/dist.md)
   * [docs-readme](output-targets/docs-readme.md)
   * [docs-json](output-targets/docs-json.md)
+  * [docs-custom](output-targets/docs-custom.md)
   * [Copy Tasks](output-targets/copy-tasks.md)
 * Guides
   * [Prerendering](guides/prerendering.md)

--- a/src/docs/output-targets/docs-custom.md
+++ b/src/docs/output-targets/docs-custom.md
@@ -1,0 +1,37 @@
+---
+title: Custom Docs Generation
+description: Custom Docs Generation
+url: /docs/docs-custom
+contributors:
+  - adamdbradley
+  - manucorporat
+---
+
+# Custom Docs Generation
+
+Stencil exposes an output target titled `docs-custom` where users can access the generated docs json data. This feature can be used to generate custom markdown or to execute other logic on the json data during the build. As with other docs output targets, `strict` mode is supported.
+
+To make use of this output target, simply add the following to your Stencil configuration.
+
+```tsx
+import { Config } from '@stencil/core';
+
+export const config: Config = {
+  outputTargets: [
+    {
+      type: 'docs-custom',
+      generator: (docs: JsonDocs) => {
+          // Custom logic goes here
+      }
+    }
+  ]
+};
+```
+
+## Config
+
+| Property    | Description                                                                              | Default |
+|-------------|------------------------------------------------------------------------------------------|---------|
+| `generator` | A function with the docs json data as argument.                                          |         |
+| `strict`    | If set to true, Stencil will output a warning whenever there is missing documentation.   | `false` |
+

--- a/src/docs/output-targets/overview.md
+++ b/src/docs/output-targets/overview.md
@@ -17,7 +17,7 @@ One of the more powerful features of the compiler is its ability to generate var
  - [`www`: Website](/docs/www)
  - [`docs-readme`: Documentation readme files formatted in markdown](/docs/docs-readme)
  - [`docs-json`: Documentation data formatted in JSON](/docs/docs-json)
-
+ - [`docs-custom`: Custom documentation generation](/docs/docs-custom)
 
 ## Example:
 


### PR DESCRIPTION
Adds a docs page for the `docs-custom` output target.

let me know if I missed something, never added a page before :man_shrugging: 

closes #535 