### PR TITLE
docs(ui): Reduce sidebar size

### DIFF
--- a/src/components/doc-component/doc-component.css
+++ b/src/components/doc-component/doc-component.css
@@ -57,8 +57,8 @@ doc-component .doc-content {
   flex: 1;
   justify-content: space-between;
   min-width: 0;
-  padding-left: 60px;
-  padding-right: 60px;
+  padding-left: 48px;
+  padding-right: 48px;
   width: 100%;
   margin-left: auto;
   margin-right: auto;

--- a/src/components/search-bar/search-bar.css
+++ b/src/components/search-bar/search-bar.css
@@ -23,7 +23,7 @@ search-bar input {
 search-bar input {
   transition: border 0.3s;
   margin-right: 8px;
-  padding: 10px 16px 10px 56px;
+  padding: 10px 16px 10px 52px;
   font-size: 16px;
   border: 1px solid #DEE3EA;
   box-sizing: border-box;
@@ -49,6 +49,15 @@ search-bar input.error {
 search-bar input::placeholder {
   color: #6D6C82;
   opacity: 0.6;
+}
+
+/* Safari has a special pseudo element for `search` fields */
+search-bar input::-webkit-search-decoration {
+  display: none;
+}
+
+#algolia-search .algolia-autocomplete {
+  max-width: 100%;
 }
 
 /* Main dropdown wrapper */

--- a/src/components/site-menu/site-menu.css
+++ b/src/components/site-menu/site-menu.css
@@ -1,7 +1,7 @@
 site-menu {
   display: block;
   flex: 0 0 auto;
-  /* max-width: 250px; */
+  max-width: 200px;
   z-index: 1;
 }
 
@@ -81,6 +81,7 @@ site-menu .menu-list a {
   font-weight: 400;
   color: #6c6c8b;
   text-decoration: none;
+  white-space: nowrap;
   border: 0;
 }
 
@@ -107,6 +108,7 @@ site-menu .menu-list ul li {
   height: 26px;
   display: block;
   overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 site-menu .menu-list ul.collapsed li {


### PR DESCRIPTION
As I mentioned in the issue, the main content section is too narrow right now. 
<img width="1083" alt="Screen Shot 2020-07-27 at 19 00 18" src="https://user-images.githubusercontent.com/1442293/88565211-f4afd280-d03c-11ea-9bac-70c83730136e.png">

It's hard to read code blocks and text lines are too short (kinda newspapers style 😄 ). So, I reduced a sidebar width.
As a side-effect the `dist-custom-elements-bundle` nav item doesn't fit to the container once it's active (bold font increases the size). That's why I prevented word-wrapping and added `ellipsis` to nav elements.

The result:
<img width="1080" alt="Screen Shot 2020-07-27 at 19 00 03" src="https://user-images.githubusercontent.com/1442293/88565544-6ee05700-d03d-11ea-9087-716fe47f97f3.png">
