### PR TITLE
docs(dist-custom-elements): update docs for autoDefineCustomElements option

### DIFF
--- a/src/docs/output-targets/custom-elements.md
+++ b/src/docs/output-targets/custom-elements.md
@@ -41,18 +41,17 @@ customElements.define('hello-world', HelloWorld);
 
 ### autoDefineCustomElements
 
-By default, consumers of the `custom-elements` output target need to either register each Stencil component in the 
-bundle manually, or call a convenience method, `defineCustomElements()`, that is exported as a part of the bundle to
-define every component in the bundle. This behavior can be cumbersome, especially when only a handful of components are 
-needed and/or those components have several child components (and their children have children, etc.).
-
-Setting this flag to `true` will recursively define all children components for a Stencil component when it is
-registered. Users of this flag should note that this may increase their bundle size by automatically defining &
-registering child components.
+By default, consumers of the `dist-custom-elements` output target need to
+register each Stencil component that they want to use in the bundle manually.
+Setting this flag to `true` will add a call to the `defineCustomElement` helper
+function for each function to it's module, which will be called when it is
+exported.
 
 This flag defaults to `false` when omitted from a Stencil configuration file.
 
-> Note: At this time, components created not using JSX may not be automatically defined. This is a known limitation of the API and users should be aware of it
+> Note: At this time, components created not using JSX may not be automatically
+  defined. This is a known limitation of the API and users should be aware of
+  it
 
 ### generateTypeDeclarations
 

--- a/src/docs/output-targets/custom-elements.md
+++ b/src/docs/output-targets/custom-elements.md
@@ -43,9 +43,9 @@ customElements.define('hello-world', HelloWorld);
 
 By default, consumers of the `dist-custom-elements` output target need to
 register each Stencil component that they want to use in the bundle manually.
-Setting this flag to `true` will add a call to the `defineCustomElement` helper
-function for each function to it's module, which will be called when it is
-exported.
+Setting this flag to `true` will define a component automatically with the
+`CustomElementRegistry` when the component's module is imported. Note that this
+will also automatically recursively define any child components as well.
 
 This flag defaults to `false` when omitted from a Stencil configuration file.
 


### PR DESCRIPTION
The documentation for the `autoDefineCustomElements` wasn't _quite_
accurate. This clarifies that what the flag does right now for the
`dist-custom-elements` output target is basically add a call to the
module for each component for that components `defineCustomElement`
function.