### PR TITLE
Fixed a typo at the Rendering State section

### DIFF
--- a/src/docs/components/component-lifecycle.md
+++ b/src/docs/components/component-lifecycle.md
@@ -101,7 +101,7 @@ It's never called during the first `render()`.
 
 ## Rendering State
 
-It's always recommended to make any rendered state updates within `componentWillRender()`, since these is the method which get called _before_ the `render()` method. Alternatively, updating rendered state with the `componentDidLoad()`, `componentDidUpdate()` and `componentDidRender()` methods will cause another rerender, which isn't ideal for performance.
+It's always recommended to make any rendered state updates within `componentWillRender()`, since this is the method which get called _before_ the `render()` method. Alternatively, updating rendered state with the `componentDidLoad()`, `componentDidUpdate()` and `componentDidRender()` methods will cause another rerender, which isn't ideal for performance.
 
 If state _must_ be updated in `componentDidUpdate()` or `componentDidRender()`, it has the potential of getting components stuck in an infinite loop. If updating state within `componentDidUpdate()` is unavoidable, then the method should also come with a way to detect if the props or state is "dirty" or not (is the data actually different or is it the same as before). By doing a dirty check, `componentDidUpdate()` is able to avoid rendering the same data, and which in turn calls `componentDidUpdate()` again.
 


### PR DESCRIPTION
"since these is the method" corrected to "since this is the method". These is referencing multiple methods, but the writers intention was to reference componentWillRender() only   