### PR TITLE
docs(versioning): add documentation around versioning & support

### DIFF
--- a/src/docs/introduction/faq.md
+++ b/src/docs/introduction/faq.md
@@ -205,6 +205,20 @@ Additionally, modern browsers are able to use the latest features natively, with
 
 If this is your first time building a design system, or you’re new to Stencil, [get in touch](https://ionicframework.com/sales?product_of_interest=Design%20Systems) with one of our Solutions Engineers for a consultation on how to meet your goals and get the most out of the platform.
 
+### What versions of Stencil are currently supported?
+
+Currently, Stencil is on version 2. 
+
+Stencil follows [semantic versioning](https://semver.org/), meaning that the team at Ionic strives to avoid any type of breaking change to Stencil without changing the 'major version number' of the library. Therefore, versions 2.7.0 and 2.8.0 are designed to be backward compatible with one another. However, there may be breaking changes between v2.7.0 and v3.0.0. Breaking changes to the library can be found [here](https://github.com/ionic-team/stencil/blob/master/BREAKING_CHANGES.md).
+
+To determine the version of Stencil your project has installed, run:
+```shell
+npm ls @stencil/core
+```
+
+To view the latest version of Stencil, please see the project's [releases page](https://github.com/ionic-team/stencil/releases).
+
+At this time, versions 0 and 1 of Stencil are not actively supported.
 
 ### How do I get involved?
 
@@ -214,7 +228,6 @@ Stencil is an open source project, and we encourage you to contribute. You can s
 ### Is Stencil open source?
 
 Yes, Stencil is open source and its source code can be [found on GitHub](https://github.com/ionic-team/stencil). Contributions are welcomed from the community.
-
 
 ### Which software license does Stencil use?
 

--- a/src/docs/introduction/faq.md
+++ b/src/docs/introduction/faq.md
@@ -209,7 +209,7 @@ If this is your first time building a design system, or you’re new to Stencil,
 
 Currently, Stencil is on version 2. 
 
-Stencil follows [semantic versioning](https://semver.org/), meaning that the team at Ionic strives to avoid any type of breaking change to Stencil without changing the 'major version number' of the library. Therefore, versions 2.7.0 and 2.8.0 are designed to be backward compatible with one another. However, there may be breaking changes between v2.7.0 and v3.0.0. Breaking changes to the library can be found [here](https://github.com/ionic-team/stencil/blob/master/BREAKING_CHANGES.md).
+Stencil follows [semantic versioning](https://semver.org/), meaning that the team at Ionic strives to avoid any type of breaking change to Stencil without changing the 'major version number' of the library. Therefore, versions 2.7.0 and 2.8.0 are designed to be backwards compatible with one another. However, there may be breaking changes between v2.7.0 and v3.0.0. Breaking changes to the library can be found [here](https://github.com/ionic-team/stencil/blob/master/BREAKING_CHANGES.md).
 
 To determine the version of Stencil your project has installed, run:
 ```shell

--- a/src/docs/introduction/faq.md
+++ b/src/docs/introduction/faq.md
@@ -218,7 +218,7 @@ npm ls @stencil/core
 
 To view the latest version of Stencil, please see the project's [releases page](https://github.com/ionic-team/stencil/releases).
 
-At this time, versions 0 and 1 of Stencil are not actively supported.
+> At this time, versions 0 and 1 of Stencil are not actively supported.
 
 ### How do I get involved?
 


### PR DESCRIPTION
add information to the site around:
- the currently supported version of stencil
- how and when breaking changes will occur
- a link to the releases page
- information that we do not support v0 and v1