### PR TITLE
Incomplete documentation.

### DIFF
--- a/src/docs/components/reactive-data.md
+++ b/src/docs/components/reactive-data.md
@@ -37,6 +37,12 @@ export class LoadingIndicator {
   watchStateHandler(newValue: boolean, oldValue: boolean) {
     console.log('The new value of busy is: ', newValue);
   }
+  
+  @Watch('activated')
+  @Watch('busy')
+  watchMultiple(newValue: boolean, oldValue: boolean, propName:string) {
+    console.log(`The new value of ${propName} is: `, newValue);
+  }
 }
 ```
 


### PR DESCRIPTION
@Watch decorates passes a third parameter, the name of the property that is changed. Very handy when you are using stencil-store and want to update the store accordingly when the initial prop/state changes.