### PR TITLE
Fix export .ts

### DIFF
--- a/src/docs/framework-integration/angular.md
+++ b/src/docs/framework-integration/angular.md
@@ -130,7 +130,7 @@ top-most-directory/
 In order to make the generated files available to your Angular component library and it’s consumers, you’ll need to export everything from within your entry file - commonly the `public-api.ts` file. To do this, you’ll write:
 
 ```tsx
-export * from './lib/stencil-generated/components.ts';
+export * from './lib/stencil-generated/components';
 ```
 
 ### Link your packages (optional)


### PR DESCRIPTION
If we had the `.ts`, it's not possible to build the angular app

![image](https://user-images.githubusercontent.com/8138585/147936426-8788ab2a-1201-4d4e-80bb-ef6bd3aefea0.png)
