### PR TITLE
docs(testing): add explicit mention of testing lib versions

### DIFF
--- a/src/docs/testing/overview.md
+++ b/src/docs/testing/overview.md
@@ -20,8 +20,8 @@ box. Stencil offers both unit testing and end-to-end testing capabilities.
 Testing within Stencil is broken up into two distinct types: Unit tests and End-to-end (e2e) tests.
 
 There are several philosophies on how testing should be done, and how to differentiate what should be considered a unit 
-test, end-to-end test. Stencil takes an opinionated stance so developers have a description of each to better choose
-when to use each type of testing:
+test versus an end-to-end test. Stencil takes an opinionated stance so developers have a description of each to better
+choose when to use each type of testing:
 
 **Unit tests** focus on testing a component's methods in isolation. For example, when a method is given the argument
 `X`, it should return `Y`.

--- a/src/docs/testing/overview.md
+++ b/src/docs/testing/overview.md
@@ -12,29 +12,46 @@ contributors:
 
 # Testing
 
+In order to ensure that your Stencil components work the way you expect, Stencil provides testing support out of the
+box. Stencil offers both unit testing and end-to-end testing capabilities.
+
 ## Unit Testing vs. End-to-end Testing
 
 Testing within Stencil is broken up into two distinct types: Unit tests and End-to-end (e2e) tests.
 
-There are countless philosophies on how testing should be done, and how to differentiate what should be considered a 
-unit test, end-to-end test. Stencil takes an opinionated stance so developers have a description of each to better 
-choose when to use each type of testing:
+There are several philosophies on how testing should be done, and how to differentiate what should be considered a unit 
+test, end-to-end test. Stencil takes an opinionated stance so developers have a description of each to better choose
+when to use each type of testing:
 
-**Unit tests** focuses on testing a component's methods in isolation. For example, when a method is given the argument `X`, it should return `Y`.
+**Unit tests** focus on testing a component's methods in isolation. For example, when a method is given the argument
+`X`, it should return `Y`.
 
-**End-to-end tests** focus on how the components are rendered in the DOM and how the individual components work together. For example, when `my-component` has the `X` attribute, the child component then renders the text `Y`, and expects to receive the event `Z`.
+**End-to-end tests** focus on how the components are rendered in the DOM and how the individual components work
+together. For example, when `my-component` has the `X` attribute, the child component then renders the text `Y`, and
+expects to receive the event `Z`.
 
-Both types use [Jest](https://jestjs.io/) as the JavaScript testing solution. End-to-end tests also use [Puppeteer](https://pptr.dev/)
-instead of a Node environment. This allows end-to-end tests to run within an actual browser in order to provide more realistic
-results.
+Both testng types use [Jest](https://jestjs.io/) as the JavaScript testing solution. End-to-end tests also use
+[Puppeteer](https://pptr.dev/) instead of a Node environment. This allows end-to-end tests to run within an actual
+browser in order to provide more realistic results.
 
 ## Library Support
 
-Stencil currently supports:
+Stencil uses [Jest](https://jestjs.io/) and [Puppeteer](https://pptr.dev/) as its testing libraries, and allows
+developers to install both libraries using their preferred package manager. Stencil currently supports:
 - Jest v24.9.0 through v27.Y.Z (inclusive)
 - Puppeteer v1.19.0 through v10.Y.Z (inclusive)
 
+If you created a project using `npm init stencil`, these libraries were installed for you. Depending on when your
+project was created, you may or may not have the latest supported version installed.
+
 ## Testing Commands
+
+Stencil tests are run using the command `stencil test`, followed by one or more optional flags:
+- `--spec` to run unit tests
+- `--e2e` to run end-to-end tests
+- `--watchAll` to watch the file system for changes, and rerun tests when changes are detected
+
+When the `--spec` and/or `--e2e` flags are provided, Stencil will automatically run the tests associated with each flag.
 
 Below a series of example `npm` scripts which can be added to the project's `package.json` file to run Stencil tests:
 
@@ -42,19 +59,24 @@ Below a series of example `npm` scripts which can be added to the project's `pac
 {
     "scripts": {
       "test": "stencil test --spec",
-      "test.watch": "stencil test --spec --watch",
-      "test.e2e": "stencil test --e2e"
+      "test.watch": "stencil test --spec --watchAll",
+      "test.end-to-end": "stencil test --e2e"
     }
 }
 ```
 
-Each command begins `stencil test`, and is followed one or more optional flags:
-- `--spec` to run unit tests
-- `--e2e` ro run end-to-end tests
+Each command above begins with `stencil test`, which tells Stencil to run tests. Note that each `stencil test` command 
+in example above is followed one or more of the optional flags. Looking at each script, one at a time:
+- the `test` script runs unit tests for our Stencil project.
+- the `test.watch` script runs unit tests for our Stencil project. It watches the filesystem for changes, and reruns
+tests when changes are detected.
+- the `test.end-to-end` script runs the end-to-end tests for our Stencil project.
 
-When the `--spec` and/or `--e2e` flags are provided, Stencil will automatically run the tests associated with each flag. 
+If you created a project using `npm init stencil`, these scripts are provided to you automatically.
 
-Note: If you created a project using `npm init stencil`, these scripts are provided to you automatically.
+Stencil does not prescribe any specific naming convention for the names of your scripts. The `test.watch` script could
+as easily be named `test-watch`, `test.incremental`, etc. As long as the script itself uses the `stencil test` command,
+your tests should be run.
 
 ### Testing Configuration
 

--- a/src/docs/testing/overview.md
+++ b/src/docs/testing/overview.md
@@ -7,39 +7,54 @@ contributors:
   - brandyscarney
   - camwiegert
   - kensodemann
+  - rwaskiewicz
 ---
 
 # Testing
 
-Testing within Stencil is broken up into two distinct types: Unit tests and End-to-end (e2e) tests. Both types use [Jest](https://jestjs.io/) as the JavaScript testing solution. The browser environment for end-to-end testing is done using [Puppeteer](https://pptr.dev/), which provides many advantages Stencil can start to incorporate into its builds.
-
-
 ## Unit Testing vs. End-to-end Testing
 
-There are countless philosophies on how testing should be done, and what should be considered a unit test, end-to-end test or even integration tests. To simplify it all, Stencil breaks it down so developers have a defined description of when to use each type of testing.
+Testing within Stencil is broken up into two distinct types: Unit tests and End-to-end (e2e) tests.
+
+There are countless philosophies on how testing should be done, and how to differentiate what should be considered a 
+unit test, end-to-end test. Stencil takes an opinionated stance so developers have a description of each to better 
+choose when to use each type of testing:
 
 **Unit tests** focuses on testing a component's methods in isolation. For example, when a method is given the argument `X`, it should return `Y`.
 
-**End-to-end tests** focus on how the components are rendered in the DOM and how the individual components work together. For example, when `my-component` has the `X` attribute, the child component then renders the text `Y`, and expects to receive the event `Z`. End-to-end tests use [Puppeteer](https://pptr.dev/) instead of a Node environment. This allows end-to-end tests to run within an actual browser in order to provide more realistic results.
+**End-to-end tests** focus on how the components are rendered in the DOM and how the individual components work together. For example, when `my-component` has the `X` attribute, the child component then renders the text `Y`, and expects to receive the event `Z`.
 
-By not blurring the lines between JavaScript testing and DOM testing, tests can be built out quickly across large teams.
+Both types use [Jest](https://jestjs.io/) as the JavaScript testing solution. End-to-end tests also use [Puppeteer](https://pptr.dev/)
+instead of a Node environment. This allows end-to-end tests to run within an actual browser in order to provide more realistic
+results.
 
+## Library Support
+
+Stencil currently supports:
+- Jest v24.9.0 through v27.Y.Z (inclusive)
+- Puppeteer v1.19.0 through v10.Y.Z (inclusive)
 
 ## Testing Commands
 
-Below is an example `npm` script which can be added to the app's `package.json` file. Notice the command is `stencil test`, with optional flags of `--spec` for unit tests, and `--e2e` for end-to-end tests.
+Below a series of example `npm` scripts which can be added to the project's `package.json` file to run Stencil tests:
 
-```tsx
-"scripts": {
-  "test": "stencil test --spec",
-  "test.watch": "stencil test --spec --watch",
-  "test.e2e": "stencil test --e2e"
+```json
+{
+    "scripts": {
+      "test": "stencil test --spec",
+      "test.watch": "stencil test --spec --watch",
+      "test.e2e": "stencil test --e2e"
+    }
 }
 ```
 
-All of this configuration is included with the Stencil App Starter and the Stencil Component Starter so if you
-use one of those templates to start your project, you should not have to add anything. This information is presented here primarily for informational purposes.
+Each command begins `stencil test`, and is followed one or more optional flags:
+- `--spec` to run unit tests
+- `--e2e` ro run end-to-end tests
 
+When the `--spec` and/or `--e2e` flags are provided, Stencil will automatically run the tests associated with each flag. 
+
+Note: If you created a project using `npm init stencil`, these scripts are provided to you automatically.
 
 ### Testing Configuration
 
@@ -59,7 +74,7 @@ export const config: Config = {
 
 Adding the following configurations to `.vscode/launch.json` will allow you to use the VS Code Debugger to run the Stencil test runner for the currently active file in your editor. Just make sure you're in the test file you want to run, then select the debug configuration respectively (depending on whether it's a spec or e2e test), and hit the play button.
 
-```tsx
+```json
 {
   "configurations": [
     {


### PR DESCRIPTION
# Changes

state the versions of jest and puppeteer that are supported by stencil. this is the 'required' work for supporting Jest 27+. however, i took an initial stab at some rework of the testing overview page, but by no means is it "good enough" for us to mark it off our sheet of pages we want to improve. the test configuration & IDE integration could certainly use a little more love, but I think it's in a slightly better state than where it was/is today