### PR TITLE
docs(props): use proper syntax for JSX boolean example

### DIFF
--- a/src/docs/components/properties.md
+++ b/src/docs/components/properties.md
@@ -66,7 +66,7 @@ Externally, Props are set on the element.
 in JSX you set an attribute using camelCase:
 
 ```markup
-<todo-list color="blue" favoriteNumber={24} isSelected="true"></todo-list>
+<todo-list color="blue" favoriteNumber={24} isSelected={true}></todo-list>
 ```
 
 They can also be accessed via JS from the element.


### PR DESCRIPTION
the example fixed was using syntax that represented passing a string
value into the component's prop, rather than a boolean.

there's an active rewrite occurring for this page, but this is a 'quick
win' we can achieve while that occurs