### PR TITLE
Add info about the files property in package.json

### DIFF
--- a/src/docs/guides/publishing.md
+++ b/src/docs/guides/publishing.md
@@ -48,6 +48,7 @@ An advantage to using the compiler is that it is able to provide help on how to 
 | `es2017`          | Commonly used by framework bundling.                                                       | `dist/esm/index.mjs`              |
 | `types`           | Entry file to the project's types.                                                         | `dist/types/components.d.ts`      |
 | `unpkg`           | Entry file for requests to the projects [unpkg](https://unpkg.com/) CDN.                   | `dist/{NAMESPACE}/{NAMESPACE}.js` |
+| `files`           | Array of files that should be included in a npm relese.                                    | `["dist/", "loader/"]`            |
 
 The `collection` properties are used to allow lazy loading in other Stencil applications.
 

--- a/src/docs/guides/publishing.md
+++ b/src/docs/guides/publishing.md
@@ -48,7 +48,7 @@ An advantage to using the compiler is that it is able to provide help on how to 
 | `es2017`          | Commonly used by framework bundling.                                                       | `dist/esm/index.mjs`              |
 | `types`           | Entry file to the project's types.                                                         | `dist/types/components.d.ts`      |
 | `unpkg`           | Entry file for requests to the projects [unpkg](https://unpkg.com/) CDN.                   | `dist/{NAMESPACE}/{NAMESPACE}.js` |
-| `files`           | Array of files that should be included in a npm relese.                                    | `["dist/", "loader/"]`            |
+| `files`           | Array of files that should be included in a npm release.                                    | `["dist/", "loader/"]`            |
 
 The `collection` properties are used to allow lazy loading in other Stencil applications.
 


### PR DESCRIPTION
Since we [don't recommend](https://stenciljs.com/docs/distribution) `dist` to be tracked by version control, but expose it in package.json, people like me who are new get confused at the first glance. So thought describing the `files` property will make it clear that though we don't add `dist` to version control, publish it to NPM.