### PR TITLE
docs(output-targets): add vscode documentation

### DIFF
--- a/src/assets/docs-structure.json
+++ b/src/assets/docs-structure.json
@@ -248,6 +248,11 @@
         "url": "/docs/docs-custom"
       },
       {
+        "text": "docs-vscode",
+        "filePath": "/assets/docs/output-targets/docs-vscode.json",
+        "url": "/docs/docs-vscode"
+      },
+      {
         "text": "Copy Tasks",
         "filePath": "/assets/docs/output-targets/copy-tasks.json",
         "url": "/docs/copy-tasks"

--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -50,6 +50,7 @@
   * [docs-readme](output-targets/docs-readme.md)
   * [docs-json](output-targets/docs-json.md)
   * [docs-custom](output-targets/docs-custom.md)
+  * [docs-vscode](output-targets/docs-vscode.md)
   * [Copy Tasks](output-targets/copy-tasks.md)
 * Guides
   * [Assets](guides/assets.md)

--- a/src/docs/output-targets/docs-vscode.md
+++ b/src/docs/output-targets/docs-vscode.md
@@ -1,0 +1,66 @@
+---
+title: VSCode Documentation
+description: VSCode Documentation
+url: /docs/docs-vscode
+contributors:
+  - rwaskiewicz
+---
+
+# VSCode Documentation
+
+One of the core features of web components is the ability to create [custom elements](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements),
+which allow developers to reuse custom functionality defined in their components.
+When Stencil compiles a project, it generates a custom element for each component in the project.
+Each of these [custom elements has an associated `tag` name](/docs/component#component-options) that allows the custom
+element to be used in HTML files. 
+
+By default, integrated development environments (IDEs) like VS Code are not aware of a project's custom elements when
+authoring HTML.
+In order to enable more intelligent features in VS Code, such as auto-completion, hover tooltips, etc., developers
+need to inform it of their project's custom elements.
+
+The `docs-vscode` output target tells Stencil to generate a JSON file containing this information.
+
+This is an opt-in feature and will save a JSON file containing [custom data](https://github.com/microsoft/vscode-custom-data)
+in a directory specified by the output target.
+Once the feature is enabled and VS Code is informed of the JSON file's location, HTML files can gain code editing
+features similar to TSX files.
+
+## Enabling
+
+To generate custom element information for VS Code, add the `docs-vscode` output target to your `stencil.config.ts`:
+
+```tsx
+import { Config } from '@stencil/core';
+
+export const config: Config = {
+  outputTargets: [
+    { 
+        type: 'docs-vscode',
+        file: 'vscode-data.json',
+    }
+  ]
+};
+```
+
+where `file` is the name & location of the file to be generated. 
+By default, Stencil assumes that the file will be generated in the project's root directory.
+
+To generate the JSON file, have Stencil build your project.
+
+## Configuring VS Code
+
+Once the `docs-vscode` output target has been enabled and the JSON file generated, VS Code needs to be informed of it.
+
+Recent versions of VS Code have a settings option named `html.customData`, which resolves to a list of JSON files to
+use when augmenting the default list of HTML elements.
+Add the path to the generated JSON file for your project's types to be added: 
+
+```json
+{
+  "html.customData": [
+    "./vscode-data.json"
+  ]
+}
+```
+

--- a/src/docs/output-targets/docs-vscode.md
+++ b/src/docs/output-targets/docs-vscode.md
@@ -1,12 +1,12 @@
 ---
-title: VSCode Documentation
-description: VSCode Documentation
+title: VS Code Documentation
+description: VS Code Documentation
 url: /docs/docs-vscode
 contributors:
   - rwaskiewicz
 ---
 
-# VSCode Documentation
+# VS Code Documentation
 
 One of the core features of web components is the ability to create [custom elements](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements),
 which allow developers to reuse custom functionality defined in their components.

--- a/src/docs/output-targets/overview.md
+++ b/src/docs/output-targets/overview.md
@@ -5,6 +5,7 @@ url: /docs/output-targets
 contributors:
   - adamdbradley
   - manucorporat
+  - rwaskiewicz
 ---
 
 # Output Targets
@@ -21,6 +22,7 @@ One of the more powerful features of the compiler is its ability to generate var
  - [`docs-readme`: Documentation readme files formatted in markdown](/docs/docs-readme)
  - [`docs-json`: Documentation data formatted in JSON](/docs/docs-json)
  - [`docs-custom`: Custom documentation generation](/docs/docs-custom)
+ - [`docs-vscode`: Documentation generation for VS Code](/docs/docs-vscode)
 
 ## Example:
 


### PR DESCRIPTION
this commit adds the initial documentation for using the `docs-vscode`
output target