### PR TITLE
docs(started): update starter text

### DIFF
--- a/src/docs/introduction/getting-started.md
+++ b/src/docs/introduction/getting-started.md
@@ -23,7 +23,7 @@ updated Node before continuing.
 Stencil can be used to create standalone components, or entire apps. When running `npm init stencil`, you will be
 provided with a prompt so that you can choose the type of project to start.
 
-```bash
+```text
 ? Select a starter project.
 
 Starters marked as [community] are developed by the Stencil Community,
@@ -31,7 +31,6 @@ rather than Ionic. For more information on the Stencil Community, please see
 https://github.com/stencil-community › - Use arrow-keys. Return to submit.
 ❯   component          Collection of web components that can be used anywhere
     app [community]    Minimal starter for building a Stencil app or website
-
 ```
 
 Selecting the 'component' option will prompt you for the name of your project.

--- a/src/docs/introduction/getting-started.md
+++ b/src/docs/introduction/getting-started.md
@@ -28,7 +28,7 @@ provided with a prompt so that you can choose the type of project to start.
 
 Starters marked as [community] are developed by the Stencil
 Community, rather than Ionic. For more information on the 
-Stencil Community, please see https://github.com/stencil-community
+Stencil Community, please see github.com/stencil-community
 › - Use arrow-keys. Return to submit.
 
 ❯   component          Collection of web components that can be

--- a/src/docs/introduction/getting-started.md
+++ b/src/docs/introduction/getting-started.md
@@ -24,10 +24,14 @@ Stencil can be used to create standalone components, or entire apps. When runnin
 provided with a prompt so that you can choose the type of project to start.
 
 ```bash
-? Pick a starter › - Use arrow-keys. Return to submit.
+? Select a starter project.
 
-❯  component     Collection of web components that can be used anywhere
-   app           Minimal starter for building a Stencil app or website
+Starters marked as [community] are developed by the Stencil Community,
+rather than Ionic. For more information on the Stencil Community, please see
+https://github.com/stencil-community › - Use arrow-keys. Return to submit.
+❯   component          Collection of web components that can be used anywhere
+    app [community]    Minimal starter for building a Stencil app or website
+
 ```
 
 Selecting the 'component' option will prompt you for the name of your project.
@@ -55,7 +59,7 @@ Upon successfully creating our project, the CLI will print something similar to 
     Starts the development server.
 
   $ npm run build
-    Builds your components/app in production mode.
+    Builds your project in production mode.
 
   $ npm test
     Starts the test runner.

--- a/src/docs/introduction/getting-started.md
+++ b/src/docs/introduction/getting-started.md
@@ -26,11 +26,15 @@ provided with a prompt so that you can choose the type of project to start.
 ```text
 ? Select a starter project.
 
-Starters marked as [community] are developed by the Stencil Community,
-rather than Ionic. For more information on the Stencil Community, please see
-https://github.com/stencil-community › - Use arrow-keys. Return to submit.
-❯   component          Collection of web components that can be used anywhere
-    app [community]    Minimal starter for building a Stencil app or website
+Starters marked as [community] are developed by the Stencil
+Community, rather than Ionic. For more information on the 
+Stencil Community, please see https://github.com/stencil-community
+› - Use arrow-keys. Return to submit.
+
+❯   component          Collection of web components that can be
+                       used anywhere
+    app [community]    Minimal starter for building a Stencil 
+                       app or website
 ```
 
 Selecting the 'component' option will prompt you for the name of your project.


### PR DESCRIPTION
update the `npm init stencil` text after releasing v3.0.0 of the
create-stencil cli (which moved the app starter to the community)