### PR TITLE
docs(component): add documentation for delegatesFocus

### DIFF
--- a/src/docs/components/component.md
+++ b/src/docs/components/component.md
@@ -51,11 +51,11 @@ export interface ComponentOptions {
    * does not support shadow-dom natively. Defaults to `false`.
    * 
    * If an object literal containing `delegatesFocus` is provided, the component will use native shadow-dom
-   * encapsulation. When `delegatesFocus` is set to `true`, components will have `delegatesFocus: true` added to their
-   * shadow DOM. When a non-focusable part of the component is clicked:
+   * encapsulation. When `delegatesFocus` is set to `true`, the component will have `delegatesFocus: true` added to its
+   * shadow DOM. When `delegatesFocus` is `true` and a non-focusable part of the component is clicked:
    * - the first focusable part of the component is given focus
    * - the component receives any available `focus` styling
-   * Setting `delegatesFocus` to `false` is equivalent to setting this property to `true`.
+   * Setting `delegatesFocus` to `false` is equivalent to setting this property (`shadow`) to `true`.
    */
   shadow?: boolean | { delegatesFocus: boolean };
 

--- a/src/docs/components/component.md
+++ b/src/docs/components/component.md
@@ -56,7 +56,7 @@ export interface ComponentOptions {
    * - the first focusable part of the component is given focus
    * - the component receives any available `focus` styling
    * Setting `delegatesFocus` to `false` will not add the `delegatesFocus` property to the shadow DOM and therefore
-   * will have the focusing behavior described for `delegatesFocus: true`.
+   * will have the focusing behavior described for `shadow: true`.
    */
   shadow?: boolean | { delegatesFocus: boolean };
 

--- a/src/docs/components/component.md
+++ b/src/docs/components/component.md
@@ -4,6 +4,7 @@ description: Decorators
 url: /docs/component
 contributors:
   - jthoms1
+  - rwaskiewicz
 ---
 
 # Component Decorator
@@ -48,8 +49,15 @@ export interface ComponentOptions {
   /**
    * If `true`, the component will use native shadow-dom encapsulation, it will fallback to `scoped` if the browser
    * does not support shadow-dom natively. Defaults to `false`.
+   * 
+   * If an object literal containing `delegatesFocus` is provided, the component will use native shadow-dom
+   * encapsulation. When `delegatesFocus` is set to `true`, components will have `delegatesFocus: true` added to their
+   * shadow DOM. When a non-focusable part of the component is clicked:
+   * - the first focusable part of the component is given focus
+   * - the component receives any available `focus` styling
+   * Setting `delegatesFocus` to `false` is equivalent to setting this property to `true`.
    */
-  shadow?: boolean;
+  shadow?: boolean | { delegatesFocus: boolean };
 
   /**
    * Relative URL to some external stylesheet file. It should be a `.css` file unless some

--- a/src/docs/components/component.md
+++ b/src/docs/components/component.md
@@ -55,7 +55,8 @@ export interface ComponentOptions {
    * shadow DOM. When `delegatesFocus` is `true` and a non-focusable part of the component is clicked:
    * - the first focusable part of the component is given focus
    * - the component receives any available `focus` styling
-   * Setting `delegatesFocus` to `false` is equivalent to setting this property (`shadow`) to `true`.
+   * Setting `delegatesFocus` to `false` will not add the `delegatesFocus` property to the shadow DOM and therefore
+   * will have the focusing behavior described for `delegatesFocus: true`.
    */
   shadow?: boolean | { delegatesFocus: boolean };
 


### PR DESCRIPTION
add documentation to configure the `shadow` property using the
`{ delegatesFocus: boolean }` object literal instead of a boolean