### PR TITLE
docs(reactive-data): typos, wording tweaks

### DIFF
--- a/src/docs/components/reactive-data.md
+++ b/src/docs/components/reactive-data.md
@@ -13,12 +13,12 @@ Stencil components update when props or state on a component change. For perform
 
 ## Rendering methods
 
-When a component updates because a state change (props or state change), the [`render()`](templating-jsx) method is scheduled to run.
+When a component updates because of a state change (props or state change), the [`render()`](templating-jsx) method is scheduled to run.
 
 
 ## Watch Decorator
 
-When a user updates a property, `Watch` will fire what ever method it's attached to and pass that method the new value of the prop along with the old value. `Watch` is useful for validating props or handling side effects. `Watch` decorator does not fire when a component initially loads.
+When a user updates a property, `Watch` will fire the method it's attached to, and pass that method the new value of the prop along with the old value. `Watch` is useful for validating props or handling side effects. The `Watch` decorator does not fire when a component initially loads.
 
 
 ```tsx
@@ -37,15 +37,17 @@ export class LoadingIndicator {
 
 ## Handling arrays and objects
 
-To update array or object data, use the following techniques which are fast-becoming a core part of the modern JavaScript  toolbox.
+To update array or object data, use the following techniques, which are fast-becoming a core part of the modern JavaScript  toolbox.
 
 ### Updating arrays
 
-For arrays, this means that the standard mutable array operations such as `push()` and `unshift()` won't work. Instead, non-mutable array operators such as `map()` and `filter()`, and the ES6 spread operator syntax, should be used as they return a copy of a new array.
+For arrays, the standard mutable array operations such as `push()` and `unshift()` won't trigger a component update. Instead, non-mutable array operators should be used as they return a copy of a new array. These include `map()` and `filter()`, and the ES6 spread operator syntax.
 
 For example, to push a new item to an array, create a new array with the existing values and the new value at the end:
 
 ```tsx
+@State() items: string[];
+
 // our original array
 this.items = ['ionic', 'stencil', 'webcomponents'];
 
@@ -63,9 +65,11 @@ The `...this.items` syntax is a relatively new feature of JavaScript that "expan
 The spread operator should also be used to update objects. As with arrays, mutating an object will not trigger a view update in Stencil, but returning a new copy of the object will. Below is an example:
 
 ```tsx
+@State() myCoolObject;
+
 // our original object
-let myCoolObject = {first: '1', second: '2'}
+this.myCoolObject = {first: '1', second: '2'}
 
 // update our object
-myCoolObject = { ...myCoolObject, third: '3' }
+this.myCoolObject = { ...myCoolObject, third: '3' }
 ```


### PR DESCRIPTION
 - some wording tweaks to split sentences up and fix typos
 - added @State() decorators to the code examples to make it clear. I've been caught out a few times and then realised I was updating a plain array/object, and not something Stencil was monitoring.