### PR TITLE
docs(custom-elements): clarify CEB is deprecated

### DIFF
--- a/src/docs/output-targets/custom-elements.md
+++ b/src/docs/output-targets/custom-elements.md
@@ -183,7 +183,7 @@ export default {
 
 The `dist-custom-elements` builds each component as a stand-alone class that extends `HTMLElement`. The output is a standardized custom element with the styles already attached and without any of Stencil's lazy-loading. This may be preferred for projects that are already handling bundling, lazy-loading and defining the custom elements themselves.
 
-The `dist-custom-elements-bundle` is nearly the same as `dist-custom-elements` - with the exception that `dist-custom-elements-bundle` will only create a single file. Which you use is up to you, but the React, Vue, and Angular output targets use the `dist-custom-elements` for improved tree-shaking features. You can also use this single file for low barrier-to-entry apps where you don't depend on IE11 or older Edge versions. 
+The `dist-custom-elements-bundle` is nearly the same as `dist-custom-elements`, but has been deprecated in [Stencil v2.12.0](https://github.com/ionic-team/stencil/releases/tag/v2.12.0) in favor of `dist-custom-elements`. Stencil's React, Vue, and Angular output targets use the `dist-custom-elements` for improved tree-shaking features. You can also use this single file for low barrier-to-entry apps where you don't depend on IE11 or older Edge versions. 
 
 The `dist` output target, on the other hand, is more for projects that want to allow components to lazy-load themselves, without having to setup bundling configurations to do so.
 

--- a/src/docs/output-targets/custom-elements.md
+++ b/src/docs/output-targets/custom-elements.md
@@ -183,7 +183,7 @@ export default {
 
 The `dist-custom-elements` builds each component as a stand-alone class that extends `HTMLElement`. The output is a standardized custom element with the styles already attached and without any of Stencil's lazy-loading. This may be preferred for projects that are already handling bundling, lazy-loading and defining the custom elements themselves.
 
-The `dist-custom-elements-bundle` is nearly the same as `dist-custom-elements`, but has been deprecated in [Stencil v2.12.0](https://github.com/ionic-team/stencil/releases/tag/v2.12.0) in favor of `dist-custom-elements`. Stencil's React, Vue, and Angular output targets use the `dist-custom-elements` for improved tree-shaking features. You can also use this single file for low barrier-to-entry apps where you don't depend on IE11 or older Edge versions. 
+The `dist-custom-elements-bundle` output target is nearly the same as `dist-custom-elements`, and has been deprecated in [Stencil v2.12.0](https://github.com/ionic-team/stencil/releases/tag/v2.12.0) in favor of `dist-custom-elements` for its improved tree-shaking features. Stencil's React, Vue, and Angular output targets use the `dist-custom-elements` for this reason.
 
 The `dist` output target, on the other hand, is more for projects that want to allow components to lazy-load themselves, without having to setup bundling configurations to do so.
 

--- a/src/docs/output-targets/dist.md
+++ b/src/docs/output-targets/dist.md
@@ -20,7 +20,9 @@ outputTargets: [
 ```
 
 
-## How is this different than "dist-custom-elements-bundle" output target?
+## How is this different from "dist-custom-elements-bundle" output target?
+
+The `dist-custom-elements-bundle` output target has been deprecated in [Stencil v2.12.0](https://github.com/ionic-team/stencil/releases/tag/v2.12.0) in favor of the [`dist-custom-elements` output target](https://stenciljs.com/docs/custom-elements). The information below is for historical purposes only. 
 
 To start, Stencil was designed to lazy-load itself only when the component was actually used on a page. There are many benefits to this approach, such as simply adding a script tag to any page and the entire library is available for use, yet only the components actually used are downloaded. For example, [`@ionic/core`](https://www.npmjs.com/package/@ionic/core) comes with over 100 components, but a one webpage may only need `ion-toggle`. Instead of requesting the entire component library, or generating a custom bundle for just `ion-toggle`, the `dist` output target is able to generate a tiny entry build ready to load any of its components on-demand.
 


### PR DESCRIPTION
add an additional note that the `dist-custom-elements-build` is deprecated when comparing it against `dist-custom-elements`