### PR TITLE
Update overview.md

### DIFF
--- a/src/docs/output-targets/overview.md
+++ b/src/docs/output-targets/overview.md
@@ -44,6 +44,8 @@ It's also important to note that the compiler will automatically generate the nu
 
 In the example below there are two script tags, however, only one of them will be requested by the user. For IE11 users, they'll download the `app.js` file which is in the `ES5` syntax and has all the polyfills. For users on modern browsers, they will only download the `app.esm.js` file which uses up-to-date JavaScript features such as [ES modules](https://developers.google.com/web/fundamentals/primers/modules), [dynamic imports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#Dynamic_Import), [async/await](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Asynchronous/Async_await), [Classes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes), etc.
 
+Note: [buildEs5](https://stenciljs.com/docs/config#buildes5) must be set to true to generate the IE11 ES5 file 
+
 ```markup
 <script type="module" src="/build/app.esm.js"></script>
 <script nomodule src="/build/app.js"></script>


### PR DESCRIPTION
The docs make an assumption that the user has read the config first and knows that buildEs5 must be set to true in order for the second file under differential bundling to be generated.

Perhaps add a note or link to the config page about buildEs5. As a first time user I spent an extra half hour trying to debug why this file was not there.