### PR TITLE
docs(extras): add documentation for experimentalImportInjection

### DIFF
--- a/src/docs/config/extras.md
+++ b/src/docs/config/extras.md
@@ -70,7 +70,7 @@ and use a bundler such as Vite to lazily load the Stencil library's components.
 
 In order for this flag to work:
 1. The Stencil library must expose lazy loadable components, such as those created with the
-[`dist` output target](/docs/output-targets/dist)
+[`dist` output target](/docs/distribution)
 2. The Stencil library must be recompiled with this flag set to `true`
 
 This flag works by creating dynamic import statements for every lazily loadable component in a Stencil project.

--- a/src/docs/config/extras.md
+++ b/src/docs/config/extras.md
@@ -62,16 +62,18 @@ Dynamic `import()` shim. This is only needed for Edge 18 and below, and Firefox 
 
 ### experimentalImportInjection
 
-In some cases, it can be difficult to lazily load Stencil components when using a bundler such as Vite.
+In some cases, it can be difficult to lazily load Stencil components in a separate project that uses a bundler such as
+Vite.
 
-This is an experimental flag that when set to `true`, will inject dynamic import statements for every lazily loadable
-component in a Stencil project.
-When a Stencil library is compiled with this flag set to `true`, downstream projects that use Vite and consume the
-Stencil library will be able to properly lazily load the Stencil library's components.
+This is an experimental flag that, when set to `true`, will allow downstream projects that consume a Stencil library
+and use a bundler such as Vite to lazily load the Stencil library's components.
 
-The Stencil library must expose lazy loadable components, such as those created with the 
-[`dist` output target](/docs/output-targets/dist) in order for this flag to work.
+In order for this flag to work:
+1. The Stencil library must expose lazy loadable components, such as those created with the
+[`dist` output target](/docs/output-targets/dist)
+2. The Stencil library must be recompiled with this flag set to `true`
 
+This flag works by creating dynamic import statements for every lazily loadable component in a Stencil project.
 Users of this flag should note that they may see an increase in their bundle size.
 
 Defaults to `false`.

--- a/src/docs/config/extras.md
+++ b/src/docs/config/extras.md
@@ -60,6 +60,22 @@ div {
 
 Dynamic `import()` shim. This is only needed for Edge 18 and below, and Firefox 67 and below. If you do not need to support Edge 18 and below (Edge before it moved to Chromium) then it's recommended to set `dynamicImportShim` to `false`. Defaults to `false`.
 
+### experimentalImportInjection
+
+In some cases, it can be difficult to lazily load Stencil components when using a bundler such as Vite.
+
+This is an experimental flag that when set to `true`, will inject dynamic import statements for every lazily loadable
+component in a Stencil project.
+When a Stencil library is compiled with this flag set to `true`, downstream projects that use Vite and consume the
+Stencil library will be able to properly lazily load the Stencil library's components.
+
+The Stencil library must expose lazy loadable components, such as those created with the 
+[`dist` output target](/docs/output-targets/dist) in order for this flag to work.
+
+Users of this flag should note that they may see an increase in their bundle size.
+
+Defaults to `false`.
+
 ### lifecycleDOMEvents
 
 Dispatches component lifecycle events. By default these events are not dispatched, but by enabling this to `true` these events can be listened for on `window`. Mainly used for testing.

--- a/src/docs/config/extras.md
+++ b/src/docs/config/extras.md
@@ -63,7 +63,7 @@ Dynamic `import()` shim. This is only needed for Edge 18 and below, and Firefox 
 ### experimentalImportInjection
 
 In some cases, it can be difficult to lazily load Stencil components in a separate project that uses a bundler such as
-Vite.
+[Vite](https://vitejs.dev/).
 
 This is an experimental flag that, when set to `true`, will allow downstream projects that consume a Stencil library
 and use a bundler such as Vite to lazily load the Stencil library's components.


### PR DESCRIPTION
this commit adds the documentation for the `experimentalImportInjection`
configuration flag

STENCIL-339: Integrate Bundler Feature into Stencil

this commit is tied to: https://github.com/ionic-team/stencil/pull/3364 & https://github.com/ionic-team/stencil/pull/3349