### PR TITLE
Correction of the 'distribution' page link

### DIFF
--- a/src/docs/output-targets/custom-elements.md
+++ b/src/docs/output-targets/custom-elements.md
@@ -181,7 +181,7 @@ Luckily, both builds can be generated at the same time, using the same source co
 
 ## Browser Support
 
-If the library is to be used on IE11 we recommend using the [`dist` output target](/output-targets/dist) instead since it will only load the required polyfills on-demand. The `dist-custom-elements-bundle` is only recommended for modern browsers that already support Custom Elements, Shadow DOM, and CSS Variables (basically not IE11 or Edge 12-18). If this build is going to be used within legacy browsers then the project consuming these components will have to provide its own polyfills, and correctly downlevel the output to ES5.
+If the library is to be used on IE11 we recommend using the [`dist` output target](/docs/distribution) instead since it will only load the required polyfills on-demand. The `dist-custom-elements-bundle` is only recommended for modern browsers that already support Custom Elements, Shadow DOM, and CSS Variables (basically not IE11 or Edge 12-18). If this build is going to be used within legacy browsers then the project consuming these components will have to provide its own polyfills, and correctly downlevel the output to ES5.
 
 Good news is that these are already widely supported for modern web develoment:
 


### PR DESCRIPTION
Just correction of the link: 

Before: /output-targets/dist
After: /docs/distribution