### PR TITLE
docs(style-guide): fix code snippet highlighter

### DIFF
--- a/src/docs/guides/style-guide.md
+++ b/src/docs/guides/style-guide.md
@@ -232,13 +232,13 @@ export class Something {
    */
   @Method()
   async open(): Promise<boolean> {
-    ...
+    // ...
     return true;
   }
 
   @Method()
   async close(): Promise<void> {
-    ...
+    // ...
   }
 
   /**
@@ -247,11 +247,11 @@ export class Something {
    * called from the host element.
    */
   prepareAnimation(): Promise<void> {
-    ...
+    // ...
   }
 
   updateState() {
-    ...
+    // ...
   }
 
   /**


### PR DESCRIPTION
Looks like the `...` in the code sample is breaking the syntax highlighter, so I've put comments on them.

![image](https://user-images.githubusercontent.com/1038062/76956408-e83ba080-690b-11ea-98b0-31f71cba2955.png)