### PR TITLE
docs(git): point stencil core links back to main branch

### DIFF
--- a/src/docs/introduction/faq.md
+++ b/src/docs/introduction/faq.md
@@ -14,7 +14,7 @@ contributors:
 
 Stencil is a developer-focused toolchain for building reusable, scalable component libraries, applications and design systems. It provides a compiler that generates highly optimized Web Components, and combines the best concepts of the most popular frameworks into a simple build-time tool.
 
-Stencil focuses on building components with web standards. It’s used by developers and organizations around the world, and is [100% free and MIT open source](https://github.com/ionic-team/stencil/blob/master/LICENSE.md).
+Stencil focuses on building components with web standards. It’s used by developers and organizations around the world, and is [100% free and MIT open source](https://github.com/ionic-team/stencil/blob/main/LICENSE.md).
 
 
 ### What does Stencil do?
@@ -208,7 +208,7 @@ If this is your first time building a design system, or you’re new to Stencil,
 
 ### How do I get involved?
 
-Stencil is an open source project, and we encourage you to contribute. You can start by creating issues on GitHub, submitting feature requests, and helping to replicate bugs. If you’re interested in contributing, please see our [Contributor Guide](https://github.com/ionic-team/stencil/blob/master/.github/CONTRIBUTING.md) and check out our [issue tracker](https://github.com/ionic-team/stencil/issues).
+Stencil is an open source project, and we encourage you to contribute. You can start by creating issues on GitHub, submitting feature requests, and helping to replicate bugs. If you’re interested in contributing, please see our [Contributor Guide](https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md) and check out our [issue tracker](https://github.com/ionic-team/stencil/issues).
 
 
 ### Is Stencil open source?
@@ -218,7 +218,7 @@ Yes, Stencil is open source and its source code can be [found on GitHub](https:/
 
 ### Which software license does Stencil use?
 
-Stencil’s software [license is MIT](https://github.com/ionic-team/stencil/blob/master/LICENSE.md).
+Stencil’s software [license is MIT](https://github.com/ionic-team/stencil/blob/main/LICENSE.md).
 
 
 ### Who works on Stencil?

--- a/src/docs/output-targets/docs-json.md
+++ b/src/docs/output-targets/docs-json.md
@@ -37,7 +37,7 @@ export const config: Config = {
 };
 ```
 
-Check out the typescript declarations for the JSON output: https://github.com/ionic-team/stencil/blob/master/src/declarations/stencil-public-docs.ts
+Check out the typescript declarations for the JSON output: https://github.com/ionic-team/stencil/blob/main/src/declarations/stencil-public-docs.ts
 
 
 ## CSS Variables

--- a/src/docs/output-targets/docs-stats.md
+++ b/src/docs/output-targets/docs-stats.md
@@ -35,7 +35,7 @@ export const config: Config = {
 
 If you don't pass a file name to the `--stats` flag or the output target's `file` key, the file will be output to the root directory of your project as `stencil-stats.json`
 
-Check out the typescript declarations for the JSON output: https://github.com/ionic-team/stencil/blob/master/src/declarations/stencil-public-docs.ts
+Check out the typescript declarations for the JSON output: https://github.com/ionic-team/stencil/blob/main/src/declarations/stencil-public-docs.ts
 
 
 ## Data Model

--- a/src/docs/testing/screenshot-connector.md
+++ b/src/docs/testing/screenshot-connector.md
@@ -29,7 +29,7 @@ module.exports = class ScreenshotCustomConnector extends ScreenshotConnector {
 };
 ```
 
-> For a good reference on how this can be done, have a look at the default `StencilLocalConnector` [here](https://github.com/ionic-team/stencil/blob/master/src/screenshot/connector-local.ts)
+> For a good reference on how this can be done, have a look at the default `StencilLocalConnector` [here](https://github.com/ionic-team/stencil/blob/main/src/screenshot/connector-local.ts)
 
 ## Methods
 The base connector which can be imported and extended from stencil has the following methods which can be overwritten:


### PR DESCRIPTION
change references from the master branch to main