### PR TITLE
fix(redirect): redirect /docs/ to intro page

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "redirects": [
     {
-      "source": "/docs",
+      "source": "/docs(/)?",
       "destination": "/docs/introduction",
       "statusCode": 301
     },


### PR DESCRIPTION
when navigating to https://stenciljs.com/docs/ (with the trailing
slash), the site complains we cannot find the page the user is looking
for. this commit updates the permanent redirect for '/docs' to accept
both `/docs/` and `/docs` for performing a redirect to the introduction
page of the docs

example
![Screen Shot 2022-05-06 at 9 03 15 AM](https://user-images.githubusercontent.com/1930213/167136768-a249eb1f-2492-47b1-ae04-0400e35228cf.png)


testing:
navigate to the Vercel preview associated with this PR:
- add `/docs/` to the URL, see the redirect work
- add `/docs` to the URL, see the  existing redirect work