### PR TITLE
docs(angular-framework-integration): set-up instructions

### DIFF
--- a/src/docs/framework-integration/angular.md
+++ b/src/docs/framework-integration/angular.md
@@ -132,7 +132,7 @@ npm link
 From your Angular component library's directory, run the following command:
 
 ```bash
-npm link name-of-your-stencil-package`
+npm link name-of-your-stencil-package
 ```
 
 The name of your Stencil package should match the `name` property from the Stencil component library's `package.json`.

--- a/src/docs/framework-integration/angular.md
+++ b/src/docs/framework-integration/angular.md
@@ -16,7 +16,7 @@ contributors:
 
 **Supports: Angular 12+ • TypeScript 4.0+ • Stencil v2.9.0+**
 
-Stencil can generate Angular component wrappers for your web components. The benefits of the component wrappers over the standard web components are:
+Stencil can generate Angular component wrappers for your web components. This allows your Stencil components to be used within an Angular application.  The benefits of using Stencil's component wrappers over the standard web components include:
 
 - Angular component wrappers will be detached from change detection, preventing unnecessary repaints of your web component.
 - Web component events will be converted to RxJS observables to align with Angular's `@Output()` and will not emit across component boundaries.

--- a/src/docs/framework-integration/angular.md
+++ b/src/docs/framework-integration/angular.md
@@ -14,17 +14,21 @@ contributors:
 
 # Angular Integration
 
-**Support: __Angular 12+__ • __TypeScript 4.0+__ • __Stencil v2.9.0+__**
+**Supports: Angular 12+ • TypeScript 4.0+ • Stencil v2.9.0+**
 
-Stencil provides a wrapper for your custom elements to be used as first-class Angular components. The goal of a wrapper is to smooth over how Stencil’s code works within a framework. Wrappers provide a function that you can use within Stencil’s Output Targets to automatically create components for the targeted framework that wrap the web components you author in a Stencil project.
+Stencil can generate Angular component wrappers for your web components. The benefits of the component wrappers over the standard web components are:
 
-One benefit of the wrapper pattern includes improved maintainability since you are writing code once, and reusing it across frameworks. Another benefit of this pattern is that you can have first-class integration with your framework of choice. For example, with the Angular wrapper, you can bind input events directly to a value accessor for seamless integration in Angular’s bi-directional data flow. 
+- Angular component wrappers will be detached from change detection, preventing unnecessary repaints of your web component.
+- Web component events will be converted to RxJS observables to align with Angular's `@Output()` and will not emit across component boundaries.
+- _Optionally_ form control web components can be used as control value accessors with Angular's reactive forms or `[ngModel]`.
 
 ## Setup
 
 ### Project Structure
 
-To organize the generated component libraries for different frameworks, we recommend using a monorepo structure. This monorepo will contain your Stencil component library as well as the component libraries for whatever frameworks you choose. The overall structure of a monorepo with Stencil and Angular component libraries might look something like this:
+We recommend using a monorepo structure for your component library with component wrappers. Your project workspace should contain your Stencil component library and the library for the generated Angular component wrappers.
+
+An example project set-up may look similar to:
 
 ```
 top-most-directory/
@@ -39,188 +43,157 @@ top-most-directory/
                 └── public-api.ts
 ```
 
-### Create an Angular Component Library
+#### Creating an Angular Component Library
 
-First, we’ll create an Angular component library next to your Stencil component library. If you already have an Angular component library prepared, you can skip this step.
+> If you already have an Angular component library, skip this section.
 
-In your CLI tool of choice, install Angular’s CLI tools:
+The first time you want to create the component wrappers, you will need to have an Angular library package to write to.
 
-```bash
-npm install -g @angular/cli
-```
-
-Next, you will create your Angular workspace and project. Ideally, this should be placed next to your Stencil project, so a monorepo structure is encouraged. 
+Using Angular's CLI, generate a workspace and a library for your Angular component wrappers:
 
 ```bash
-ng new angular-workspace --no-create-application
+npx -p @angular/cli ng new angular-workspace --no-create-application
 cd angular-workspace
-ng generate library component-library
+npx -p @angular/cli ng generate library component-library
 ```
 
-### Create a Stencil Component Library
+#### Creating a Stencil Component Library
 
-Your Stencil library will be the location that you write your web components. 
+> If you already have a Stencil component library, skip this section.
 
 ```bash
 npm init stencil components stencil-library
 ```
 
-### Install the Angular Output Target in your Stencil Component Library
+### Adding Angular Output Target
 
-Now that the project structure is set up, we can install the Angular Output Target package. This package contains the Angular wrapper function that we will use to generate our Angular wrapped components. To install the Angular Output Target package, run the following command in your Stencil project directory
+Install the `@stencil/angular-output-target` dependency to your Stencil component library package.
 
-`npm i @stencil/angular-output-target`
+```bash
+npm install @stencil/angular-output-target --save-dev
+```
 
-or
+In your project's `stencil.config.ts`, add the `angularOutputTarget` configuration to the `outputTargets` array:
 
-`yarn add @stencil/angular-output-target`
+```ts
+import { angularOutputTarget } from '@stencil/angular-output-target';
 
-### Add the Angular Wrapper Function to your Stencil Component Library
-With the Angular Output Target package installed, we can now configure our Stencil Component Library to build our Angular wrapped components. In the `stencil.config.ts` file of your Stencil component library, add the Angular wrapper function. 
-
-Within your Stencil’s config file, you can import the Angular wrapper function for use within the outputTargets array. If you copy and paste this, ensure you update the “my-workspace” and “my-lib” to coincide with what you named your component library, as well as to update the `componentCorePackage` to the name of your Stencil component library.
-
-```tsx
-import { angularOutputTarget as angular } from '@stencil/angular-output-target';
 export const config: Config = {
-  namespace: 'demo',
+  namespace: '',
   outputTargets: [
-    angular({
-      componentCorePackage: `your-stencil-library-name`,
-      directivesProxyFile: `../your-angular-workspace-name/projects/your-angular-library-name/src/lib/stencil-generated/components.ts`
+    angularOutputTarget({
+      componentCorePackage: 'your-stencil-library-package-name',
+      directivesProxyFile: '../angular-workspace/projects/component-library/src/lib/stencil-generated/components.ts',
     }),
-    {
-      type: 'dist',
-      esmLoaderPath: '../loader',
-    },
-    {
-      type: 'dist-custom-elements',
-    },
   ],
 };
 ```
 
-Once you have added this and have `directivesProxyFile` pointing to the correct directory of your Angular component library, you can build Stencil. 
+> The `directivesProxyFile` is the relative path to the file that will be generated with all of the Angular component wrappers. You will replace the file path to match your project's structure and respective names. You can generate any file name instead of `components.ts`.
 
-`npm run build`
+You can now build your Stencil component library to generate the component wrappers.
 
-Or
-
-`yarn build`
-
-Once the build is complete, you will see new files in your Angular component library's directory!
-
-
-```
-top-most-directory/
-├── stencil-library/
-│   ├── stencil.config.js
-│   └── src/components
-└── angular-workspace/
-    └── projects/
-        └── component-library/
-            └── src/
-                ├── lib/
-                │   └── stencil-generated/components.ts
-                └── public-api.ts
+```bash
+npm run build
 ```
 
-### Add the components to your Angular project’s entry file (public-api.ts)
+If the build is successful, you will now have contents in the file specified in `directivesProxyFile`.
 
-In order to make the generated files available to your Angular component library and it’s consumers, you’ll need to export everything from within your entry file - commonly the `public-api.ts` file. To do this, you’ll write:
+You can now finally import and export the generated component wrappers for your component library. For example, in your main `AppModule` you may do the following:
 
-```tsx
-export * from './lib/stencil-generated/components';
+```ts
+import { COMPONENTS } from './stencil-generated/components';
+
+@NgModule({
+  declarations: [...COMPONENTS],
+  exports: [...COMPONENTS],
+})
+export class AppModule {}
+```
+
+Any components that are included in the `exports` array should additionally be exported in your main entry point (either `public-api.ts` or `index.ts`). Skipping this step will lead to Angular Ivy errors when building for production.
+
+```ts
+export { COMPONENTS } from './stencil-generated/components';
 ```
 
 ### Link your packages (optional)
 
-If you’re using a monorepo tool like Lerna or Nx, you can skip this step. Before you can successfully build a local version of your Angular component library, you will need to link the Stencil package to the Angular package.
+> If you are using a monorepo tool (Learn, Nx), skip this section.
 
-**First, in your Stencil directory, run the following command:**
+Before you can successfully build a local version of your Angular component library, you will need to link the Stencil package to the Angular package.
 
-`npm link`
+From your Stencil project's directory, run the following command:
 
-Or
+```bash
+npm link
+```
 
-`yarn link`
+From your Angular component library's directory, run the following command:
 
-**Next, in your Angular component library, run the following command:**
+```bash
+npm link name-of-your-stencil-package`
+```
 
-`npm link {the name of your Stencil package}`
+The name of your Stencil package should match the `name` property from the Stencil component library's `package.json`.
 
-Or
-
-`yarn link {the name of your Stencil package}`
-
-To determine your Stencil’s package name, you can visit your Stencil Component Library's `package.json` file.
-
-And with that, your component libraries are linked together. Now, you can make changes in your Stencil component library and run npm run build to propagate them through to the Angular component library.
+Your component libraries are now linked together. You can make changes in the Stencil component library and run `npm run build` to propagate the changes to the Angular component library.
 
 > **NOTE**: As an alternative to `npm link` , you can also run `npm install` with a relative path to your Stencil component library. This strategy, however, will modify your `package.json` so it is important to make sure you do not commit those changes.
 
-### All done!
+## Consumer Usage
 
-At this point, once you build your Angular project and import this library into your app, you will have access to all of the wrapped Angular components.  You can visit the Angular package and run the following command to see the result.
+This section covers how developers consuming your Angular component wrappers will use your package and component wrappers.
 
-`npm run build`
+If you distributed your components through a primary `NgModule`, developers can simply import that module into their implementation to use your components.
 
-Or
-
-`yarn build`
-
-## Usage
-
-You're now able to import your components into an Angular app and use them directly. Here's how the consumers of your Angular Component Library will use this code. 
-
-### Adding the components to a module
-
-Your component library consumers will be able to import your Angular components into your app's module by writing: 
-
-```tsx
-import { MyComponent } from 'angular-component-library';
-import { SomeComponent } from './some.component';
+```ts
+import { ExampleLibraryModule } from 'your-angular-library-package-name';
 
 @NgModule({
-  imports: [MyComponent],
-  declarations: [SomeViewComponent],
-  exports: [SomeComponent]
+  imports: [ExampleLibraryModule],
 })
-export class SomeViewModule {}
+export class FeatureModule {}
 ```
 
-Which will automatically define and run your components! 
+Alternatively, developers can individually import the components and declare them on a module:
 
-### Usage in your templates
+```ts
+import { MyComponent } from 'your-angular-library-package-name';
+
+@NgModule({
+  declarations: [MyComponent],
+  exports: [MyComponent],
+})
+export class FeatureModule {}
+```
+
+Developers can now directly leverage your components in their template and take advantage of Angular template binding syntax.
 
 ```html
-<my-component first="Stencil" last="Compiler"></my-component>
+<my-component first="Your" last="Name"></my-component>
 ```
-
-### Considerations
-
-Please note, you can create your own NgModule that can export and define all of your components, and encourage your customers to use that module within the imports property of their NgModules. There is a [Github issue](https://github.com/ionic-team/stencil-ds-output-targets/issues/207) to expand on this feature to align to single component angular modules (or SCAM). 
 
 ## FAQs
 
 ### What is the best format to write event names?
 
-Event names shouldn’t include special characters when initially written in Stencil, try to lean on using camelCased event names for interoperability between frameworks. 
+Event names shouldn’t include special characters when initially written in Stencil, try to lean on using camelCased event names for interoperability between frameworks.
 
 ### How do I bind input events directly to a value accessor?
 
-You can configure how your input events can map directly to a value accessor, allowing two-way data-binding to be a built in feature of any of your components. Take a look at [valueAccessorConfig's option below](). 
+You can configure how your input events can map directly to a value accessor, allowing two-way data-binding to be a built in feature of any of your components. Take a look at [valueAccessorConfig's option below]().
 
 ### How do I add IE11 or Edge support?
 
 If you want your custom elements to be able to work on older browsers, you should add the `applyPolyfills()` that surround the `defineCustomElements()` function.
 
-```tsx
+```ts
 import { applyPolyfills, defineCustomElements } from 'test-components/loader';
 ...
 applyPolyfills().then(() => {
-  defineCustomElements()
-})
+  defineCustomElements();
+});
 ```
 
 ### How do I access components with ViewChild or ViewChildren?
@@ -228,22 +201,21 @@ applyPolyfills().then(() => {
 Once included, components could be referenced in your code using `ViewChild` and `ViewChildren` as in the following example:
 
 ```tsx
-import {Component, ElementRef, ViewChild} from '@angular/core';
+import { Component, ElementRef, ViewChild } from '@angular/core';
 
 import { TestComponent } from 'test-components';
 
 @Component({
-    selector: 'app-home',
-    template: `<test-components #test></test-components>`,
-    styleUrls: ['./home.component.scss'],
+  selector: 'app-home',
+  template: `<test-components #test></test-components>`,
+  styleUrls: ['./home.component.scss'],
 })
 export class HomeComponent {
+  @ViewChild(TestComponent) myTestComponent: ElementRef<TestComponent>;
 
-    @ViewChild(TestComponent) myTestComponent: ElementRef<TestComponent>;
-
-    async onAction() {
-        await this.myTestComponent.nativeElement.testComponentMethod();
-    }
+  async onAction() {
+    await this.myTestComponent.nativeElement.testComponentMethod();
+  }
 }
 ```
 
@@ -262,7 +234,7 @@ The angularOutputTarget method accepts 5 parameters:
 The title of the Stencil package where components are available for consumers. This is used during compilation to write the correct imports for components e.g.
 
 ```js
-import { IonApp } from '@ionic/core/components/ion-app.js'
+import { IonApp } from '@ionic/core/components/ion-app.js';
 ```
 
 ### directivesProxyFile
@@ -270,19 +242,20 @@ import { IonApp } from '@ionic/core/components/ion-app.js'
 This parameter allows you to name the file that contains all the component wrapper definitions produced during the compilation process. This is the first file you should import in your Angular project.
 
 ### includeImportCustomElements
-If `true`, Angular components will import and define elements from the `dist-custom-elements` build, rather than `dist`. 
+
+If `true`, Angular components will import and define elements from the `dist-custom-elements` build, rather than `dist`.
 
 ### directivesArrayFile
 
-Used to provide a list of type Proxies to the Angular Component Library. [See Ionic Framework for a sample](https://github.com/ionic-team/ionic-framework/blob/main/angular/src/directives/proxies-list.txt). 
+Used to provide a list of type Proxies to the Angular Component Library. [See Ionic Framework for a sample](https://github.com/ionic-team/ionic-framework/blob/main/angular/src/directives/proxies-list.txt).
 
 ### directivesUtilsFile
 
-This is the file where helper functions for the component wrappers are defined. 
+This is the file where helper functions for the component wrappers are defined.
 
 ### valueAccessorConfigs
 
-This lets you define which components should be integrated with ngModel (I.e. form components). It lets you set what the target prop is (I.e. `value`), which event will cause the target prop to change, and more. 
+This lets you define which components should be integrated with ngModel (I.e. form components). It lets you set what the target prop is (I.e. `value`), which event will cause the target prop to change, and more.
 
 ```tsx
 const angularValueAccessorBindings: ValueAccessorConfig[] = [
@@ -292,7 +265,7 @@ const angularValueAccessorBindings: ValueAccessorConfig[] = [
     targetAttr: 'value',
     type: 'text',
   },
-]; 
+];
 
 export const config: Config = {
   namespace: 'component-library',

--- a/src/docs/framework-integration/angular.md
+++ b/src/docs/framework-integration/angular.md
@@ -20,7 +20,7 @@ Stencil can generate Angular component wrappers for your web components. The ben
 
 - Angular component wrappers will be detached from change detection, preventing unnecessary repaints of your web component.
 - Web component events will be converted to RxJS observables to align with Angular's `@Output()` and will not emit across component boundaries.
-- _Optionally_ form control web components can be used as control value accessors with Angular's reactive forms or `[ngModel]`.
+- Optionally, form control web components can be used as control value accessors with Angular's reactive forms or `[ngModel]`.
 
 ## Setup
 

--- a/src/docs/framework-integration/angular.md
+++ b/src/docs/framework-integration/angular.md
@@ -16,7 +16,7 @@ contributors:
 
 **Supports: Angular 12+ • TypeScript 4.0+ • Stencil v2.9.0+**
 
-Stencil can generate Angular component wrappers for your web components. This allows your Stencil components to be used within an Angular application.  The benefits of using Stencil's component wrappers over the standard web components include:
+Stencil can generate Angular component wrappers for your web components. This allows your Stencil components to be used within an Angular application. The benefits of using Stencil's component wrappers over the standard web components include:
 
 - Angular component wrappers will be detached from change detection, preventing unnecessary repaints of your web component.
 - Web component events will be converted to RxJS observables to align with Angular's `@Output()` and will not emit across component boundaries.
@@ -101,7 +101,7 @@ npm run build
 
 If the build is successful, you will now have contents in the file specified in `directivesProxyFile`.
 
-You can now finally import and export the generated component wrappers for your component library. For example, in your main `AppModule` you may do the following:
+You can now finally import and export the generated component wrappers for your component library. For example, in your main Angular `AppModule` you may do the following:
 
 ```ts
 import { COMPONENTS } from './stencil-generated/components';

--- a/src/docs/framework-integration/angular.md
+++ b/src/docs/framework-integration/angular.md
@@ -64,7 +64,10 @@ npx -p @angular/cli ng generate library component-library
 ```bash
 npm init stencil components stencil-library
 cd stencil-library
+# Install dependencies
 npm install
+# or if using yarn
+yarn install
 ```
 
 ### Adding Angular Output Target
@@ -72,7 +75,10 @@ npm install
 Install the `@stencil/angular-output-target` dependency to your Stencil component library package.
 
 ```bash
+# Install dependency
 npm install @stencil/angular-output-target --save-dev
+# or if using yarn
+yarn add @stencil/angular-output-target
 ```
 
 In your project's `stencil.config.ts`, add the `angularOutputTarget` configuration to the `outputTargets` array:
@@ -96,7 +102,10 @@ export const config: Config = {
 You can now build your Stencil component library to generate the component wrappers.
 
 ```bash
+# Build the library and wrappers
 npm run build
+# or if using yarn
+yarn run build
 ```
 
 If the build is successful, you will now have contents in the file specified in `directivesProxyFile`.
@@ -128,13 +137,19 @@ Before you can successfully build a local version of your Angular component libr
 From your Stencil project's directory, run the following command:
 
 ```bash
+# Link the working directory
 npm link
+# or if using yarn
+yarn link
 ```
 
 From your Angular component library's directory, run the following command:
 
 ```bash
+# Link the package name
 npm link name-of-your-stencil-package
+# or if using yarn
+yarn link name-of-your-stencil-package
 ```
 
 The name of your Stencil package should match the `name` property from the Stencil component library's `package.json`.

--- a/src/docs/framework-integration/angular.md
+++ b/src/docs/framework-integration/angular.md
@@ -119,7 +119,7 @@ export { COMPONENTS } from './stencil-generated/components';
 
 ### Link your packages (optional)
 
-> If you are using a monorepo tool (Learn, Nx), skip this section.
+> If you are using a monorepo tool (Lerna, Nx), skip this section.
 
 Before you can successfully build a local version of your Angular component library, you will need to link the Stencil package to the Angular package.
 

--- a/src/docs/framework-integration/angular.md
+++ b/src/docs/framework-integration/angular.md
@@ -87,7 +87,7 @@ In your project's `stencil.config.ts`, add the `angularOutputTarget` configurati
 import { angularOutputTarget } from '@stencil/angular-output-target';
 
 export const config: Config = {
-  namespace: 'component-library',
+  namespace: 'stencil-library',
   outputTargets: [
     angularOutputTarget({
       componentCorePackage: 'your-stencil-library-package-name',
@@ -285,7 +285,7 @@ const angularValueAccessorBindings: ValueAccessorConfig[] = [
 ];
 
 export const config: Config = {
-  namespace: 'component-library',
+  namespace: 'stencil-library',
   outputTargets: [
     angularOutputTarget({
       componentCorePackage: 'component-library',

--- a/src/docs/framework-integration/angular.md
+++ b/src/docs/framework-integration/angular.md
@@ -113,11 +113,11 @@ If the build is successful, you will now have contents in the file specified in 
 You can now finally import and export the generated component wrappers for your component library. For example, in your main Angular `AppModule` you may do the following:
 
 ```ts
-import { COMPONENTS } from './stencil-generated/components';
+import { DIRECTIVES } from './stencil-generated/components';
 
 @NgModule({
-  declarations: [...COMPONENTS],
-  exports: [...COMPONENTS],
+  declarations: [...DIRECTIVES],
+  exports: [...DIRECTIVES],
 })
 export class AppModule {}
 ```
@@ -125,7 +125,7 @@ export class AppModule {}
 Any components that are included in the `exports` array should additionally be exported in your main entry point (either `public-api.ts` or `index.ts`). Skipping this step will lead to Angular Ivy errors when building for production.
 
 ```ts
-export { COMPONENTS } from './stencil-generated/components';
+export { DIRECTIVES } from './stencil-generated/components';
 ```
 
 ### Link your packages (optional)

--- a/src/docs/framework-integration/angular.md
+++ b/src/docs/framework-integration/angular.md
@@ -110,7 +110,7 @@ yarn run build
 
 If the build is successful, you will now have contents in the file specified in `directivesProxyFile`.
 
-You can now finally import and export the generated component wrappers for your component library. For example, in your main Angular `AppModule` you may do the following:
+You can now finally import and export the generated component wrappers for your component library. For example, in your library's main Angular module:
 
 ```ts
 import { DIRECTIVES } from './stencil-generated/components';
@@ -119,7 +119,7 @@ import { DIRECTIVES } from './stencil-generated/components';
   declarations: [...DIRECTIVES],
   exports: [...DIRECTIVES],
 })
-export class AppModule {}
+export class ExampleLibraryModule {}
 ```
 
 Any components that are included in the `exports` array should additionally be exported in your main entry point (either `public-api.ts` or `index.ts`). Skipping this step will lead to Angular Ivy errors when building for production.

--- a/src/docs/framework-integration/angular.md
+++ b/src/docs/framework-integration/angular.md
@@ -87,7 +87,7 @@ In your project's `stencil.config.ts`, add the `angularOutputTarget` configurati
 import { angularOutputTarget } from '@stencil/angular-output-target';
 
 export const config: Config = {
-  namespace: '',
+  namespace: 'component-library',
   outputTargets: [
     angularOutputTarget({
       componentCorePackage: 'your-stencil-library-package-name',

--- a/src/docs/framework-integration/angular.md
+++ b/src/docs/framework-integration/angular.md
@@ -63,6 +63,8 @@ npx -p @angular/cli ng generate library component-library
 
 ```bash
 npm init stencil components stencil-library
+cd stencil-library
+npm install
 ```
 
 ### Adding Angular Output Target

--- a/src/docs/framework-integration/angular.md
+++ b/src/docs/framework-integration/angular.md
@@ -92,12 +92,15 @@ export const config: Config = {
     angularOutputTarget({
       componentCorePackage: 'your-stencil-library-package-name',
       directivesProxyFile: '../angular-workspace/projects/component-library/src/lib/stencil-generated/components.ts',
+      directivesArrayFile: '../angular-workspace/projects/component-library/src/lib/stencil-generated/index.ts',
     }),
   ],
 };
 ```
 
 > The `directivesProxyFile` is the relative path to the file that will be generated with all of the Angular component wrappers. You will replace the file path to match your project's structure and respective names. You can generate any file name instead of `components.ts`.
+
+> The `directivesArrayFile` is the relative path to the file that will be generated with a constant of all the Angular component wrappers. This constant can be used to easily declare and export all the wrappers.
 
 You can now build your Stencil component library to generate the component wrappers.
 
@@ -108,12 +111,12 @@ npm run build
 yarn run build
 ```
 
-If the build is successful, you will now have contents in the file specified in `directivesProxyFile`.
+If the build is successful, you will now have contents in the file specified in `directivesProxyFile` and `directivesArrayFile`.
 
 You can now finally import and export the generated component wrappers for your component library. For example, in your library's main Angular module:
 
 ```ts
-import { DIRECTIVES } from './stencil-generated/components';
+import { DIRECTIVES } from './stencil-generated';
 
 @NgModule({
   declarations: [...DIRECTIVES],
@@ -125,7 +128,7 @@ export class ExampleLibraryModule {}
 Any components that are included in the `exports` array should additionally be exported in your main entry point (either `public-api.ts` or `index.ts`). Skipping this step will lead to Angular Ivy errors when building for production.
 
 ```ts
-export { DIRECTIVES } from './stencil-generated/components';
+export { DIRECTIVES } from './stencil-generated';
 ```
 
 ### Link your packages (optional)


### PR DESCRIPTION
Updates the usage instructions for setting up the `@stencil/angular-output-target` as found here: https://stenciljs.com/docs/angular#what-is-the-best-format-to-write-event-names

- Fixes an incorrect implementation detail where Angular components were being added to the `imports` array (which is not correct for Angular modules).
- Uses `npx` to avoid installing global dependencies
- Removes npm vs. yarn syntax (developers are commonly aware)
- Uses less verbose language for instructions
- Specifies the advantages of using the component wrappers over the vanilla web components

Does not modify language of FAQ and API. Those sections should be updated at a later date. 