### PR TITLE
docs(docs-readme): update docs-readme description of alternative CLI flag

### DIFF
--- a/src/docs/output-targets/docs-readme.md
+++ b/src/docs/output-targets/docs-readme.md
@@ -27,11 +27,15 @@ export const config: Config = {
 };
 ```
 
-Another option would be to add the flag `--docs-readme`, such as:
+Another option would be to use the `--docs` CLI flag, like so:
 
 ```bash
-stencil build --docs-readme
+stencil build --docs
 ```
+
+This will cause the Stencil compiler to automatically add a `docs-readme`
+output target to your configuration, without having to save it in
+`stencil.config.ts`.
 
 ## Adding Custom Markdown to Auto-Generated Files
 

--- a/src/docs/output-targets/docs-readme.md
+++ b/src/docs/output-targets/docs-readme.md
@@ -33,10 +33,8 @@ Another option would be to use the `--docs` CLI flag, like so:
 stencil build --docs
 ```
 
-This will cause the Stencil compiler to automatically add a `docs-readme`
-output target to your configuration, without having to save it in
-`stencil.config.ts`.
-
+This will cause the Stencil compiler to perform a one-time generation of README
+files using the [`docs-readme`](https://stenciljs.com/docs/docs-readme) output target.
 ## Adding Custom Markdown to Auto-Generated Files
 
 Once you've generated a `readme.md` file you can customize it with your own markdown content. Simply add your own markdown above the comment that reads: `<!-- Auto Generated Below -->`.


### PR DESCRIPTION
The documentation is currently out of date, describing the use of a
`--docs-readme` CLI flag which Stencil does not support. However, the
`--docs` CLI flag does what the docs say that the `--docs-readme` flag
should do, so we can point the user towards that instead.

This was reported in ionic-team/stencil#3405

STENCIL-472