### PR TITLE
docs: fix extend in screenshot example

### DIFF
--- a/src/docs/testing/screenshot-connector.md
+++ b/src/docs/testing/screenshot-connector.md
@@ -24,7 +24,7 @@ To write a connector, import the base `ScreenshotConnector` class from stencil a
 ```javascript
 const { ScreenshotConnector } = require('@stencil/core/screenshot');
 
-module.exports = class ScreenshotCustomConnector extends ScreenshotLocalConnector {
+module.exports = class ScreenshotCustomConnector extends ScreenshotConnector {
   ...
 };
 ```


### PR DESCRIPTION
Currently ScreenshotConnector is imported but ScreenshotLocalConnector is extended.
Fixed to both use ScreenshotConnector.