### PR TITLE
docs(lifecycle): update lifecycle chart

### DIFF
--- a/src/docs/components/component-lifecycle.md
+++ b/src/docs/components/component-lifecycle.md
@@ -12,6 +12,84 @@ Components have numerous lifecycle methods which can be used to know when the co
 
 Implement one of the following methods within a component class and Stencil will automatically call them in the right order:
 
+
+<svg viewBox="0 0 643 922" xmlns="http://www.w3.org/2000/svg" style="margin: 60px 0;">
+  <g fill-rule="evenodd">
+    <g fill="none" stroke="#b3b6c5">
+      <path d="m552 743c49.706 0 90-40.294 90-90v-488c0-58.5-47.2-106-105.5-106-58.393 0.16547-105.61 47.607-105.5 106l0.4 136.5v304" stroke-linecap="square" />
+      <path d="m437.7 600.3-6.3 6.3-6.3-6.3" />
+      <path d="m126.4 19.5v586" stroke-linecap="square" />
+      <path d="m132.7 600.3-6.3 6.3-6.3-6.3" />
+      <path d="m290.3 805v53.5" stroke-linecap="square" />
+      <path d="m296.6 852.3-6.3 6.3-6.3-6.3" />
+    </g>
+    <g fill="#fdf5e4">
+      <rect x="1" y="718" width="555" height="50" rx="4" ry="4" />
+      <rect x="1" y="779" width="555" height="50" rx="4" ry="4" />
+      <rect width="252" height="50" rx="4" ry="4" />
+    </g>
+    <g fill="#9a6400" font-size="14px" letter-spacing="-.2">
+      <text y="-1.0898438">
+        <tspan x="57" y="28.910156">Component initialized</tspan>
+      </text>
+      <text y="166.90677">
+        <tspan x="110.8" y="746.90674">Change in a value of prop or state triggers rerender</tspan>
+      </text>
+      <text y="167.91019">
+        <tspan x="211.7" y="807.91016">Component removed</tspan>
+      </text>
+    </g>
+    <rect y="451" width="555" height="49" rx="24.5" ry="24.5" fill="#39b54a" />
+    <g fill="#212431">
+      <rect y="620" width="252" height="49" rx="24.5" ry="24.5" />
+      <rect x="303" y="620" width="252" height="49" rx="24.5" ry="24.5" />
+      <rect x="164" y="873" width="252" height="49" rx="24.5" ry="24.5" />
+      <rect x="303" y="161" width="252" height="49" rx="24.5" ry="24.5" />
+      <rect y="89" width="252" height="49" rx="24.5" ry="24.5" />
+      <rect x="303" y="233" width="252" height="49" rx="24.5" ry="24.5" />
+      <rect x="77.5" y="377" width="400" height="49" rx="24.5" ry="24.5" />
+      <rect x="303" y="305" width="252" height="49" rx="24.5" ry="24.5" />
+      <rect x="77.5" y="523" width="400" height="49" rx="24.5" ry="24.5" />
+      <rect y="161" width="252" height="49" rx="24.5" ry="24.5" />
+    </g>
+    <g fill="#ffffff" font-family="SFMono-Regular, 'SF Mono', 'Lucida Console', monospace" font-size="15px">
+      <text x="2.2028809" y="166.83597">
+        <tspan x="45.202881" y="648.83594">componentDidLoad()</tspan>
+      </text>
+      <text x="2.8501587" y="166.83597">
+        <tspan x="339.15015" y="648.83594">componentDidUpdate()</tspan>
+      </text>
+      <text x="-7.070755" y="148.19852">
+        <tspan x="191.22925" y="902.19849">disconnectedCallback()</tspan>
+      </text>
+      <text x="2.5288086" y="-8">
+        <tspan x="348.52881" y="190">@Watch(‘propName’)</tspan>
+      </text>
+      <text x="1.035553" y="109.1985">
+        <tspan x="241.43555" y="480.19852">render()</tspan>
+      </text>
+      <text x="2.2765121" y="26.198486">
+        <tspan x="40.676514" y="118.19849">connectedCallback()</tspan>
+      </text>
+      <text x="-6.5289083" y="2.8359385">
+        <tspan x="325.57104" y="261.83594">componentShouldUpdate()</tspan>
+      </text>
+      <text x="-148.97623" y="146.83594">
+        <tspan x="183.12378" y="405.83594">componentWillRender()</tspan>
+      </text>
+      <text x="2.5237732" y="74.835938">
+        <tspan x="334.62378" y="333.83594">componentWillUpdate()</tspan>
+      </text>
+      <text x="-144.44986" y="292.83597">
+        <tspan x="187.65015" y="551.83594">componentDidRender()</tspan>
+      </text>
+      <text x="2.2765121" y="97.835938">
+        <tspan x="40.676514" y="189.83594">componentWillLoad()</tspan>
+      </text>
+    </g>
+  </g>
+</svg>
+
 ## connectedCallback()
 
 Called every time the component is connected to the DOM.
@@ -95,57 +173,6 @@ A promise can be returned, that can be used to wait for the next render.
 Called just after the component updates.
 It's never called during the first `render()`.
 
-
-<svg viewBox="0 0 643 774" xmlns="http://www.w3.org/2000/svg" style="margin: 60px 0;">
-  <g fill="none" fill-rule="evenodd">
-    <path d="M552 576a90 90 0 0 0 90-90V165c0-58.5-47.2-106-105.5-106A105.8 105.8 0 0 0 431 165l.4 136.5v136" stroke="#B3B6C5" stroke-linecap="square"/>
-    <path stroke="#B3B6C5" d="M437.6 432.3l-6.3 6.3-6.3-6.3"/>
-    <path d="M126.4 19.5v419" stroke="#B3B6C5" stroke-linecap="square"/>
-    <path stroke="#B3B6C5" d="M132.6 432.3l-6.3 6.3-6.3-6.3"/>
-    <path d="M290.3 628.5v82" stroke="#B3B6C5" stroke-linecap="square"/>
-    <path stroke="#B3B6C5" d="M296.6 704.3l-6.3 6.3-6.3-6.3"/>
-    <rect fill="#FDF5E4" x="1" y="550" width="555" height="50" rx="4"/>
-    <rect fill="#FDF5E4" x="1" y="611" width="555" height="50" rx="4"/>
-    <rect fill="#FDF5E4" width="252" height="50" rx="4"/>
-    <rect fill="#212431" y="452" width="252" height="49" rx="24.5"/>
-    <rect fill="#212431" x="303" y="452" width="252" height="49" rx="24.5"/>
-    <rect fill="#212431" x="303" y="229" width="252" height="49" rx="24.5"/>
-    <rect fill="#212431" x="164" y="725" width="252" height="49" rx="24.5"/>
-    <rect fill="#212431" x="303" y="169" width="252" height="49" rx="24.5"/>
-    <text font-size="14" letter-spacing="-.2" fill="#9A6400">
-      <tspan x="57" y="30">Component initialized</tspan>
-    </text>
-    <text font-family="SFMono-Regular, SF Mono, Lucida Console, monospace" font-size="15" fill="#FFF">
-      <tspan x="43" y="482">componentDidLoad()</tspan>
-    </text>
-    <text font-family="SFMono-Regular, SF Mono, Lucida Console, monospace" font-size="15" fill="#FFF">
-      <tspan x="336.3" y="482">componentDidUpdate()</tspan>
-    </text>
-    <text font-family="SFMono-Regular, SF Mono, Lucida Console, monospace" font-size="15" fill="#FFF">
-      <tspan x="332.1" y="259">componentWillUpdate()</tspan>
-    </text>
-    <text font-family="SFMono-Regular, SF Mono, Lucida Console, monospace" font-size="15" fill="#FFF">
-      <tspan x="198.3" y="754">componentDidUnload()</tspan>
-    </text>
-    <text font-family="SFMono-Regular, SF Mono, Lucida Console, monospace" font-size="15" fill="#FFF">
-      <tspan x="346" y="198">@Watch(‘propName’)</tspan>
-    </text>
-    <text font-size="14" letter-spacing="-.2" fill="#9A6400">
-      <tspan x="110.8" y="580">Change in a value of prop or state triggers rerender</tspan>
-    </text>
-    <text font-size="14" letter-spacing="-.2" fill="#9A6400">
-      <tspan x="211.7" y="640">Component removed</tspan>
-    </text>
-    <rect fill="#39B54A" y="342" width="555" height="49" rx="24.5"/>
-    <text font-family="SFMono-Regular, SF Mono, Lucida Console, monospace" font-size="15" fill="#FFF">
-      <tspan x="240.4" y="371">render()</tspan>
-    </text>
-    <rect fill="#212431" y="63" width="252" height="49" rx="24.5"/>
-    <text font-family="SFMono-Regular, SF Mono, Lucida Console, monospace" font-size="15" fill="#FFF">
-      <tspan x="38.4" y="92">componentWillLoad()</tspan>
-    </text>
-  </g>
-</svg>
 
 ## Rendering State
 

--- a/src/docs/components/component-lifecycle.md
+++ b/src/docs/components/component-lifecycle.md
@@ -15,43 +15,43 @@ Implement one of the following methods within a component class and Stencil will
 
 <svg viewBox="0 0 643 922" xmlns="http://www.w3.org/2000/svg" style="margin: 60px 0;">
   <g fill-rule="evenodd">
-    <g fill="none" stroke="#b3b6c5">
-      <path d="m552 743c49.706 0 90-40.294 90-90v-488c0-58.5-47.2-106-105.5-106-58.393 0.16547-105.61 47.607-105.5 106l0.4 136.5v304" stroke-linecap="square" />
-      <path d="m437.7 600.3-6.3 6.3-6.3-6.3" />
+    <g fill="none">
+      <path d="m552 743c49.706 0 90-40.294 90-90v-488c0-58.5-47.2-106-105.5-106-58.393 0.16547-105.61 47.607-105.5 106l0.4 136.5v304" stroke="#7b83a6" stroke-linecap="square" />
+      <path d="m437.7 600.3-6.3 6.3-6.3-6.3" stroke="#b3b6c5" />
+    </g>
+    <g fill="none" stroke="#212431">
       <path d="m126.4 19.5v586" stroke-linecap="square" />
       <path d="m132.7 600.3-6.3 6.3-6.3-6.3" />
-      <path d="m290.3 805v53.5" stroke-linecap="square" />
-      <path d="m296.6 852.3-6.3 6.3-6.3-6.3" />
+    </g>
+    <g fill="none" stroke="#575e7f">
+      <path d="m278 19.5v58.059" stroke-linecap="square" />
+      <path d="m284.3 71.993-6.3 6.3-6.3-6.3" />
+      <path d="m278.5 805v53.5" stroke-linecap="square" />
+      <path d="m284.8 852.3-6.3 6.3-6.3-6.3" />
     </g>
     <g fill="#fdf5e4">
       <rect x="1" y="718" width="555" height="50" rx="4" ry="4" />
       <rect x="1" y="779" width="555" height="50" rx="4" ry="4" />
-      <rect width="252" height="50" rx="4" ry="4" />
-    </g>
-    <g fill="#9a6400" font-size="14px" letter-spacing="-.2">
-      <text y="-1.0898438">
-        <tspan x="57" y="28.910156">Component initialized</tspan>
-      </text>
-      <text y="166.90677">
-        <tspan x="110.8" y="746.90674">Change in a value of prop or state triggers rerender</tspan>
-      </text>
-      <text y="167.91019">
-        <tspan x="211.7" y="807.91016">Component removed</tspan>
-      </text>
+      <rect width="190" height="50" rx="4" ry="4" />
+      <rect x="215" width="190" height="50" rx="4" ry="4" />
     </g>
     <rect y="451" width="555" height="49" rx="24.5" ry="24.5" fill="#39b54a" />
-    <g fill="#212431">
-      <rect y="620" width="252" height="49" rx="24.5" ry="24.5" />
+    <rect y="620" width="252" height="49" rx="24.5" ry="24.5" fill="#212431" />
+    <g fill="#7b83a6">
       <rect x="303" y="620" width="252" height="49" rx="24.5" ry="24.5" />
-      <rect x="164" y="873" width="252" height="49" rx="24.5" ry="24.5" />
       <rect x="303" y="161" width="252" height="49" rx="24.5" ry="24.5" />
-      <rect y="89" width="252" height="49" rx="24.5" ry="24.5" />
-      <rect x="303" y="233" width="252" height="49" rx="24.5" ry="24.5" />
-      <rect x="77.5" y="377" width="400" height="49" rx="24.5" ry="24.5" />
+      <a href="#componentshouldupdate-newval-any-oldval-any-propname-string-boolean">
+        <rect x="303" y="233" width="252" height="49" rx="24.5" ry="24.5" />
+      </a>
       <rect x="303" y="305" width="252" height="49" rx="24.5" ry="24.5" />
-      <rect x="77.5" y="523" width="400" height="49" rx="24.5" ry="24.5" />
-      <rect y="161" width="252" height="49" rx="24.5" ry="24.5" />
     </g>
+    <g fill="#4b516e">
+      <rect x="152.5" y="873" width="252" height="49" rx="24.5" ry="24.5" />
+      <rect x="65" y="89" width="275" height="49" rx="24.5" ry="24.5" />
+      <rect x="77.5" y="377" width="400" height="49" rx="24.5" ry="24.5" />
+      <rect x="77.5" y="523" width="400" height="49" rx="24.5" ry="24.5" />
+    </g>
+    <rect y="161" width="252" height="49" rx="24.5" ry="24.5" fill="#212431" />
     <g fill="#ffffff" font-family="SFMono-Regular, 'SF Mono', 'Lucida Console', monospace" font-size="15px">
       <text x="2.2028809" y="166.83597">
         <tspan x="45.202881" y="648.83594">componentDidLoad()</tspan>
@@ -59,8 +59,8 @@ Implement one of the following methods within a component class and Stencil will
       <text x="2.8501587" y="166.83597">
         <tspan x="339.15015" y="648.83594">componentDidUpdate()</tspan>
       </text>
-      <text x="-7.070755" y="148.19852">
-        <tspan x="191.22925" y="902.19849">disconnectedCallback()</tspan>
+      <text x="-18.570755" y="148.19852">
+        <tspan x="179.72925" y="902.19849">disconnectedCallback()</tspan>
       </text>
       <text x="2.5288086" y="-8">
         <tspan x="348.52881" y="190">@Watch(‘propName’)</tspan>
@@ -68,12 +68,14 @@ Implement one of the following methods within a component class and Stencil will
       <text x="1.035553" y="109.1985">
         <tspan x="241.43555" y="480.19852">render()</tspan>
       </text>
-      <text x="2.2765121" y="26.198486">
-        <tspan x="40.676514" y="118.19849">connectedCallback()</tspan>
+      <text x="78.77652" y="26.198486">
+        <tspan x="117.17651" y="118.19849">connectedCallback()</tspan>
       </text>
-      <text x="-6.5289083" y="2.8359385">
-        <tspan x="325.57104" y="261.83594">componentShouldUpdate()</tspan>
-      </text>
+      <a href="#componentshouldupdate-newval-any-oldval-any-propname-string-boolean">
+        <text x="-11.721779" y="2.8359385">
+          <tspan x="320.37817" y="261.83594">componentShouldUpdate()*</tspan>
+        </text>
+      </a>
       <text x="-148.97623" y="146.83594">
         <tspan x="183.12378" y="405.83594">componentWillRender()</tspan>
       </text>
@@ -85,6 +87,20 @@ Implement one of the following methods within a component class and Stencil will
       </text>
       <text x="2.2765121" y="97.835938">
         <tspan x="40.676514" y="189.83594">componentWillLoad()</tspan>
+      </text>
+    </g>
+    <g fill="#9a6400" font-size="14px" letter-spacing="-.2">
+      <text x="-35.790039" y="-1.0898438">
+        <tspan x="21.209961" y="28.910156">Component initialized</tspan>
+      </text>
+      <text y="166.90677">
+        <tspan x="110.8" y="746.90674">Change in a value of prop or state triggers rerender</tspan>
+      </text>
+      <text y="167.91019">
+        <tspan x="211.7" y="807.91016">Component removed</tspan>
+      </text>
+      <text x="174.59824" y="-1.0898438">
+        <tspan x="231.59824" y="28.910156">Component reattached</tspan>
       </text>
     </g>
   </g>


### PR DESCRIPTION
Removed `componentDidUnload`. Added `connectedCallback`, `disconnectedCallback`, `componentShouldUpdate`, `componentWillRender` and `componentDidRender`.