### PR TITLE
docs(custom-elements): clarify distribution example

### DIFF
--- a/src/docs/output-targets/custom-elements.md
+++ b/src/docs/output-targets/custom-elements.md
@@ -101,8 +101,6 @@ Your component library can be easily distributed on NPM, similar to how [`@ionic
 
 To make the custom elements index the entry module for a package, set the `module` property in `package.json` to:
 
-Also be sure to set `@stencil/core` as a dependency of the package.
-
 ```tsx
 {
   "module": "dist/components/index.js",
@@ -114,6 +112,8 @@ Also be sure to set `@stencil/core` as a dependency of the package.
 ```
 
 Note: If you are distributing both the `dist` and `dist-custom-elements`, then it's up to you to choose which one of them should be available in the `module` entry.
+
+Be sure to set `@stencil/core` as a dependency of the package as well.
 
 Now you can publish your library to [Node Package Manager (NPM)](https://www.npmjs.com/). For more information about setting up the `package.json` file, and publishing, see: [Publishing Component Library To NPM](/docs/publishing).
 

--- a/src/docs/output-targets/custom-elements.md
+++ b/src/docs/output-targets/custom-elements.md
@@ -111,9 +111,10 @@ To make the custom elements index the entry module for a package, set the `modul
 }
 ```
 
-Note: If you are distributing both the `dist` and `dist-custom-elements`, then it's up to you to choose which one of them should be available in the `module` entry.
-
 Be sure to set `@stencil/core` as a dependency of the package as well.
+
+> Note: If you are distributing both the `dist` and `dist-custom-elements`, then it's up to you to choose which one of them should be available in the `module` entry.
+
 
 Now you can publish your library to [Node Package Manager (NPM)](https://www.npmjs.com/). For more information about setting up the `package.json` file, and publishing, see: [Publishing Component Library To NPM](/docs/publishing).
 


### PR DESCRIPTION
this commit moves a statement about adding `@stencil/core` as
a dependency in `package.json` down. otherwise, it looks like we're
missing an example

fixes: #885 