### PR TITLE
docs(templating): add warning for `key`

### DIFF
--- a/src/docs/components/templating-and-jsx.md
+++ b/src/docs/components/templating-and-jsx.md
@@ -201,6 +201,8 @@ Each step through the `map` function creates a new JSX sub tree and adds it to t
 
 If your list is dynamic, i. e., it's possible to change, add, remove or reorder items, you should assign a unique `key` to each element to give it a stable identity. This enables Stencil to reuse DOM elements for better performance. The best way to pick a key is to use a string that uniquely identifies that list item among its siblings (often your data will already have IDs).
 
+> Do not use the `map`-function's index variable as a key. It does not represent a stable identity of an item as it can change if the order of the list changed or if you added an item to the beginning of the list. As such it is not suitable as a `key`.
+
 ```tsx
 render() {
   return (


### PR DESCRIPTION
I've seen several people that first hear about the `key` property use the index-parameter of the `map` function as the key like this:

```{ this.aList.map((item, idx) =>
  <div key={ idx }></div>
}```

This proposal adds a warning that this parameter is unfit as a `key` and explains why.