### PR TITLE
Update style-guide.md

### DIFF
--- a/src/docs/guides/style-guide.md
+++ b/src/docs/guides/style-guide.md
@@ -260,7 +260,8 @@ export class Something {
 
   /**
    * 10. render() function
-   * Always the last one in the class.
+   * Always the last public method in the class.
+   * If private methods present, they are below public methods.
    */
   render() {
     return (


### PR DESCRIPTION
Since TypeScript can be used (and should be used) with StencilJS, then one should also use access modifiers. Based on latter private methods go below public API. Same should go for `render()` method.