### PR TITLE
Correct misleading event documentation

### DIFF
--- a/src/docs/components/events.md
+++ b/src/docs/components/events.md
@@ -197,6 +197,8 @@ We can now listen to this event directly on the component in our JSX using the f
 <todo-list onTodoCompleted={ev => this.someMethod(ev)} />
 ```
 
+**Note:** This syntax will _not_ work in React. React output bindings must be used instead.
+
 ## Listening to events from a non-JSX element
 
 ```tsx


### PR DESCRIPTION
I've been having problems with CustomEvents inconsistently working in React. I started a thread on the Stencil slack where I learned that apparently the "Using events in JSX" section does not apply to React. This is misleading considering that JSX is most commonly used in React projects.

https://stencil-worldwide.slack.com/archives/C79EANFL7/p1626804965104300?thread_ts=1626383974.480700&cid=C79EANFL7