### PR TITLE
docs: remove `componentDidUnload`

### DIFF
--- a/src/components/custom-clock.tsx
+++ b/src/components/custom-clock.tsx
@@ -4,18 +4,19 @@ import { Component, State, h } from '@stencil/core';
   tag: 'custom-clock'
 })
 export class CustomClock {
-  timer: any;
+
+  timer?: number;
 
   @State() time: number = Date.now();
 
-  componentDidLoad() {
-    this.timer = setInterval(() => {
+  connectedCallback() {
+    this.timer = window.setInterval(() => {
       this.time = Date.now();
     }, 1000);
   }
 
-  componentDidUnload() {
-    clearInterval(this.timer);
+  disconnectedCallback() {
+    window.clearInterval(this.timer);
   }
 
   render() {

--- a/src/docs/components/component-lifecycle.md
+++ b/src/docs/components/component-lifecycle.md
@@ -8,7 +8,7 @@ contributors:
 
 # Component Lifecycle Methods
 
-Components have numerous lifecycle methods which can be used to know when the component "will" and "did" load, update, and unload. These methods can be added to a component to hook into operations at the right time.
+Components have numerous lifecycle methods which can be used to know when the component "will" and "did" load, update, and render. These methods can be added to a component to hook into operations at the right time.
 
 Implement one of the following methods within a component class and Stencil will automatically call them in the right order:
 
@@ -105,6 +105,7 @@ Implement one of the following methods within a component class and Stencil will
     </g>
   </g>
 </svg>
+
 
 ## connectedCallback()
 
@@ -242,7 +243,7 @@ componentWillLoad() {
 
 ## Example
 
-This simple example shows a clock and updates the current time every second. Since `componentDidLoad` is only called once, we will only ever have one instance of the timer running. Once the component unloads, the timer is stopped.
+This simple example shows a clock and updates the current time every second. The timer is started when the component is added to the DOM. Once it's removed from the DOM, the timer is stopped.
 
 ```tsx
 import { Component, State, h } from '@stencil/core';
@@ -256,13 +257,13 @@ export class CustomClock {
 
   @State() time: number = Date.now();
 
-  componentDidLoad() {
+  connectedCallback() {
     this.timer = window.setInterval(() => {
       this.time = Date.now();
     }, 1000);
   }
 
-  componentDidUnload() {
+  disconnectedCallback() {
     window.clearInterval(this.timer);
   }
 

--- a/src/docs/guides/style-guide.md
+++ b/src/docs/guides/style-guide.md
@@ -205,11 +205,14 @@ export class Something {
    * Ordered by their natural call order, for example
    * WillLoad should go before DidLoad.
    */
-  componentWillLoad() {}
+  connectedCallback() {}
+  disconnectedCallback() {}
   componentDidLoad() {}
   componentWillUpdate() {}
   componentDidUpdate() {}
-  componentDidUnload() {}
+  componentWillRender() {}
+  componentShouldRender(newVal: any, oldVal: any, propName: string) {}
+  componentDidRender() {}
 
   /**
    * 7. Listeners


### PR DESCRIPTION
Use of `componentDidUnload` is discouraged. It will eventually be removed and it's recommended to use `disconnectedCallback`

@adamdbradley:
> componentDidUnload() is difficult to be accurate 100% of the time since frameworks will sometimes reuse the same "element" it created in the dom, so it's hard for stencil to know if it's a new instance of a component, or that the element was just reused by a framework