### PR TITLE
docs(dist-custom-elements): update documentation to reflect index.js changes

### DIFF
--- a/src/docs/output-targets/custom-elements.md
+++ b/src/docs/output-targets/custom-elements.md
@@ -37,6 +37,19 @@ import { HelloWorld } from 'my-library/dist/components/hello-world';
 customElements.define('hello-world', HelloWorld);
 ```
 
+The output directory will also contain an `index.js` file which imports and
+re-exports all of your components and their respective `defineCustomElement`
+helper functions, looking something like this:
+
+```tsx
+export { setAssetPath, setPlatformOptions } from '@stencil/core/internal/client';
+export { MyComponent, defineCustomElement as defineCustomElementMyComponent } from './my-component.js';
+export {
+  MyOtherComponent,
+  defineCustomElement as defineCustomElementMyOtherComponent
+} from './my-other-component.js';
+```
+
 ## Config
 
 ### autoDefineCustomElements

--- a/src/docs/output-targets/custom-elements.md
+++ b/src/docs/output-targets/custom-elements.md
@@ -37,9 +37,9 @@ import { HelloWorld } from 'my-library/dist/components/hello-world';
 customElements.define('hello-world', HelloWorld);
 ```
 
-The output directory will also contain an `index.js` file which imports and
-re-exports all of your components and their respective `defineCustomElement`
-helper functions, looking something like this:
+The output directory will also contain an `index.js` file which exports all of
+your components and their respective `defineCustomElement` helper functions,
+looking something like this:
 
 ```tsx
 export { setAssetPath, setPlatformOptions } from '@stencil/core/internal/client';
@@ -49,6 +49,9 @@ export {
   defineCustomElement as defineCustomElementMyOtherComponent
 } from './my-other-component.js';
 ```
+
+This file can be used as the root module when distributing your component
+library, see [below](#distributing-custom-elements) for more details.
 
 ## Config
 
@@ -109,9 +112,15 @@ The configs below provide examples of how to do this automatically with popular 
 
 ## Distributing Custom Elements
 
-Your component library can be easily distributed on NPM, similar to how [`@ionic/core`](https://www.npmjs.com/package/@ionic/core) does it. From there, consumers of your library can decide how to import your library into their project. For the `dist-custom-elements`, the default import location would be `my-library/dist/components`, but this can get further configured within the `package.json` file.
+Your component library can be easily distributed on NPM, just like
+[`@ionic/core`](https://www.npmjs.com/package/@ionic/core). From there,
+consumers of your library can decide how to import your library into their
+project. For the `dist-custom-elements` output target, the default import
+location would be `my-library/dist/components`, but this can get further
+configured within the `package.json` file.
 
-To make the custom elements index the entry module for a package, set the `module` property in `package.json` to:
+To make the custom elements index the entry module for a package, set the
+`module` property in `package.json` to:
 
 ```tsx
 {
@@ -127,8 +136,29 @@ Be sure to set `@stencil/core` as a dependency of the package as well.
 
 > Note: If you are distributing both the `dist` and `dist-custom-elements`, then it's up to you to choose which one of them should be available in the `module` entry.
 
+Note: If you are distributing the output of both the
+[`dist`](/docs/output-targets/dist) and `dist-custom-elements` targets, then
+it's up to you to choose which one of them should be available in the `module`
+entry.
 
-Now you can publish your library to [Node Package Manager (NPM)](https://www.npmjs.com/). For more information about setting up the `package.json` file, and publishing, see: [Publishing Component Library To NPM](/docs/publishing).
+Consumers of your library can then either import components from their
+individual files, like so:
+
+```tsx
+import { MyComponent } from 'best-web-components/dist/components/my-component';
+```
+
+Or they can import directly from the index module (`dist/components/index.js`),
+like so:
+
+```tsx
+import { MyComponent } from 'best-web-components';
+```
+
+Now you can publish your library to [Node Package Manager
+(NPM)](https://www.npmjs.com/). For more information about setting up the
+`package.json` file, and publishing, see: [Publishing Component Library To
+NPM](/docs/publishing).
 
 ## Example Bundler Configs
 

--- a/src/docs/output-targets/custom-elements.md
+++ b/src/docs/output-targets/custom-elements.md
@@ -120,7 +120,7 @@ location would be `my-library/dist/components`, but this can get further
 configured within the `package.json` file.
 
 To make the custom elements index the entry module for a package, set the
-`module` property in `package.json` to:
+`module` property like so in your `package.json`:
 
 ```tsx
 {
@@ -134,12 +134,10 @@ To make the custom elements index the entry module for a package, set the
 
 Be sure to set `@stencil/core` as a dependency of the package as well.
 
-> Note: If you are distributing both the `dist` and `dist-custom-elements`, then it's up to you to choose which one of them should be available in the `module` entry.
-
-Note: If you are distributing the output of both the
-[`dist`](/docs/output-targets/dist) and `dist-custom-elements` targets, then
-it's up to you to choose which one of them should be available in the `module`
-entry.
+> Note: If you are distributing the output of both the
+  [`dist`](/docs/output-targets/dist) and `dist-custom-elements` targets, then
+  it's up to you to choose which one of them should be available in the
+  `module` entry.
 
 Consumers of your library can then either import components from their
 individual files, like so:
@@ -159,6 +157,35 @@ Now you can publish your library to [Node Package Manager
 (NPM)](https://www.npmjs.com/). For more information about setting up the
 `package.json` file, and publishing, see: [Publishing Component Library To
 NPM](/docs/publishing).
+
+### Usage in Typescript
+
+If you plan to support consuming your component library in Typescript you'll
+need to set `generateTypeDeclarations: true` on the your output target in
+`stencil.config.ts`, like so:
+
+```tsx
+outputTargets: [
+  {
+    type: 'dist-custom-elements',
+    generateTypeDeclarations: true,
+  },
+];
+```
+
+Then you can set the `types` property in `package.json` so that consumers of
+your package can find the type definitions, like so:
+
+```tsx
+{
+  "module": "dist/components/index.js",
+  "types": "dist/components/index.d.ts",
+  "dependencies": {
+    "@stencil/core": "latest"
+  },
+  ...
+}
+```
 
 ## Example Bundler Configs
 

--- a/src/docs/output-targets/custom-elements.md
+++ b/src/docs/output-targets/custom-elements.md
@@ -112,7 +112,7 @@ The configs below provide examples of how to do this automatically with popular 
 
 ## Distributing Custom Elements
 
-Your component library can be easily distributed on NPM, just like
+Your component library can be distributed on NPM, just like
 [`@ionic/core`](https://www.npmjs.com/package/@ionic/core). From there,
 consumers of your library can decide how to import your library into their
 project. For the `dist-custom-elements` output target, the default import


### PR DESCRIPTION
This adds documentation of the change to the `dist-custom-elements`
output target introduced in ionic-team/stencil#3368. That PR adds
a re-export of all the built components from the `index.js` file,
which will support some existing workflows based on the
`dist-custom-elements-bundle` output target.