### PR TITLE
docs(support): add support policy + versioning docs

### DIFF
--- a/src/assets/docs-structure.json
+++ b/src/assets/docs-structure.json
@@ -430,7 +430,8 @@
     "children": [
       {
         "text": "Support Policy",
-        "filePath": "/assets/docs/reference/support-policy.json"
+        "filePath": "/assets/docs/reference/support-policy.json",
+        "url": "/docs/support-policy"
       }
     ]
   }

--- a/src/assets/docs-structure.json
+++ b/src/assets/docs-structure.json
@@ -424,5 +424,14 @@
         "filePath": "https://ionicframework.com/privacy"
       }
     ]
+  },
+  {
+    "text": "Reference",
+    "children": [
+      {
+        "text": "Support Policy",
+        "filePath": "/assets/docs/reference/support-policy.json"
+      }
+    ]
   }
 ]

--- a/src/assets/docs-structure.json
+++ b/src/assets/docs-structure.json
@@ -432,6 +432,11 @@
         "text": "Support Policy",
         "filePath": "/assets/docs/reference/support-policy.json",
         "url": "/docs/support-policy"
+      },
+      {
+        "text": "Versioning",
+        "filePath": "/assets/docs/reference/versioning.json",
+        "url": "/docs/versioning"
       }
     ]
   }

--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -86,3 +86,5 @@
 * Legal
   * [Telemetry](telemetry.md)
   * [Privacy Policy](https://ionicframework.com/privacy)
+* Reference
+  * [Support Policy](reference/support-policy.md)

--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -88,3 +88,4 @@
   * [Privacy Policy](https://ionicframework.com/privacy)
 * Reference
   * [Support Policy](reference/support-policy.md)
+  * [Versioning](reference/versioning.md)

--- a/src/docs/introduction/faq.md
+++ b/src/docs/introduction/faq.md
@@ -201,25 +201,6 @@ Additionally, modern browsers are able to use the latest features natively, with
 
 ## Stencil Project
 
-### Where can I get support?
-
-If this is your first time building a design system, or you’re new to Stencil, [get in touch](https://ionicframework.com/sales?product_of_interest=Design%20Systems) with one of our Solutions Engineers for a consultation on how to meet your goals and get the most out of the platform.
-
-### What versions of Stencil are currently supported?
-
-Currently, Stencil is on version 2. 
-
-Stencil follows [semantic versioning](https://semver.org/), meaning that the team at Ionic strives to avoid any type of breaking change to Stencil without changing the 'major version number' of the library. Therefore, versions 2.7.0 and 2.8.0 are designed to be backwards compatible with one another. However, there may be breaking changes between v2.7.0 and v3.0.0. Breaking changes to the library can be found [here](https://github.com/ionic-team/stencil/blob/master/BREAKING_CHANGES.md).
-
-To determine the version of Stencil your project has installed, run:
-```shell
-npm ls @stencil/core
-```
-
-To view the latest version of Stencil, please see the project's [releases page](https://github.com/ionic-team/stencil/releases).
-
-> At this time, versions 0 and 1 of Stencil are not actively supported.
-
 ### How do I get involved?
 
 Stencil is an open source project, and we encourage you to contribute. You can start by creating issues on GitHub, submitting feature requests, and helping to replicate bugs. If you’re interested in contributing, please see our [Contributor Guide](https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md) and check out our [issue tracker](https://github.com/ionic-team/stencil/issues).

--- a/src/docs/reference/support-policy.md
+++ b/src/docs/reference/support-policy.md
@@ -54,3 +54,36 @@ The table below describes the timeline of various versions of Stencil
 |    C    |      Maintenance      |     TBD      |       TBD        |        TBD        |
 |    B    | Extended Support Only | Aug 08, 2020 |       TBD        |        TBD        |
 |    A    |    End of Support     | Jun 03, 2019 |   Aug 08, 2020   |    Aug 08, 2020   |
+
+## Compatability Recommendations
+
+Stencil is in many regards an opinionated library, and includes much of the software necessary to get users building
+web components as quickly as possible. There are a few pieces of software that Stencil allows users to choose to best
+fit their team, organization structure, and existing technical stack. The Stencil team has compiled a series of
+compatability tables to describe the interoperability requirements of these pieces of software and Stencil.
+
+### Runtime
+
+| Stencil Version | Node v12 |   Node v14   | Node v16 | Node v18 | Deno |
+|:---------------:|:--------:|:------------:|:--------:|:--------:|:----:|
+|       V3        |    N     |      N       |    N     |    N     |  N   |
+|       V2        |    N     |      N       |    N     |    N     |  N   |
+|       V1        |    N     |      N       |    N     |    N     |  N   |
+
+### Testing Libraries
+
+#### Jest
+
+| Stencil Version | Jest v12 |   Jest v14   | Jest v16 | Jest v18 |
+|:---------------:|:--------:|:------------:|:--------:|:--------:|
+|       V3        |    N     |      N       |    N     |    N     |
+|       V2        |    N     |      N       |    N     |    N     |
+|       V1        |    N     |      N       |    N     |    N     |
+
+#### Puppeteer
+
+| Stencil Version | Puppeteer v12 | Puppeteer v14 | Puppeteer v16 | Puppeteer v18 |
+|:---------------:|:-------------:|:-------------:|:-------------:|:-------------:|
+|       V3        |       N       |       N       |       N       |       N       |
+|       V2        |       N       |       N       |       N       |       N       |
+|       V1        |       N       |       N       |       N       |       N       |

--- a/src/docs/reference/support-policy.md
+++ b/src/docs/reference/support-policy.md
@@ -38,28 +38,35 @@ support options available. To learn more, see our
 ### Stencil Support Details
 
 Starting with Stencil v2, the Stencil team is adopting a newly revised maintenance policy. When a new major version of
-Stencil is released, the previous major version release will enter maintenance mode. While during the maintenance
-period, only critical bug and security fixes will be applied. No major feature improvements added will be added to
-versions in maintenance mode. The maintenance period shall **TODO: last three months**. Once the maintenance period has ended for
+Stencil is released, the previous major version release will enter maintenance mode. While a version of Stencil
+is in maintenance mode, only critical bug & security fixes will be applied to that version, and no major feature improvements will be 
+added. The maintenance period shall last three months from the release of the new major version. 
+
+Once the maintenance period has ended for a
 version of Stencil, that version enters the extended support period. During the extended support period, only critical 
 bug and security fixes will be applied for teams and organizations using Stencil's Enterprise offerings. The extended 
-support period **TODO lasts for X months**.
+support period lasts for six months from the release of the new major version.
 
-The table below describes the timeline of various versions of Stencil
+The table below describes a theoretical timeline of releases:
 
 | Version |        Status         |   Released   | Maintenance Ends | Ext. Support Ends |
 |:-------:|:---------------------:|:------------:|:----------------:|:-----------------:|
 |    D    |        Active         | Jan 01, 2022 |       TBD        |        TBD        |
-|    C    |      Maintenance      | Jul 07, 2021 |       TBD        |        TBD        |
-|    B    | Extended Support Only | Jan 01, 2021 |       TBD        |        TBD        |
-|    A    |    End of Support     | Jul 07, 2020 |   Aug 08, 2020   |   Aug 08, 2020    |
+|    C    |      Maintenance      | Jul 07, 2021 |   Apr 01, 2022   |   Jul 01, 2022    |
+|    B    | Extended Support Only | Jan 01, 2021 |   Oct 07, 2021   |   Jan 07, 2022    |
+|    A    |    End of Support     | Jul 07, 2020 |   Apr 01, 2021   |   Jul 01, 2021    |
 
-## Compatability Recommendations
+In the example above, when Version D is released, Version C enters maintenance mode. Version D was released on January
+1st, 2022. Version C shall be in maintenance mode until April 1st, 2022, three months after the release of Version D.
+After April 1st 2022, Version C will be in extended support until July 1st, 2022, six months after the release of 
+Version D.
+
+## Compatibility Recommendations
 
 Stencil is in many regards an opinionated library, and includes much of the software necessary to get users building
 web components as quickly as possible. There are a few pieces of software that Stencil allows users to choose to best
 fit their team, organizational structure, and existing technical stack. The Stencil team has compiled a series of
-compatability tables to describe the interoperability requirements of these pieces of software and Stencil.
+compatibility tables to describe the interoperability requirements of these pieces of software and Stencil.
 
 ### JavaScript Runtime
 

--- a/src/docs/reference/support-policy.md
+++ b/src/docs/reference/support-policy.md
@@ -39,11 +39,11 @@ support options available. To learn more, see our
 Starting with Stencil v2, the Stencil team is adopting a newly revised maintenance policy. When a new major version of
 Stencil is released, the previous major version release will enter maintenance mode. While a version of Stencil is in
 maintenance mode, only critical bug & security fixes will be applied to that version, and no major feature improvements
-will be added. The maintenance period shall last three months from the release of the new major version.
+will be added. The maintenance period shall last six months from the release of the new major version.
 
 Once the maintenance period has ended for a version of Stencil, that version enters the extended support period. During
 the extended support period, only critical bug and security fixes will be applied for teams and organizations using
-Stencil's Enterprise offerings. The extended  support period lasts for six months from the release of the new major 
+Stencil's Enterprise offerings. The extended support period lasts for six months from the release of the new major 
 version.
 
 The table below describes a theoretical timeline of releases:
@@ -51,13 +51,13 @@ The table below describes a theoretical timeline of releases:
 | Version |        Status         |   Released   | Maintenance Ends | Ext. Support Ends |
 |:-------:|:---------------------:|:------------:|:----------------:|:-----------------:|
 |    D    |        Active         | Jan 01, 2022 |       TBD        |        TBD        |
-|    C    |      Maintenance      | Jul 07, 2021 |   Apr 01, 2022   |   Jul 01, 2022    |
-|    B    | Extended Support Only | Jan 01, 2021 |   Oct 07, 2021   |   Jan 07, 2022    |
-|    A    |    End of Support     | Jul 07, 2020 |   Apr 01, 2021   |   Jul 01, 2021    |
+|    C    |      Maintenance      | Jul 07, 2021 |   Jul 01, 2022   |   Jan 01, 2023    |
+|    B    | Extended Support Only | Jan 01, 2021 |   Jan 07, 2022   |   Jul 07, 2022    |
+|    A    |    End of Support     | Jul 07, 2020 |   Jul 01, 2021   |   Jan 01, 2021    |
 
 In the example above, when Version D is released, Version C enters maintenance mode. Version D was released on January
-1st, 2022. Version C shall be in maintenance mode until April 1st, 2022, three months after the release of Version D.
-After April 1st 2022, Version C will be in extended support until July 1st, 2022, six months after the release of
+1st, 2022. Version C shall be in maintenance mode until July 1st, 2022, three months after the release of Version D.
+After July 1st 2022, Version C will be in extended support until Jun 1st, 2023, twelve months after the release of
 Version D.
 
 ## Compatibility Recommendations

--- a/src/docs/reference/support-policy.md
+++ b/src/docs/reference/support-policy.md
@@ -16,7 +16,7 @@ is welcoming to community pull requests.
 
 ## Stencil Maintenance and Support Status
 
-Given the reality of time and resource restraints as well as the desire to keep innovating in the frontend development
+Given the reality of time and resource constraints as well as the desire to keep innovating in the frontend development
 space, over time it becomes necessary for the Stencil team to shift focus to newer versions of the library. However, the
 Stencil team will do everything it can to make the transition to newer versions as smooth as possible. The Stencil team
 recommends updating to the newest version of the Stencil for the latest features, improvements and stability updates.

--- a/src/docs/reference/support-policy.md
+++ b/src/docs/reference/support-policy.md
@@ -31,22 +31,26 @@ The current status of each Stencil version is:
 |   V1    | End of Support | Jun 03, 2019 |   Aug 08, 2020   |    Aug 08, 2020   |
 
 **Maintenance Period**: Only critical bug and security fixes. No major feature improvements.
+
 **Extended Support Period**: For teams and organizations that require additional long term support, Ionic has extended 
 support options available. To learn more, see our 
 [Enterprise offerings](https://ionicframework.com/sales?product_of_interest=Design%20Systems).
 
-Starting with Stencil v2, the Stencil team is adopting a revised maintenance policy.
+### Stencil Support Details
 
-When a new major version of Stencil is released, the previous major version release will enter maintenance mode. While
-during the maintenance period, only critical bug and security fixes will be applied, with no major feature improvements.
-The maintenance period shall last three months. Once the maintenance period has ended for version of Stencil, that 
-version enters the extended support period. During the extended support period, only critical bug and security fixes
-will be applied for teams and organizations using Stencil's Enterprise offerings. The extended support period lasts
-for X months.
+Starting with Stencil v2, the Stencil team is adopting a newly revised maintenance policy. When a new major version of
+Stencil is released, the previous major version release will enter maintenance mode. While during the maintenance
+period, only critical bug and security fixes will be applied. No major feature improvements added will be added to
+versions in maintenance mode. The maintenance period shall last three months. Once the maintenance period has ended for
+version of Stencil, that version enters the extended support period. During the extended support period, only critical 
+bug and security fixes will be applied for teams and organizations using Stencil's Enterprise offerings. The extended 
+support period lasts for X months.
+
+The table below describes the timeline of various versions of Stencil
 
 | Version |        Status         |   Released   | Maintenance Ends | Ext. Support Ends |
 |:-------:|:---------------------:|:------------:| :--------------: |:-----------------:|
-|    D    |        Active         |     TBD      |       TBD        |        TBD        |
+|    D    |        Active         | Jan 01, 2022 |       TBD        |        TBD        |
 |    C    |      Maintenance      |     TBD      |       TBD        |        TBD        |
 |    B    | Extended Support Only | Aug 08, 2020 |       TBD        |        TBD        |
 |    A    |    End of Support     | Jun 03, 2019 |   Aug 08, 2020   |    Aug 08, 2020   |

--- a/src/docs/reference/support-policy.md
+++ b/src/docs/reference/support-policy.md
@@ -6,6 +6,14 @@ contributors:
 - rwaskiewicz
 ---
 
+# Support Policy
+
+## Community Maintenance
+
+The Stencil is a 100% open source (MIT) project. Developers can ensure Stencil is the right choice for building web 
+components through Ionic’s community maintenance strategy. The Stencil team regularly ships new releases, bug fixes, and 
+is welcoming to community pull requests.
+
 ### Where can I get support?
 
 If this is your first time building a design system, or you’re new to Stencil, [get in touch](https://ionicframework.com/sales?product_of_interest=Design%20Systems) with one of our Solutions Engineers for a consultation on how to meet your goals and get the most out of the platform.

--- a/src/docs/reference/support-policy.md
+++ b/src/docs/reference/support-policy.md
@@ -1,0 +1,9 @@
+---
+title: Support Policy
+description: Support Policy
+url: /docs/support-policy
+contributors:
+- rwaskiewicz
+---
+
+Bonjour!

--- a/src/docs/reference/support-policy.md
+++ b/src/docs/reference/support-policy.md
@@ -25,10 +25,9 @@ updates.
 The current status of each Stencil version is:
 
 | Version |     Status     |   Released   | Maintenance Ends | Ext. Support Ends |
-|:-------:|:--------------:|:------------:| :--------------: |:-----------------:|
-|   V3    |  **Upcoming**  |     TBD      |       TBD        |        TBD        |
+|:-------:|:--------------:|:------------:|:----------------:|:-----------------:|
 |   V2    |   **Active**   | Aug 08, 2020 |       TBD        |        TBD        |
-|   V1    | End of Support | Jun 03, 2019 |   Aug 08, 2020   |    Aug 08, 2020   |
+|   V1    | End of Support | Jun 03, 2019 |   Aug 08, 2020   |   Aug 08, 2020    |
 
 **Maintenance Period**: Only critical bug and security fixes. No major feature improvements.
 
@@ -41,49 +40,52 @@ support options available. To learn more, see our
 Starting with Stencil v2, the Stencil team is adopting a newly revised maintenance policy. When a new major version of
 Stencil is released, the previous major version release will enter maintenance mode. While during the maintenance
 period, only critical bug and security fixes will be applied. No major feature improvements added will be added to
-versions in maintenance mode. The maintenance period shall last three months. Once the maintenance period has ended for
+versions in maintenance mode. The maintenance period shall **TODO: last three months**. Once the maintenance period has ended for
 version of Stencil, that version enters the extended support period. During the extended support period, only critical 
 bug and security fixes will be applied for teams and organizations using Stencil's Enterprise offerings. The extended 
-support period lasts for X months.
+support period **TODO lasts for X months**.
 
 The table below describes the timeline of various versions of Stencil
 
 | Version |        Status         |   Released   | Maintenance Ends | Ext. Support Ends |
-|:-------:|:---------------------:|:------------:| :--------------: |:-----------------:|
+|:-------:|:---------------------:|:------------:|:----------------:|:-----------------:|
 |    D    |        Active         | Jan 01, 2022 |       TBD        |        TBD        |
-|    C    |      Maintenance      |     TBD      |       TBD        |        TBD        |
-|    B    | Extended Support Only | Aug 08, 2020 |       TBD        |        TBD        |
-|    A    |    End of Support     | Jun 03, 2019 |   Aug 08, 2020   |    Aug 08, 2020   |
+|    C    |      Maintenance      | Jul 07, 2021 |       TBD        |        TBD        |
+|    B    | Extended Support Only | Jan 01, 2021 |       TBD        |        TBD        |
+|    A    |    End of Support     | Jul 07, 2020 |   Aug 08, 2020   |   Aug 08, 2020    |
 
 ## Compatability Recommendations
 
 Stencil is in many regards an opinionated library, and includes much of the software necessary to get users building
 web components as quickly as possible. There are a few pieces of software that Stencil allows users to choose to best
-fit their team, organization structure, and existing technical stack. The Stencil team has compiled a series of
+fit their team, organizational structure, and existing technical stack. The Stencil team has compiled a series of
 compatability tables to describe the interoperability requirements of these pieces of software and Stencil.
 
-### Runtime
+### JavaScript Runtime
 
-| Stencil Version | Node v12 |   Node v14   | Node v16 | Node v18 | Deno |
-|:---------------:|:--------:|:------------:|:--------:|:--------:|:----:|
-|       V3        |    N     |      N       |    N     |    N     |  N   |
-|       V2        |    N     |      N       |    N     |    N     |  N   |
-|       V1        |    N     |      N       |    N     |    N     |  N   |
+| Stencil Version | Node v10 | Node v12 | Node v14 | Node v16 | Node v18 |  Deno*  |
+|:---------------:|:--------:|:--------:|:--------:|:--------:|:--------:|:-------:|
+|       V2        | &#10060; | &#9989;  | &#9989;  | &#9989;  | &#10060; | &#9888; |
+|       V1        | &#9989;  | &#9989;  | &#9989;  | &#9989;  | &#10060; | &#9888; |
+
+\* Experimental Deno support was available in Stencil
+[v1.16.0](https://github.com/ionic-team/stencil/releases/tag/v1.16.0) through
+[v2.8.1](https://github.com/ionic-team/stencil/releases/tag/v2.8.1). This experimental support was removed in 
+[v2.9.0](https://github.com/ionic-team/stencil/releases/tag/v2.9.0). For additional reasoning behind this decision, 
+please see [this document](https://github.com/ionic-team/stencil/blob/main/docs/adr/0013-deno-removal.md).
 
 ### Testing Libraries
 
 #### Jest
 
-| Stencil Version | Jest v12 |   Jest v14   | Jest v16 | Jest v18 |
-|:---------------:|:--------:|:------------:|:--------:|:--------:|
-|       V3        |    N     |      N       |    N     |    N     |
-|       V2        |    N     |      N       |    N     |    N     |
-|       V1        |    N     |      N       |    N     |    N     |
+| Stencil Version | Jest v24 | Jest v25 | Jest v26 | Jest v27 |
+|:---------------:|:--------:|:--------:|:--------:|:--------:|
+|       V2        | &#9989;  | &#9989;  | &#9989;  | &#9989;  |
+|       V1        | &#9989;  | &#9989;  | &#9989;  | &#10060; |
 
 #### Puppeteer
 
-| Stencil Version | Puppeteer v12 | Puppeteer v14 | Puppeteer v16 | Puppeteer v18 |
-|:---------------:|:-------------:|:-------------:|:-------------:|:-------------:|
-|       V3        |       N       |       N       |       N       |       N       |
-|       V2        |       N       |       N       |       N       |       N       |
-|       V1        |       N       |       N       |       N       |       N       |
+| Stencil Version | Puppeteer v5 | Puppeteer v6 | Puppeteer v7 | Puppeteer v8 | Puppeteer v9 | Puppeteer v10 |
+|:---------------:|:------------:|:------------:|:------------:|:------------:|:------------:|:-------------:|
+|       V2        |   &#9989;    |   &#9989;    |   &#9989;    |   &#9989;    |   &#9989;    |    &#9989;    |
+|       V1        |   &#9989;    |   &#9989;    |   &#9989;    |   &#9989;    |   &#9989;    |   &#10060;    |

--- a/src/docs/reference/support-policy.md
+++ b/src/docs/reference/support-policy.md
@@ -14,21 +14,39 @@ The Stencil is a 100% open source (MIT) project. Developers can ensure Stencil i
 components through Ionic’s community maintenance strategy. The Stencil team regularly ships new releases, bug fixes, and 
 is welcoming to community pull requests.
 
-### Where can I get support?
+## Stencil Maintenance and Support Status
 
-If this is your first time building a design system, or you’re new to Stencil, [get in touch](https://ionicframework.com/sales?product_of_interest=Design%20Systems) with one of our Solutions Engineers for a consultation on how to meet your goals and get the most out of the platform.
+Given the reality of time and resource restraints as well as the desire to keep innovating in the frontend development
+space, over time it becomes necessary for the Stencil team to shift focus to newer versions of the library. However,
+the Stencil team will do everything it can to make the transition to newer versions as smooth as possible. The Stencil
+team recommends updating to the newest version of the Stencil for the latest features, improvements and stability 
+updates.
 
-### What versions of Stencil are currently supported?
+The current status of each Stencil version is:
 
-Currently, Stencil is on version 2.
+| Version |     Status     |   Released   | Maintenance Ends | Ext. Support Ends |
+|:-------:|:--------------:|:------------:| :--------------: |:-----------------:|
+|   V3    |  **Upcoming**  |     TBD      |       TBD        |        TBD        |
+|   V2    |   **Active**   | Aug 08, 2020 |       TBD        |        TBD        |
+|   V1    | End of Support | Jun 03, 2019 |   Aug 08, 2020   |    Aug 08, 2020   |
 
-Stencil follows [semantic versioning](https://semver.org/), meaning that the team at Ionic strives to avoid any type of breaking change to Stencil without changing the 'major version number' of the library. Therefore, versions 2.7.0 and 2.8.0 are designed to be backwards compatible with one another. However, there may be breaking changes between v2.7.0 and v3.0.0. Breaking changes to the library can be found [here](https://github.com/ionic-team/stencil/blob/master/BREAKING_CHANGES.md).
+**Maintenance Period**: Only critical bug and security fixes. No major feature improvements.
+**Extended Support Period**: For teams and organizations that require additional long term support, Ionic has extended 
+support options available. To learn more, see our 
+[Enterprise offerings](https://ionicframework.com/sales?product_of_interest=Design%20Systems).
 
-To determine the version of Stencil your project has installed, run:
-```shell
-npm ls @stencil/core
-```
+Starting with Stencil v2, the Stencil team is adopting a revised maintenance policy.
 
-To view the latest version of Stencil, please see the project's [releases page](https://github.com/ionic-team/stencil/releases).
+When a new major version of Stencil is released, the previous major version release will enter maintenance mode. While
+during the maintenance period, only critical bug and security fixes will be applied, with no major feature improvements.
+The maintenance period shall last three months. Once the maintenance period has ended for version of Stencil, that 
+version enters the extended support period. During the extended support period, only critical bug and security fixes
+will be applied for teams and organizations using Stencil's Enterprise offerings. The extended support period lasts
+for X months.
 
-> At this time, versions 0 and 1 of Stencil are not actively supported.
+| Version |        Status         |   Released   | Maintenance Ends | Ext. Support Ends |
+|:-------:|:---------------------:|:------------:| :--------------: |:-----------------:|
+|    D    |        Active         |     TBD      |       TBD        |        TBD        |
+|    C    |      Maintenance      |     TBD      |       TBD        |        TBD        |
+|    B    | Extended Support Only | Aug 08, 2020 |       TBD        |        TBD        |
+|    A    |    End of Support     | Jun 03, 2019 |   Aug 08, 2020   |    Aug 08, 2020   |

--- a/src/docs/reference/support-policy.md
+++ b/src/docs/reference/support-policy.md
@@ -10,17 +10,16 @@ contributors:
 
 ## Community Maintenance
 
-The Stencil is a 100% open source (MIT) project. Developers can ensure Stencil is the right choice for building web 
-components through Ionic’s community maintenance strategy. The Stencil team regularly ships new releases, bug fixes, and 
+Stencil is a 100% open source (MIT) project. Developers can ensure Stencil is the right choice for building web
+components through Ionic’s community maintenance strategy. The Stencil team regularly ships new releases, bug fixes, and
 is welcoming to community pull requests.
 
 ## Stencil Maintenance and Support Status
 
 Given the reality of time and resource restraints as well as the desire to keep innovating in the frontend development
-space, over time it becomes necessary for the Stencil team to shift focus to newer versions of the library. However,
-the Stencil team will do everything it can to make the transition to newer versions as smooth as possible. The Stencil
-team recommends updating to the newest version of the Stencil for the latest features, improvements and stability 
-updates.
+space, over time it becomes necessary for the Stencil team to shift focus to newer versions of the library. However, the
+Stencil team will do everything it can to make the transition to newer versions as smooth as possible. The Stencil team
+recommends updating to the newest version of the Stencil for the latest features, improvements and stability updates.
 
 The current status of each Stencil version is:
 
@@ -32,20 +31,20 @@ The current status of each Stencil version is:
 **Maintenance Period**: Only critical bug and security fixes. No major feature improvements.
 
 **Extended Support Period**: For teams and organizations that require additional long term support, Ionic has extended 
-support options available. To learn more, see our 
+support options available. To learn more, see our
 [Enterprise offerings](https://ionicframework.com/sales?product_of_interest=Design%20Systems).
 
 ### Stencil Support Details
 
 Starting with Stencil v2, the Stencil team is adopting a newly revised maintenance policy. When a new major version of
-Stencil is released, the previous major version release will enter maintenance mode. While a version of Stencil
-is in maintenance mode, only critical bug & security fixes will be applied to that version, and no major feature improvements will be 
-added. The maintenance period shall last three months from the release of the new major version. 
+Stencil is released, the previous major version release will enter maintenance mode. While a version of Stencil is in
+maintenance mode, only critical bug & security fixes will be applied to that version, and no major feature improvements
+will be added. The maintenance period shall last three months from the release of the new major version.
 
-Once the maintenance period has ended for a
-version of Stencil, that version enters the extended support period. During the extended support period, only critical 
-bug and security fixes will be applied for teams and organizations using Stencil's Enterprise offerings. The extended 
-support period lasts for six months from the release of the new major version.
+Once the maintenance period has ended for a version of Stencil, that version enters the extended support period. During
+the extended support period, only critical bug and security fixes will be applied for teams and organizations using
+Stencil's Enterprise offerings. The extended  support period lasts for six months from the release of the new major 
+version.
 
 The table below describes a theoretical timeline of releases:
 
@@ -58,14 +57,14 @@ The table below describes a theoretical timeline of releases:
 
 In the example above, when Version D is released, Version C enters maintenance mode. Version D was released on January
 1st, 2022. Version C shall be in maintenance mode until April 1st, 2022, three months after the release of Version D.
-After April 1st 2022, Version C will be in extended support until July 1st, 2022, six months after the release of 
+After April 1st 2022, Version C will be in extended support until July 1st, 2022, six months after the release of
 Version D.
 
 ## Compatibility Recommendations
 
-Stencil is in many regards an opinionated library, and includes much of the software necessary to get users building
-web components as quickly as possible. There are a few pieces of software that Stencil allows users to choose to best
-fit their team, organizational structure, and existing technical stack. The Stencil team has compiled a series of
+Stencil is in many regards an opinionated library, and includes much of the software necessary to get users building web
+components as quickly as possible. There are a few pieces of software that Stencil allows users to choose to best fit
+their team, organizational structure, and existing technical stack. The Stencil team has compiled a series of
 compatibility tables to describe the interoperability requirements of these pieces of software and Stencil.
 
 ### JavaScript Runtime

--- a/src/docs/reference/support-policy.md
+++ b/src/docs/reference/support-policy.md
@@ -6,4 +6,21 @@ contributors:
 - rwaskiewicz
 ---
 
-Bonjour!
+### Where can I get support?
+
+If this is your first time building a design system, or you’re new to Stencil, [get in touch](https://ionicframework.com/sales?product_of_interest=Design%20Systems) with one of our Solutions Engineers for a consultation on how to meet your goals and get the most out of the platform.
+
+### What versions of Stencil are currently supported?
+
+Currently, Stencil is on version 2.
+
+Stencil follows [semantic versioning](https://semver.org/), meaning that the team at Ionic strives to avoid any type of breaking change to Stencil without changing the 'major version number' of the library. Therefore, versions 2.7.0 and 2.8.0 are designed to be backwards compatible with one another. However, there may be breaking changes between v2.7.0 and v3.0.0. Breaking changes to the library can be found [here](https://github.com/ionic-team/stencil/blob/master/BREAKING_CHANGES.md).
+
+To determine the version of Stencil your project has installed, run:
+```shell
+npm ls @stencil/core
+```
+
+To view the latest version of Stencil, please see the project's [releases page](https://github.com/ionic-team/stencil/releases).
+
+> At this time, versions 0 and 1 of Stencil are not actively supported.

--- a/src/docs/reference/versioning.md
+++ b/src/docs/reference/versioning.md
@@ -33,12 +33,10 @@ team priorities.
 
 A patch release will be published when bug fixes were included, but the API has not changed and no breaking changes were
 introduced.  Patch releases are scheduled to occur at least **once a month**, although this cadence may vary according
-to team priorities. There may be times where patch releases need to released more often than scheduled.  To ensure patch
-releases can fix existing code without introducing new issues from the new features, patch releases will always be
-published prior to a minor release.
+to team priorities. There may be times where patch releases need to released more often than scheduled.
 
 ## Changelog
 
 To see a list of all notable changes to Stencil, please refer to the 
-<a href="https://github.com/ionic-team/stencil/releases" target="_blank" rel="noreferrer noopener">releases page</a>. This contains an ordered
-list of all bug fixes and new features under each release.
+<a href="https://github.com/ionic-team/stencil/releases" target="_blank" rel="noreferrer noopener">releases page</a>.
+This contains an ordered list of all bug fixes and new features under each release.

--- a/src/docs/reference/versioning.md
+++ b/src/docs/reference/versioning.md
@@ -1,0 +1,44 @@
+---
+title: Versioning
+description: Versioning
+url: /docs/versioning
+contributors:
+- rwaskiewicz
+---
+
+# Versioning
+
+Stencil follows the <a href="https://semver.org/" target="_blank">Semantic Versioning (SemVer)</a> convention:
+<code>major.minor.patch.</code> Incompatible API changes increment the <code>major</code> version, adding 
+backwards-compatible functionality increments the <code>minor</code> version, and backwards-compatible bug fixes
+increment the <code>patch</code> version.
+
+## Release Schedule
+
+### Major Release
+
+A major release will be published when there is a breaking change introduced in the API. Major releases will occur
+roughly every **6 months** and may contain breaking changes. Release candidates will be published prior to a major
+release in order to get feedback before the final release. An outline of what is changing and why will be included with
+the release candidates.
+
+### Minor Release
+
+A minor release will be published when a new feature is added or API changes that are non-breaking are introduced.
+We will heavily test any changes so that we are confident with the release, but with new code comes the potential for
+new issues. Minor releases are scheduled to occur at least **once a month**, although this cadence may vary according to
+team priorities.
+
+### Patch Release
+
+A patch release will be published when bug fixes were included, but the API has not changed and no breaking changes were
+introduced.  Patch releases are scheduled to occur at least **once a month**, although this cadence may vary according
+to team priorities. There may be times where patch releases need to released more often than scheduled.  To ensure patch
+releases can fix existing code without introducing new issues from the new features, patch releases will always be
+published prior to a minor release.
+
+## Changelog
+
+To see a list of all notable changes to Stencil, please refer to the 
+<a href="https://github.com/ionic-team/stencil/releases" target="_blank" rel="noreferrer noopener">releases page</a>. This contains an ordered
+list of all bug fixes and new features under each release.


### PR DESCRIPTION
this pr adds 2 pages to our documentation:
1. a support policy
2. an explainer on how Stencil shall use semver

both documents are heavily borrowed from the Ionic
framework, where the former is borrowed from
https://ionicframework.com/docs/reference/support
and the latter from https://ionicframework.com/docs/reference/versioning