### PR TITLE
docs(testing): add hint for upstream Jest config

### DIFF
--- a/src/docs/testing/config.md
+++ b/src/docs/testing/config.md
@@ -5,13 +5,16 @@ url: /docs/testing-config
 contributors:
   - adamdbradley
   - mattcosta7
+  - viernullvier
 ---
 
 # Testing Config
 
-The `testing` config setting specifies an object that corresponds to the jest configuration that should be used in your tests. Stencil provides a default configuration, which you likely won't need to edit, however it can be extended with the same configuration options as Jest. See the [Configuring Jest Guide](https://jestjs.io/docs/en/configuration.html) for configuration details..
+The `testing` config setting specifies an object that corresponds to the jest configuration that should be used in your tests. Stencil provides a default configuration, which you likely won't need to edit, however it can be extended with the same configuration options as Jest. See the [Configuring Jest Guide](https://jestjs.io/docs/en/configuration.html) for configuration details.
 
-Some additional Stencil specific options may be set here as well for configuring the e2e tests
+> Keep in mind that the usual way of configuring Jest (`package.json` and `jest.config.js`) will not work in a Stencil project.
+
+Some additional Stencil specific options may be set here as well for configuring the e2e tests:
 
 ```tsx
 export interface TestingConfig extends JestConfig {


### PR DESCRIPTION
This change will add a hint explaining that Jest configurations in `package.json` and `jest.config.js` will not be applied. While we're at it, it also fixes two minor punctuation issues.