### PR TITLE
docs: extras and es5 are opt in options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ $RECYCLE.BIN/
 .DS_Store
 Thumbs.db
 UserInterfaceState.xcuserstate
+
+.idea

--- a/src/docs/config/extras.md
+++ b/src/docs/config/extras.md
@@ -18,7 +18,7 @@ Example `extras` config when __supporting__ legacy browsers:
 export const config: Config = {
   buildEs5: true,
   extras: {
-    cssVarsShim: false,
+    cssVarsShim: true,
     dynamicImportShim: true,
     shadowDomShim: true,
     safari10: true,

--- a/src/docs/config/extras.md
+++ b/src/docs/config/extras.md
@@ -16,7 +16,7 @@ Example `extras` config when __supporting__ legacy browsers:
 
 ```tsx
 export const config: Config = {
-  buildEs5: true,
+  buildEs5: 'prod',
   extras: {
     cssVarsShim: true,
     dynamicImportShim: true,
@@ -30,7 +30,7 @@ export const config: Config = {
 };
 ```
 
-Note: `buildEs5: true` was also set in the config since this example needs to support legacy browsers. See the [buildEs5 config](/docs/config#buildes5) for more information.
+Note: `buildEs5: 'prod'` was also set in the config since this example needs to support legacy browsers. See the [buildEs5 config](/docs/config#buildes5) for more information.
 
 ### appendChildSlotFix
 

--- a/src/docs/config/extras.md
+++ b/src/docs/config/extras.md
@@ -10,24 +10,27 @@ contributors:
 
 The `extras` config contains options to add and remove runtime for DOM features that require manipulations to polyfills. For example, not all DOM APIs are fully polyfilled when using the Slot polyfill. Most of these are opt-in, since not all users require the additional runtime.
 
-Many of the options are also available to remove unnecessary runtime your app does not need. For example, by default Stencil works on IE11, Edge 18 and below (Edge before it moved to Chromium) and Safari 10. While modern browsers will not download and run the polyfills, there's still additional checks within the runtime in order to support legacy browsers. By using the `extras` config, apps can completely opt-out of the additional runtime.
+By default, Stencil does not work on IE11, Edge 18 and below (Edge before it moved to Chromium) and Safari 10. In order to support legacy browsers, the browsers would need to download and run polyfills. By using the `extras` config, apps can opt-in these additional runtime settings.
 
-Example `extras` config when __not__ supporting legacy browsers:
+Example `extras` config when __supporting__ legacy browsers:
 
 ```tsx
 export const config: Config = {
-  buildEs5: false,
+  buildEs5: true,
   extras: {
     cssVarsShim: false,
-    dynamicImportShim: false,
-    safari10: false,
-    scriptDataOpts: false,
-    shadowDomShim: false
+    dynamicImportShim: true,
+    shadowDomShim: true,
+    safari10: true,
+    scriptDataOpts: true,
+    appendChildSlotFix: false,
+    cloneNodeFix: false,
+    slotChildNodesFix: true,
   }
 };
 ```
 
-Note: `buildEs5: false` was also set in the config since this example does not need to support legacy browsers. See the [buildEs5 config](/docs/config#buildes5) for more information.
+Note: `buildEs5: true` was also set in the config since this example needs to support legacy browsers. See the [buildEs5 config](/docs/config#buildes5) for more information.
 
 ### appendChildSlotFix
 

--- a/src/docs/config/overview.md
+++ b/src/docs/config/overview.md
@@ -27,7 +27,7 @@ export const config: Config = {
 
 ## buildEs5
 
-Sets if the ES5 build should be generated or not. It defaults to `false` in dev mode, and `true` in production mode. Notice that Stencil always generates a modern build too, whereas this setting will either disable es5 builds entirely with `false`, or always create es5 builds (even in dev mode) when set to `true`. Basically if the app does not need to run on legacy browsers (IE11 and Edge 18 and below), it's safe to set `buildEs5` to `false`, which will also speed up production build times. In addition to not creating es5 builds, apps may also be interested in disabling any unnecessary runtime when __not__ supporting legacy browsers. See [config extras](/docs/config-extras) for more information.
+Sets if the ES5 build should be generated or not. It defaults to `false`. Basically if the app does not need to run on legacy browsers (IE11 and Edge 18 and below), it's safe to use the default respectively, `buildEs5` set  to `false`, which will also speed up production build times. In addition to creating es5 builds, apps may also be interested in enable runtime options to __support__ legacy browsers. See [config extras](/docs/config-extras) for more information.
 
 ```tsx
 buildEs5: false

--- a/src/docs/config/overview.md
+++ b/src/docs/config/overview.md
@@ -27,10 +27,10 @@ export const config: Config = {
 
 ## buildEs5
 
-Sets if the ES5 build should be generated or not. It defaults to `false`. Basically if the app does not need to run on legacy browsers (IE11 and Edge 18 and below), it's safe to use the default respectively, `buildEs5` set  to `false`, which will also speed up production build times. In addition to creating es5 builds, apps may also be interested in enable runtime options to __support__ legacy browsers. See [config extras](/docs/config-extras) for more information.
+Sets if the ES5 build should be generated or not. It defaults to `false`. Setting `true` will also create es5 builds for both dev and prod modes. Setting `buildEs5` to `prod` will only build ES5 in prod mode. Basically if the app does not need to run on legacy browsers (IE11 and Edge 18 and below), it's safe to use the default respectively, `buildEs5` set  to `false`, which will also speed up production build times. In addition to creating es5 builds, apps may also be interested in enable runtime options to __support__ legacy browsers. See [config extras](/docs/config-extras) for more information.
 
 ```tsx
-buildEs5: false
+buildEs5: boolean | 'prod'
 ```
 
 ## bundles


### PR DESCRIPTION
Following the release of Stencil v2 and according its [CHANGELOG](https://github.com/ionic-team/stencil/blob/master/CHANGELOG.md), extras for legacy browsers and es5 are now opt in options.

This PR reflects these changes to the doc.