### PR TITLE
docs(properties): fix isBlank code sample

### DIFF
--- a/src/docs/components/properties.md
+++ b/src/docs/components/properties.md
@@ -191,7 +191,7 @@ export class TodoList {
 
   @Watch('name')
   validateName(newValue: string, oldValue: string) {
-    const isBlank = typeof newValue == null;
+    const isBlank = typeof newValue !== 'string' || newValue === '';
     const has2chars = typeof newValue === 'string' && newValue.length >= 2;
     if (isBlank) { throw new Error('name: required') };
     if (!has2chars) { throw new Error('name: has2chars') };


### PR DESCRIPTION
I know it's just an illustrative example, but it wouldn't have worked. If the `newValue` was `null` then `typeof newValue` would be `object`. If `newValue === ''` then `typeof newValue` would be `string`, so it wouldn't ever catch a blank value.

[Confirmed null === "object"](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof#Description)