### PR TITLE
docs(getting-started): remove warning notice

### DIFF
--- a/src/docs/introduction/getting-started.md
+++ b/src/docs/introduction/getting-started.md
@@ -69,8 +69,6 @@ Upon successfully creating our project, the CLI will print something similar to 
 
 The first section describes a few commands required to finish getting your project bootstrapped.
 
-> You will need to complete these steps in order to run any of the above commands
-
 ```bash
     $ cd my-first-stencil-project
     $ npm install


### PR DESCRIPTION
remove warning notice for having to run npm install. this should
be self explanatory now that we've fixed the flow of this section