### PR TITLE
docs(getting-started): explain cli output

### DIFF
--- a/src/docs/introduction/getting-started.md
+++ b/src/docs/introduction/getting-started.md
@@ -90,7 +90,7 @@ The second section describes a few commands required to finish getting your proj
 ```
 
 This will change your current directory to `my-first-stencil-project` (or whatever you named your project), install your
-dependencies for you, and begin the development server.
+dependencies for you, and start the development server.
 
 At this time, Stencil does not interact with any version control systems (VCS) when running `npm init stencil`. If you
 wish to place your project under version control, we recommend creating initializing your VCS now. If you wish to use

--- a/src/docs/introduction/getting-started.md
+++ b/src/docs/introduction/getting-started.md
@@ -79,7 +79,7 @@ meant to be used in the local development server, but rather within a project th
 
 - `npm test` runs your project's tests. The Stencil CLI has created both end-to-end and unit tests when scaffolding your project.
 
-The second section describes a few commands to required to finish getting your project bootstrapped.
+The second section describes a few commands required to finish getting your project bootstrapped.
 
 > You will need to complete these steps in order to run any of the above commands
 

--- a/src/docs/introduction/getting-started.md
+++ b/src/docs/introduction/getting-started.md
@@ -92,6 +92,16 @@ The second section describes a few commands to required to finish getting your p
 will change your current directory to `my-first-stencil-project` (or whatever you named your project), install your
 dependencies for you, and begin the development server.
 
+At this time, Stencil does not interact with any version control systems (VCS) when running `npm init stencil`. If you
+wish to place your project under version control, we recommend creating initializing your VCS now. If you wish to use
+git, run the following after changing your current directory to the root of your Stencil project:
+
+```bash
+$ git init
+$ git add -A
+$ git commit -m "initialize project using stencil cli" 
+```
+
 ## Updating Stencil
 
 To get the latest version of @stencil/core you can run:

--- a/src/docs/introduction/getting-started.md
+++ b/src/docs/introduction/getting-started.md
@@ -79,7 +79,10 @@ meant to be used in the local development server, but rather within a project th
 
 - `npm test` runs your project's tests. The Stencil CLI has created both end-to-end and unit tests when scaffolding your project.
 
-The second section describes a few commands to required to finish getting your project bootstrapped:
+The second section describes a few commands to required to finish getting your project bootstrapped.
+
+> You will need to complete these steps in order to run any of the above commands
+
 ```bash
     $ cd my-first-stencil-project
     $ npm install

--- a/src/docs/introduction/getting-started.md
+++ b/src/docs/introduction/getting-started.md
@@ -89,7 +89,7 @@ The second section describes a few commands required to finish getting your proj
     $ npm start
 ```
 
-will change your current directory to `my-first-stencil-project` (or whatever you named your project), install your
+This will change your current directory to `my-first-stencil-project` (or whatever you named your project), install your
 dependencies for you, and begin the development server.
 
 At this time, Stencil does not interact with any version control systems (VCS) when running `npm init stencil`. If you

--- a/src/docs/introduction/getting-started.md
+++ b/src/docs/introduction/getting-started.md
@@ -11,7 +11,8 @@ contributors:
 
 ## Starting a new project
 
-Stencil requires a recent LTS version of [NodeJS](https://nodejs.org/) and npm. Make sure you've installed and/or updated Node before continuing.
+Stencil requires a recent LTS version of [NodeJS](https://nodejs.org/) and npm. Make sure you've installed and/or 
+updated Node before continuing.
 
 > Note that you will need to use npm 6 or higher.
 
@@ -19,8 +20,8 @@ Stencil requires a recent LTS version of [NodeJS](https://nodejs.org/) and npm. 
  npm init stencil
 ```
 
-Stencil can be used to create standalone components, or entire apps. After running init
-you will be provided with a prompt so that you can choose the type of project to start.
+Stencil can be used to create standalone components, or entire apps. When running `npm init stencil`, you will be
+provided with a prompt so that you can choose the type of project to start.
 
 ```bash
 ? Pick a starter › - Use arrow-keys. Return to submit.
@@ -29,6 +30,64 @@ you will be provided with a prompt so that you can choose the type of project to
    app           Minimal starter for building a Stencil app or website
 ```
 
+Selecting the 'component' option will prompt you for the name of your project.
+
+```bash
+✔ Pick a starter › component
+? Project name › my-first-stencil-project
+```
+
+Here, we've named our project 'my-first-stencil project'. After hitting `ENTER` to confirm your choices, the CLI will
+scaffold a Stencil project for us in a directory that matches the project name you provided.
+
+Upon successfully creating our project, the CLI will print something similar to the following to the console:
+```bash
+✔ Project name › my-first-stencil-project
+✔ All setup  in 26 ms
+
+  $ npm start
+    Starts the development server.
+
+  $ npm run build
+    Builds your components/app in production mode.
+
+  $ npm test
+    Starts the test runner.
+
+
+  We suggest that you begin by typing:
+
+   $ cd my-first-stencil-project
+   $ npm install
+   $ npm start
+
+  Further reading:
+
+   - https://github.com/ionic-team/stencil-component-starter
+
+  Happy coding! 🎈
+```
+
+The first section of the output describes a few useful commands available during the development process:
+
+- `npm start` starts a local development server. The development server will open a new browser tab containing your 
+project's components. The dev-server uses hot-module reloading to update your components in the browser as you modify
+them for a rapid feedback cycle.
+
+- `npm run build` creates a production-ready version of your components. The components generated in this step are not
+meant to be used in the local development server, but rather within a project that consumes your components.
+
+- `npm test` runs your project's tests. The Stencil CLI has created both end-to-end and unit tests when scaffolding your project.
+
+The second section describes a few commands to required to finish getting your project bootstrapped:
+```bash
+    $ cd my-first-stencil-project
+    $ npm install
+    $ npm start
+```
+
+will change your current directory to `my-first-stencil-project` (or whatever you named your project), install your
+dependencies for you, and begin the development server.
 
 ## Updating Stencil
 

--- a/src/docs/introduction/getting-started.md
+++ b/src/docs/introduction/getting-started.md
@@ -93,7 +93,7 @@ This will change your current directory to `my-first-stencil-project` (or whatev
 dependencies for you, and start the development server.
 
 At this time, Stencil does not interact with any version control systems (VCS) when running `npm init stencil`. If you
-wish to place your project under version control, we recommend creating initializing your VCS now. If you wish to use
+wish to place your project under version control, we recommend initializing your VCS now. If you wish to use
 git, run the following after changing your current directory to the root of your Stencil project:
 
 ```bash


### PR DESCRIPTION
explain the output of the `npx init stencil` command, to try to bridge
the gap between running the command and getting started/running with
stencil for the first time.

there's some duplication of information here. ie if we were to change
the cli output, we'd need to change the instructions here as well, which
as a landing point of sorts of our docs, i'm looking for
feedback/thoughts here

i personally don't _love_ the ordering of the output, this may make for a
good JEDI days quick project. To me it makes more sense to output the 
'next steps' (`cd` to your project dir, `npm i`) then talking about running
`npm start`, `npm run build`, etc.

fixes: https://github.com/ionic-team/stencil-site/issues/817
(or attempts to)