### PR TITLE
Fix search menu + code blocks

### DIFF
--- a/src/components/site-menu/site-menu.css
+++ b/src/components/site-menu/site-menu.css
@@ -2,6 +2,7 @@ site-menu {
   display: block;
   flex: 0 0 auto;
   /* max-width: 250px; */
+  z-index: 1;
 }
 
 site-menu .wrapper {


### PR DESCRIPTION
When the search menu is open, code blocks appear on top of the menu. This PR adds a small z-index to the site-menu tp address that.

I believe @fvaldes33 worked on the search feature, so he may be able to determine if this is the most appropriate way to fix this.

Before:
<img width="823" alt="CleanShot 2020-07-08 at 09 29 00@2x" src="https://user-images.githubusercontent.com/55639/86924792-ee919a80-c0fd-11ea-9e04-279dcd0a0b3b.png">

After:
<img width="829" alt="CleanShot 2020-07-08 at 09 28 43@2x" src="https://user-images.githubusercontent.com/55639/86924481-88a51300-c0fd-11ea-980d-0bc8617c0d81.png">

