### PR TITLE
docs(props): add documentation for exporting prop types

### DIFF
--- a/src/docs/components/properties.md
+++ b/src/docs/components/properties.md
@@ -25,8 +25,7 @@ export class TodoList {
 ```
 
 When using user-defined types like `MyHttpService`, the type must be exported using the `export` keyword. Above,
-`MyHttpService` is imported from `'../some/local/directory/MyHttpService'`, and must be exported from that file 
-(otherwise we'd have no way to use it).
+`MyHttpService` is imported from `'../some/local/directory/MyHttpService'`, and must be exported from that file.
 
 If `MyHttpService` were defined in `TodoList.tsx`, the `export` keyword would still be required, as Stencil needs to
 know what type `myHttpService` is when passing an instance of `MyHttpService` to `TodoList` from a parent component.

--- a/src/docs/components/properties.md
+++ b/src/docs/components/properties.md
@@ -4,6 +4,7 @@ description: Properties
 url: /docs/properties
 contributors:
   - jthoms1
+  - rwaskiewicz
 ---
 
 # Prop Decorator
@@ -11,8 +12,33 @@ contributors:
 Props are custom attribute/properties exposed publicly on the element that developers can provide values for. Children components should not know about or reference parent components, so Props should be used to pass data down from the parent to the child. Components need to explicitly declare the Props they expect to receive using the `@Prop()` decorator. Props can be a `number`, `string`, `boolean`, or even an `Object` or `Array`. By default, when a member decorated with a `@Prop()` decorator is set, the component will efficiently rerender.
 
 ```tsx
+// TodoList.tsx
 import { Prop } from '@stencil/core';
+import { MyHttpService } from '../some/local/directory/MyHttpService';
+...
+export class TodoList {
+  @Prop() color: string;
+  @Prop() favoriteNumber: number;
+  @Prop() isSelected: boolean;
+  @Prop() myHttpService: MyHttpService;
+}
+```
 
+When using user-defined types like `MyHttpService`, the type must be exported using the `export` keyword. Above,
+`MyHttpService` is imported from `'../some/local/directory/MyHttpService'`, and must be exported from that file 
+(otherwise we'd have no way to use it).
+
+If `MyHttpService` were defined in `TodoList.tsx`, the `export` keyword would still be required, as Stencil needs to
+know what type `myHttpService` is when passing an instance of `MyHttpService` to `TodoList` from a parent component.
+
+```tsx
+// TodoList.tsx
+import { Prop } from '@stencil/core';
+...
+// the export keyword is still required here, so that a parent component knows what a `MyHttpService` is
+export type MyHttpService = {
+  // type definition goes here  
+};
 ...
 export class TodoList {
   @Prop() color: string;


### PR DESCRIPTION
add documentation around types used by @props and their visibility

STENCIL-222: bug: @Prop can't work with typescript's Type alias