### PR TITLE
docs(node): update support policy for node in v3

### DIFF
--- a/src/docs/reference/support-policy.md
+++ b/src/docs/reference/support-policy.md
@@ -25,6 +25,7 @@ The current status of each Stencil version is:
 
 | Version |     Status     |   Released   | Maintenance Ends | Ext. Support Ends |
 |:-------:|:--------------:|:------------:|:----------------:|:-----------------:|
+|   V3    |    Upcoming    |     TBD      |       TBD        |        TBD        |
 |   V2    |   **Active**   | Aug 08, 2020 |       TBD        |        TBD        |
 |   V1    | End of Support | Jun 03, 2019 |   Aug 08, 2020   |   Aug 08, 2020    |
 
@@ -102,6 +103,7 @@ compatibility tables to describe the interoperability requirements of these piec
 
 | Stencil Version | Node v10 | Node v12 | Node v14 | Node v16 | Node v18 |  Deno*  |
 |:---------------:|:--------:|:--------:|:--------:|:--------:|:--------:|:-------:|
+|       V3        | &#10060; | &#10060; | &#9989;  | &#9989;  | &#10060; | &#9888; |
 |       V2        | &#10060; | &#9989;  | &#9989;  | &#9989;  | &#10060; | &#9888; |
 |       V1        | &#9989;  | &#9989;  | &#9989;  | &#9989;  | &#10060; | &#9888; |
 


### PR DESCRIPTION
this commit updates the node runtime support table to state that node
v12 will not be supported in stencil v3. we do not update the table to
explicitly state that node v18 will be supported in v3 (although it's
expected to), as we haven't tested against node 18 at this time

this commit also **stubs** out the v3 release in the maintenance
schedule table. we will update this when the time comes closer to having
a firmer date