### PR TITLE
Fix url to DeviceDescriptors.js

### DIFF
--- a/src/docs/testing/config.md
+++ b/src/docs/testing/config.md
@@ -87,7 +87,7 @@ export interface TestingConfig extends JestConfig {
 export interface EmulateConfig {
   /**
    * Predefined device descriptor name, such as "iPhone X" or "Nexus 10".
-   * For a complete list please see: https://github.com/GoogleChrome/puppeteer/blob/master/DeviceDescriptors.js
+   * For a complete list please see: https://github.com/puppeteer/puppeteer/blob/main/src/DeviceDescriptors.ts
    */
   device?: string;
 


### PR DESCRIPTION
the device list for puppeteer moved 
from https://github.com/GoogleChrome/puppeteer/blob/master/DeviceDescriptors.js
to https://github.com/puppeteer/puppeteer/blob/main/src/DeviceDescriptors.ts