### PR TITLE
chore(urls): remove hostname from urls

### DIFF
--- a/src/docs/components/host-element.md
+++ b/src/docs/components/host-element.md
@@ -103,7 +103,7 @@ If you need to update the host element in response to prop or state changes, you
 
 ## Styling
 
-See full information about styling on the [Styling page](https://stenciljs.com/docs/styling#shadow-dom-in-stencil).
+See full information about styling on the [Styling page](/docs/styling#shadow-dom-in-stencil).
 
 CSS can be applied to the `<Host>` element by using its component tag defined in the `@Component` decorator.
 

--- a/src/docs/components/styling.md
+++ b/src/docs/components/styling.md
@@ -33,9 +33,9 @@ To use the Shadow DOM in a Stencil component, you can set the `shadow` option to
 export class ShadowComponent {}
 ```
 
-If you'd like to learn more about enabling and configuring the shadow DOM, see the [shadow field of the component api](https://stenciljs.com/docs/component#component-options).
+If you'd like to learn more about enabling and configuring the shadow DOM, see the [shadow field of the component api](/docs/component#component-options).
 
-By default, components created with the [`stencil generate` command](https://stenciljs.com/docs/cli#stencil-generate-sub-folder) use the shadow DOM.
+By default, components created with the [`stencil generate` command](/docs/cli#stencil-generate-sub-folder) use the shadow DOM.
 
 ### Styling with the Shadow DOM
 
@@ -51,7 +51,7 @@ div {
 }
 ```
 
-> **NOTE**: The `:host` pseudo-class selector is used to select the [`Host` element](https://stenciljs.com/docs/host-element) of the component
+> **NOTE**: The `:host` pseudo-class selector is used to select the [`Host` element](/docs/host-element) of the component
 
 With the shadow DOM enabled, only these styles will be applied to the component. Even if a style in the light DOM uses a selector that matches an element in the component, those styles will not be applied.
 
@@ -242,7 +242,7 @@ export const config: Config = {
 };
 ```
 
-The compiler will run the same minification, autoprefixing, and plugins over `global.css` and generate an output file for the [`www`](https://stenciljs.com/docs/www) and [`dist`](https://stenciljs.com/docs/distribution) output targets. The generated file will always have the `.css` extension and be named as the specified `namespace`.
+The compiler will run the same minification, autoprefixing, and plugins over `global.css` and generate an output file for the [`www`](/docs/www) and [`dist`](/docs/distribution) output targets. The generated file will always have the `.css` extension and be named as the specified `namespace`.
 
 In the example above, since the namespace is `app`, the generated global styles file will be located at: `./www/build/app.css`.
 

--- a/src/docs/config/overview.md
+++ b/src/docs/config/overview.md
@@ -97,7 +97,7 @@ The global style config takes a file path as a string. The output from this buil
 globalStyle: 'src/global/app.css'
 ```
 
-Check out the [styling docs](https://stenciljs.com/docs/styling#global-styles) of how to use global styles in your app.
+Check out the [styling docs](/docs/styling#global-styles) of how to use global styles in your app.
 
 ## invisiblePrehydration
 
@@ -223,7 +223,7 @@ across the frames to efficiently render and reduce layout thrashing. By default,
 `async` is used. It's recommended to also try each setting to decide which works
 best for your use-case. In all cases, if your app has many CPU intensive tasks causing the
 main thread to periodically lock-up, it's always recommended to try
-[Web Workers](https://stenciljs.com/docs/web-workers) for those tasks.
+[Web Workers](/docs/web-workers) for those tasks.
 
 * `congestionAsync`: DOM reads and writes are scheduled in the next frame to prevent layout
   thrashing. When the app is heavily tasked and the queue becomes congested it will then
@@ -235,14 +235,14 @@ main thread to periodically lock-up, it's always recommended to try
 * `async`: DOM read and writes are scheduled in the next frame to prevent layout thrashing.
   During intensive CPU tasks it will not reschedule rendering to happen in the next frame.
   `async` is ideal for most apps, and if the app has many intensive tasks causing the main
-  thread to lock-up, it's recommended to try [Web Workers](https://stenciljs.com/docs/web-workers)
+  thread to lock-up, it's recommended to try [Web Workers](/docs/web-workers)
   rather than the congestion async queue.
 
 * `immediate`: Makes writeTask() and readTask() callbacks to be executed synchronously. Tasks
   are not scheduled to run in the next frame, but do note there is at least one microtask.
   The `immediate` setting is ideal for apps that do not provide long-running and smooth
   animations. Like the async setting, if the app has intensive tasks causing the main thread
-  to lock-up, it's recommended to try [Web Workers](https://stenciljs.com/docs/web-workers).
+  to lock-up, it's recommended to try [Web Workers](/docs/web-workers).
 
 ```tsx
 taskQueue: 'async'

--- a/src/docs/config/plugins.md
+++ b/src/docs/config/plugins.md
@@ -55,4 +55,4 @@ export const config = {
 
 
 ## Node Polyfills
-See the [Node Polyfills in Module bundling](https://stenciljs.com/docs/module-bundling#node-polyfills) for other examples.
+See the [Node Polyfills in Module bundling](/docs/module-bundling#node-polyfills) for other examples.

--- a/src/docs/framework-integration/react.md
+++ b/src/docs/framework-integration/react.md
@@ -228,7 +228,7 @@ This parameter allows you to name the file that contains all the component wrapp
 
 ### includeDefineCustomElements
 
-If `true`, React components will import and define elements from the [`dist-custom-elements` build](https://stenciljs.com/docs/custom-elements), rather than [`dist`](https://stenciljs.com/docs/distribution).
+If `true`, React components will import and define elements from the [`dist-custom-elements` build](/docs/custom-elements), rather than [`dist`](/docs/distribution).
 
 ### excludeComponents
 

--- a/src/docs/introduction/overview.md
+++ b/src/docs/introduction/overview.md
@@ -18,7 +18,7 @@ Stencil uses TypeScript, JSX, and CSS to create standards-based Web Components t
 
 Stencil generates standards-compliant Web Components that can work with popular frameworks right out of the box. In addition, Stencil can be used to generate framework native components that can be used just like any other components in your framework of choice. Stencil accomplishes this by wrapping your Web Components via Stencil's Output Target feature.
 
-Compared to using Custom Elements directly, Stencil provides [extra APIs](https://stenciljs.com/docs/api) that makes writing fast components simpler. APIs like Virtual DOM, JSX, and async rendering make fast, powerful components easy to create, while still maintaining 100% compatibility with Web Components. Stencil also enables a number of key capabilities on top of Web Components, in particular, prerendering, and objects-as-properties (instead of just strings).
+Compared to using Custom Elements directly, Stencil provides [extra APIs](/docs/api) that makes writing fast components simpler. APIs like Virtual DOM, JSX, and async rendering make fast, powerful components easy to create, while still maintaining 100% compatibility with Web Components. Stencil also enables a number of key capabilities on top of Web Components, in particular, prerendering, and objects-as-properties (instead of just strings).
 
 The developer experience is also tuned, and comes with live reload and a small dev server baked in to the compiler.
 
@@ -26,7 +26,7 @@ The developer experience is also tuned, and comes with live reload and a small d
 
 ### Design Systems & Component Libraries
 
-Stencil's primary objective is providing amazing tools for Design Systems and Component Libraries. Components as a concept provide similar language for engineers and designers to have productive conversations about design implementation. [Visit the Stencil for Design Systems page to learn more.](https://stenciljs.com/docs/stencil-for-design-systems)
+Stencil's primary objective is providing amazing tools for Design Systems and Component Libraries. Components as a concept provide similar language for engineers and designers to have productive conversations about design implementation. [Visit the Stencil for Design Systems page to learn more.](/docs/stencil-for-design-systems)
 
 ## The History of Stencil
 

--- a/src/docs/output-targets/dist.md
+++ b/src/docs/output-targets/dist.md
@@ -22,7 +22,7 @@ outputTargets: [
 
 ## How is this different from "dist-custom-elements-bundle" output target?
 
-The `dist-custom-elements-bundle` output target has been deprecated in [Stencil v2.12.0](https://github.com/ionic-team/stencil/releases/tag/v2.12.0) in favor of the [`dist-custom-elements` output target](https://stenciljs.com/docs/custom-elements). The information below is for historical purposes only. 
+The `dist-custom-elements-bundle` output target has been deprecated in [Stencil v2.12.0](https://github.com/ionic-team/stencil/releases/tag/v2.12.0) in favor of the [`dist-custom-elements` output target](custom-elements). The information below is for historical purposes only. 
 
 To start, Stencil was designed to lazy-load itself only when the component was actually used on a page. There are many benefits to this approach, such as simply adding a script tag to any page and the entire library is available for use, yet only the components actually used are downloaded. For example, [`@ionic/core`](https://www.npmjs.com/package/@ionic/core) comes with over 100 components, but a one webpage may only need `ion-toggle`. Instead of requesting the entire component library, or generating a custom bundle for just `ion-toggle`, the `dist` output target is able to generate a tiny entry build ready to load any of its components on-demand.
 

--- a/src/docs/output-targets/overview.md
+++ b/src/docs/output-targets/overview.md
@@ -46,7 +46,7 @@ It's also important to note that the compiler will automatically generate the nu
 
 In the example below there are two script tags, however, only one of them will be requested by the user. For IE11 users, they'll download the `app.js` file which is in the `ES5` syntax and has all the polyfills. For users on modern browsers, they will only download the `app.esm.js` file which uses up-to-date JavaScript features such as [ES modules](https://developers.google.com/web/fundamentals/primers/modules), [dynamic imports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#Dynamic_Import), [async/await](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Asynchronous/Async_await), [Classes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes), etc.
 
-Note: [buildEs5](https://stenciljs.com/docs/config#buildes5) must be set to true to generate the IE11 ES5 file 
+Note: [buildEs5](/docs/config#buildes5) must be set to true to generate the IE11 ES5 file 
 
 ```markup
 <script type="module" src="/build/app.esm.js"></script>

--- a/src/docs/testing/e2e-testing.md
+++ b/src/docs/testing/e2e-testing.md
@@ -229,4 +229,4 @@ export const config: Config = {
 };
 ```
 
-Check [this part of the doc](https://stenciljs.com/docs/config#testing) to learn more about the possibilities on this matter. 
+Check [this part of the doc](/docs/config#testing) to learn more about the possibilities on this matter. 


### PR DESCRIPTION
this commit removes the host name from the urls throughout the site.
this decouples our links from the domain that we're using for the site
(stenciljs.com)

testing:
1. pull down this branch
2. `npm ci` 
3. `npm run docs`
4. `npm start`
5. Clicked each link manually to verify it worked still