### PR TITLE
refactor(docs): corrected some links

### DIFF
--- a/src/components/resources-page/resources-data.ts
+++ b/src/components/resources-page/resources-data.ts
@@ -13,7 +13,6 @@ export const RESOURCES = {
     { title: 'st-payment: Stencil Payment API Component', url: 'https://github.com/Fdom92/stencil-payment' },
     { title: 'st-fetch: A simple component for performing http fetch calls', url: 'https://github.com/Fdom92/stencil-fetch' },
     { title: 'web-photo-filter: Use webGL for amazing instagram like filters', url: 'https://github.com/peterpeterparker/web-photo-filter' },
-    { title: 'stencil-flip-images: Awesome animated image gallery', url: 'https://github.com/jepiqueau/stencil-flip-images' },
     { title: 'd3-stencil: Charts built with D3 and Stencil. Framework-agnostic, simple.', url: 'https://d3-stencil.dev' },
     { title: 'Animatable: Animate any HTML Element using Web Animations API in a declarative way! 💅', url: 'https://proyecto26.github.io/animatable-component' },
     { title: 'IonPhaser: A web component to integrate Phaser Framework with Angular, React, Vue, etc 🎮', url: 'https://github.com/proyecto26/ion-phaser' },

--- a/src/docs/introduction/faq.md
+++ b/src/docs/introduction/faq.md
@@ -218,7 +218,7 @@ Yes, Stencil is open source and its source code can be [found on GitHub](https:/
 
 ### Which software license does Stencil use?
 
-Stencil’s software [license is MIT](https://github.com/ionic-team/stencil/blob/master/LICENSE).
+Stencil’s software [license is MIT](https://github.com/ionic-team/stencil/blob/master/LICENSE.md).
 
 
 ### Who works on Stencil?

--- a/src/docs/introduction/faq.md
+++ b/src/docs/introduction/faq.md
@@ -208,7 +208,7 @@ If this is your first time building a design system, or you’re new to Stencil,
 
 ### How do I get involved?
 
-Stencil is an open source project, and we encourage you to contribute. You can start by creating issues on GitHub, submitting feature requests, and helping to replicate bugs. If you’re interested in contributing, please see our [Contributor Guide](https://github.com/ionic-team/ionic/blob/master/.github/CONTRIBUTING.md) and check out our [issue tracker](https://github.com/ionic-team/stencil/issues).
+Stencil is an open source project, and we encourage you to contribute. You can start by creating issues on GitHub, submitting feature requests, and helping to replicate bugs. If you’re interested in contributing, please see our [Contributor Guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md) and check out our [issue tracker](https://github.com/ionic-team/stencil/issues).
 
 
 ### Is Stencil open source?

--- a/src/docs/introduction/faq.md
+++ b/src/docs/introduction/faq.md
@@ -208,7 +208,7 @@ If this is your first time building a design system, or you’re new to Stencil,
 
 ### How do I get involved?
 
-Stencil is an open source project, and we encourage you to contribute. You can start by creating issues on GitHub, submitting feature requests, and helping to replicate bugs. If you’re interested in contributing, please see our [Contributor Guide](https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md) and check out our [issue tracker](https://github.com/ionic-team/stencil/issues).
+Stencil is an open source project, and we encourage you to contribute. You can start by creating issues on GitHub, submitting feature requests, and helping to replicate bugs. If you’re interested in contributing, please see our [Contributor Guide](https://github.com/ionic-team/stencil/blob/master/.github/CONTRIBUTING.md) and check out our [issue tracker](https://github.com/ionic-team/stencil/issues).
 
 
 ### Is Stencil open source?

--- a/src/docs/introduction/faq.md
+++ b/src/docs/introduction/faq.md
@@ -114,7 +114,7 @@ At the same time, components built with Stencil can still be imported and consum
 
 A consumer of a component library may use one component, a few of them, or all of them. In any of these scenarios a component library is used by just adding a script tag, lazy loading ensures fast startup with a low bandwidth footprint.
 
-You can also learn more about lazy loading in [How Lazy-Loading Web Components Work with Stencil](/blog/how-lazy-loading-web-components-work).
+You can also learn more about lazy loading in [How Lazy-Loading Web Components Work with Stencil](https://web.archive.org/web/20201108000809/https://stenciljs.com/blog/how-lazy-loading-web-components-work).
 
 
 ### Why doesn’t Stencil extend HTMLElement?

--- a/src/docs/introduction/my-first-component.md
+++ b/src/docs/introduction/my-first-component.md
@@ -10,7 +10,7 @@ contributors:
 # My First Component
 
 Stencil components are created by adding a new file with a `.tsx` extension, such as `my-first-component.tsx`, and placing them in the `src/components` directory.
-The `.tsx` extension is required since Stencil components are built using [JSX](https://facebook.github.io/react/docs/introducing-jsx.html) and TypeScript.
+The `.tsx` extension is required since Stencil components are built using [JSX](https://reactjs.org/docs/introducing-jsx.html) and TypeScript.
 
 Here is an example of what a Stencil component looks like:
 


### PR DESCRIPTION
### Summary of changes

- The repository https://github.com/jepiqueau/stencil-flip-images doesn't exist any more, and there wasn't a replacement to find during a quick research, so I've removed the link in total
- The blog entry "How Lazy-Loading Web Components Work with Stencil" ([/blog/how-lazy-loading-web-components-work](https://ionicframework.com/blog/how-lazy-loading-web-components-work)) doesn't exist any more – it must have been either removed intentionally or hasn't been migrated to the new home of the blog entries on https://ionicframework.com/. So I've added an archived version of that page as the link target as I still expect that content to be relevant.
- The `master` branch of the https://github.com/ionic-team/ionic/ repository has been renamed to `main`, so we had to change the related link to prevent the redirect.
- The link to https://github.com/ionic-team/stencil/blob/master/LICENSE leads to a 404 error, as the fileending was missing.
- https://facebook.github.io/react/docs/introducing-jsx.html redirects to https://reactjs.org/docs/introducing-jsx.html so we could insert that link target directly.