### PR TITLE
docs(support): add current jest 28 support status

### DIFF
--- a/src/docs/reference/support-policy.md
+++ b/src/docs/reference/support-policy.md
@@ -115,10 +115,12 @@ please see [this document](https://github.com/ionic-team/stencil/blob/main/docs/
 
 #### Jest
 
-| Stencil Version | Jest v24 | Jest v25 | Jest v26 | Jest v27 |
-|:---------------:|:--------:|:--------:|:--------:|:--------:|
-|       V2        | &#9989;  | &#9989;  | &#9989;  | &#9989;  |
-|       V1        | &#9989;  | &#9989;  | &#9989;  | &#10060; |
+| Stencil Version | Jest v24 | Jest v25 | Jest v26 | Jest v27 | Jest v28* |
+|:---------------:|:--------:|:--------:|:--------:|:--------:|:---------:|
+|       V2        | &#9989;  | &#9989;  | &#9989;  | &#9989;  | &#10060;  |
+|       V1        | &#9989;  | &#9989;  | &#9989;  | &#10060; | &#10060;  |
+
+\* Support for Jest 28 will be released in an upcoming version of Stencil.
 
 #### Puppeteer
 


### PR DESCRIPTION
this commit updates the documentation site's support status page to
state that jest v28 is not supported at this time, but will be in the
future