### PR TITLE
fix: fix typo

### DIFF
--- a/src/docs/components/methods.md
+++ b/src/docs/components/methods.md
@@ -9,7 +9,7 @@ contributors:
 
 # Method Decorator
 
-The `@Method()` decorator is used to expose methods on the public API. Functions decorated with the `@Method()` decorator can be called directly from the element, ie. they are intended to be callable from the outside!
+The `@Method()` decorator is used to expose methods on the public API. Functions decorated with the `@Method()` decorator can be called directly from the element, i.e. they are intended to be callable from the outside!
 
 > Developers should try to rely on publicly exposed methods as little as possible, and instead default to using properties and events as much as possible. As an app scales, we've found it's easier to manage and pass data through @Prop rather than public methods.
 

--- a/src/docs/components/properties.md
+++ b/src/docs/components/properties.md
@@ -564,7 +564,7 @@ export class ToDoListItem {
 ### Reflect Properties Values to Attributes (`reflect`)
 
 In some cases it may be useful to keep a Prop in sync with an attribute. In this case you can set the `reflect` option
-in the `@Prop()` decorator to `true`. When a prop is reflected, its will be rendered in the DOM as an HTML attribute.
+in the `@Prop()` decorator to `true`. When a prop is reflected, it will be rendered in the DOM as an HTML attribute.
 
 Take the following component as example:
 

--- a/src/docs/components/properties.md
+++ b/src/docs/components/properties.md
@@ -481,7 +481,7 @@ export interface PropOptions {
 ### Attribute Name (`attribute`)
 
 Properties and component attributes are strongly connected but not necessarily the same thing. While attributes are an
-HTML concept, properties are a JavaScrip concept inherent to Object-Oriented Programming.
+HTML concept, properties are a JavaScript concept inherent to Object-Oriented Programming.
 
 In Stencil, the `@Prop()` decorator applied to a **property** will instruct the Stencil compiler to also listen for
 changes in a DOM attribute.


### PR DESCRIPTION
There is a typo in the docs: It should be "JavaScript" instead of "JavaScrip"