### PR TITLE
Remove reference to stencil_appload event in extras config

### DIFF
--- a/src/docs/config/extras.md
+++ b/src/docs/config/extras.md
@@ -63,7 +63,6 @@ Dispatches component lifecycle events. By default these events are not dispatche
 
 | Event Name                     | Description                                                    |
 |--------------------------------|----------------------------------------------------------------|
-| `stencil_appload`              | The app and all of its child components have finished loading. |
 | `stencil_componentWillLoad`    | Dispatched for each component's `componentWillLoad`. |
 | `stencil_componentWillUpdate`  | Dispatched for each component's `componentWillUpdate`. |
 | `stencil_componentWillRender`  | Dispatched for each component's `componentWillRender`. |


### PR DESCRIPTION
This event has been renamed to `appload`, and made to be fired regardless of the value of `lifecycleDOMEvents` (see https://github.com/ionic-team/stencil/commits/346736)

I'll leave it to the  Stencil team to decide where best to document the `appload` event itself.