### PR TITLE
Making the documentation for componentShouldUpdate() more explicit about it utility

### DIFF
--- a/src/docs/components/component-lifecycle.md
+++ b/src/docs/components/component-lifecycle.md
@@ -63,14 +63,15 @@ This hook is called when a component's `Prop` or `State` property changes and a 
 
 A couple of things to notice is that this method will not be executed before the initial render, that is, when the component is first attached to the dom, nor when a rerender is already scheduled in the next frame.
 
-Let’s say the following two props of a component change synchronously:
+The callback can be used to log scheduled updates:
 
 ```tsx
-component.somePropA = 42;
-component.somePropB = 88;
+componentShouldUpdate(newValue: any, oldValue: any, propName: string) {
+    console.log(`${propname} was updated\n` +
+        `New value: %&{newValue}\n` +
+        `Old value: %&{oldValue}`};
+}
 ```
-
-The `componentShouldUpdate` will be first called with arguments: `42`, `undefined` and `somePropA`. If it does return `true`, the hook will not be called again since the rerender is already scheduled to happen. Instead, if the first hook returned `false`, then `componentShouldUpdate` will be called again with `88`, `undefined` and `somePropB` as arguments, triggered by the `component.somePropB = 88` mutation.
 
 Since the execution of this hook might be conditioned, it's not good to rely on it to watch for prop changes, instead use the `@Watch` decorator for that.
 


### PR DESCRIPTION
The documentation for this callback does not explain how to use it. Personally, I did not realize that I could provide arguments in order to get the scheduled updates until I saw the unit tests. From the ambiguous current description, it reads to me like an internal function that can't be intercepted.