### PR TITLE
docs(extra) - typo - mainly used for testing

### DIFF
--- a/src/docs/config/extras.md
+++ b/src/docs/config/extras.md
@@ -53,7 +53,7 @@ div {
 
 Dispatches component lifecycle events. By default these events are not dispatched,
 but by enabling this to `true` these events can be listened for on `window`.
-Mainly for used testing.
+Mainly used for testing.
 
 | Event Name                     | Description                                                    |
 |--------------------------------|----------------------------------------------------------------|


### PR DESCRIPTION
Based on an [earlier commit](https://github.com/ionic-team/stencil-site/commit/b11071f5f65f5230a6b8ac43b3faff6708c2952f#diff-9b4631c224886721e8787d8e58d94d3e), this seems to have got switched around.