### PR TITLE
feat: window isn't needed anymore to load components with defineCustomElements

### DIFF
--- a/src/docs/framework-integration/angular.md
+++ b/src/docs/framework-integration/angular.md
@@ -16,7 +16,7 @@ contributors:
 Using a Stencil built web component collection within an Angular CLI project is a two-step process. We need to:
 
 1. Include the `CUSTOM_ELEMENTS_SCHEMA` in the modules that use the components.
-2. Call `defineCustomElements(window)` from `main.ts` (or some other appropriate place).
+2. Call `defineCustomElements()` from `main.ts` (or some other appropriate place).
 
 ## Including the Custom Elements Schema
 
@@ -61,7 +61,7 @@ if (environment.production) {
 
 platformBrowserDynamic().bootstrapModule(AppModule)
   .catch(err => console.log(err));
-defineCustomElements(window);
+defineCustomElements();
 ```
 
 ## Edge and IE11 polyfills
@@ -72,7 +72,7 @@ If you want your custom elements to be able to work on older browsers, you shoul
 import { applyPolyfills, defineCustomElements } from 'test-components/loader';
 ...
 applyPolyfills().then(() => {
-  defineCustomElements(window)
+  defineCustomElements()
 })
 
 ```

--- a/src/docs/framework-integration/javascript.md
+++ b/src/docs/framework-integration/javascript.md
@@ -34,7 +34,7 @@ Alternatively, if you wanted to take advantage of ES Modules, you could include 
   <script type="module">
     import { applyPolyfills, defineCustomElements } from 'https://unpkg.com/test-components/loader';
     applyPolyfills().then(() => {
-      defineCustomElements(window);
+      defineCustomElements();
     });
   </script>
 </head>

--- a/src/docs/framework-integration/react.md
+++ b/src/docs/framework-integration/react.md
@@ -12,7 +12,7 @@ contributors:
 ---
 # React
 
-With an application built using the `create-react-app` script the easiest way to include the component library is to call `defineCustomElements(window)` from the `index.js` file.
+With an application built using the `create-react-app` script the easiest way to include the component library is to call `defineCustomElements()` from the `index.js` file.
 Note that in this scenario `applyPolyfills` is needed if you are targeting Edge or IE11.
 
 ```tsx
@@ -30,7 +30,7 @@ ReactDOM.render(<App />, document.getElementById('root'));
 registerServiceWorker();
 
 applyPolyfills().then(() => {
-  defineCustomElements(window);
+  defineCustomElements();
 });
 ```
 

--- a/src/docs/framework-integration/vue.md
+++ b/src/docs/framework-integration/vue.md
@@ -35,7 +35,7 @@ Vue.config.ignoredElements = [/test-\w*/];
 
 // Bind the custom elements to the window object
 applyPolyfills().then(() => {
-  defineCustomElements(window);
+  defineCustomElements();
 });
 
 new Vue({


### PR DESCRIPTION
As discussed on Slack, `window` isn't needed anymore to load components with `defineCustomElements`.

Moreover, on Gatsby build, no using `window` is a must, otherwise their prerendering build would fail.

That's why, it's better to display `defineCustomElements` without it.