### PR TITLE
docs(publishing): add existing publishing

### DIFF
--- a/src/assets/docs-structure.json
+++ b/src/assets/docs-structure.json
@@ -311,6 +311,11 @@
         "text": "Stencil Store",
         "filePath": "/assets/docs/guides/store.json",
         "url": "/docs/stencil-store"
+      },
+      {
+        "text": "Publishing",
+        "filePath": "/assets/docs/guides/publishing.json",
+        "url": "/docs/publishing"
       }
     ]
   },

--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -63,6 +63,7 @@
   * [Style Guide](guides/style-guide.md)
   * [Service Workers](guides/service-workers.md)
   * [Stencil Store](guides/store.md)
+  * [Publishing](guides/publishing.md)
 * Testing
   * [Overview](testing/overview.md)
   * [Config](testing/config.md)


### PR DESCRIPTION
The page was created in f149dfd but not added to the readme and therefore not accessible.