### PR TITLE
chore(docs) update copyright in footer

### DIFF
--- a/src/components/app-root/app-root.tsx
+++ b/src/components/app-root/app-root.tsx
@@ -111,7 +111,7 @@ export class AppRoot {
               <ResponsiveContainer>
                 <div class="footer-col">
                   <app-icon name="logo" />
-                  <p>© 2020 StencilJS. Released under MIT License</p>
+                  <p>© {(new Date().getFullYear())} StencilJS. Released under MIT License</p>
                   <ul class="external-links list--unstyled">
                     <li>
                       <a rel="noopener" class="link--external" target="_blank" href="https://twitter.com/stenciljs" aria-label="Twitter">


### PR DESCRIPTION
Changes:
- auto-generate the correct year for the copyright

Testing:
```
  $  npm run build
  $ npm run docs
  $  npm start
```

Navigated to [the docs](http://localhost:3333/docs/introduction) to verify the output was correct
![Screen Shot 2021-06-26 at 11 39 26 AM](https://user-images.githubusercontent.com/1930213/123518373-912a8c80-d673-11eb-9b4f-4efd25946c00.png)