### PR TITLE
Fix incorrect name of Component Lifecycle Method

### DIFF
--- a/src/docs/guides/style-guide.md
+++ b/src/docs/guides/style-guide.md
@@ -213,7 +213,7 @@ export class Something {
   componentWillUpdate() {}
   componentDidUpdate() {}
   componentWillRender() {}
-  componentShouldRender(newVal: any, oldVal: any, propName: string) {}
+  componentShouldUpdate(newVal: any, oldVal: any, propName: string) {}
   componentDidRender() {}
 
   /**

--- a/src/docs/guides/style-guide.md
+++ b/src/docs/guides/style-guide.md
@@ -210,10 +210,10 @@ export class Something {
   disconnectedCallback() {}
   componentWillLoad() {}
   componentDidLoad() {}
+  componentShouldUpdate(newVal: any, oldVal: any, propName: string) {}
   componentWillUpdate() {}
   componentDidUpdate() {}
   componentWillRender() {}
-  componentShouldUpdate(newVal: any, oldVal: any, propName: string) {}
   componentDidRender() {}
 
   /**


### PR DESCRIPTION
❌ Incorrect name: `componentShouldRender`
✅ Correct name: `componentShouldUpdate`