### PR TITLE
docs(resources): remove stencil announcement presentation

### DIFF
--- a/src/components/resources-page/resources-page.css
+++ b/src/components/resources-page/resources-page.css
@@ -134,22 +134,6 @@ resources-page h2 + .list--unstyled {
   margin-top: 22px;
 }
 
-resources-page .slide-wrapper {
-  position: relative;
-  padding-bottom: 56.25%;
-  /* 16:9 */
-  padding-top: 25px;
-  height: 0;
-}
-
-resources-page .slide-wrapper iframe {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-}
-
 resources-page a {
   text-decoration: none;
 }

--- a/src/components/resources-page/resources-page.tsx
+++ b/src/components/resources-page/resources-page.tsx
@@ -210,23 +210,6 @@ export class ResourcesPage {
               </div>
             </div>
           </section>
-
-          <section class="measure-lg">
-            <h2>Present Stencil</h2>
-            <div class="slide-wrapper screenshot">
-              <iframe src="https://ionic-team.github.io/stencil-present/" title="Present Stencil" loading="lazy"></iframe>
-            </div>
-            <p>
-              A forkable presentation for your next meetup or conference talk on Stencil. Built with <a href="https://github.com/hakimel/reveal.js">Reveal.js</a>
-            </p>
-            <a target="_blank" rel="noopener" href="https://ionic-team.github.io/stencil-present/">
-              Stencil Presentation
-            </a>
-            <br />
-            <a target="_blank" rel="noopener" href="https://github.com/ionic-team/stencil-present/">
-              Source
-            </a>
-          </section>
         </ResponsiveContainer>
       </Host>
     );


### PR DESCRIPTION
as a part of an initiative to clearly define the projects that the
stencil team is maintaining, the team is going through and archiving
projects that will no longer be maintained by ionic nor by the
community. one such example is https://github.com/ionic-team/stencil-present

before we archive that project, i'd like to remove it from the
resources/ page on the stencil site.

in removing the stencil component that wrapped the iframe, any css
classes that were removed were searched for in the codebase. any classes
that were only used for the removed component were also removed