### PR TITLE
docs(react): update react wrapper output dirs

### DIFF
--- a/src/docs/framework-integration/react.md
+++ b/src/docs/framework-integration/react.md
@@ -134,6 +134,7 @@ top-most-directory/
         └── components/
         │   └── stencil-generated/
         │       └── react-component-lib/
+        │       └── index.ts <-- the newly generated file 
         └── index.ts
 ```
 

--- a/src/docs/framework-integration/react.md
+++ b/src/docs/framework-integration/react.md
@@ -132,7 +132,8 @@ top-most-directory/
 └── react-library/
     └── src/
         └── components/
-        │   └── stencil-generated/index.ts
+        │   └── stencil-generated/
+        │       └── react-component-lib/
         └── index.ts
 ```
 


### PR DESCRIPTION
update react wrapper output directory structure to show
`react-component-lib/` is a child directory of `stencil-generated`