### PR TITLE
docs(component): remove reference to deprecated `assetsDir` option

### DIFF
--- a/src/docs/components/component.md
+++ b/src/docs/components/component.md
@@ -83,11 +83,6 @@ export interface ComponentOptions {
    * Array of relative links to folders of assets required by the component.
    */
   assetsDirs?: string[];
-
-  /**
-   * @deprecated Use `assetsDirs` instead
-   */
-  assetsDir?: string;
 }
 ```
 


### PR DESCRIPTION
The `assetsDir` parameter to `@Component` was deprecated some time ago,
and for stencil v3 we will remove backwards compatibility for it. This
commit accordingly removes references to it from the docs.

STENCIL-410