### PR TITLE
docs(vue): update vue library bootstrapping

### DIFF
--- a/src/docs/framework-integration/vue.md
+++ b/src/docs/framework-integration/vue.md
@@ -96,11 +96,9 @@ lerna create vue-library
 # Follow the prompts and confirm
 cd packages/vue-library
 # Install Vue dependency
-npm install vue@3
-
+npm install vue@3 --save-dev
 # or if you are using yarn
 yarn add vue@3 --dev
-
 # Add the stencil-library dependency
 lerna add stencil-library
 # or if you are using other monorepo tools, install your Stencil library as a dependency

--- a/src/docs/framework-integration/vue.md
+++ b/src/docs/framework-integration/vue.md
@@ -96,9 +96,11 @@ lerna create vue-library
 # Follow the prompts and confirm
 cd packages/vue-library
 # Install Vue dependency
-npm install vue@3 --save-dev
+npm install vue@3
+
 # or if you are using yarn
 yarn add vue@3 --dev
+
 # Add the stencil-library dependency
 lerna add stencil-library
 # or if you are using other monorepo tools, install your Stencil library as a dependency
@@ -158,6 +160,8 @@ Update your `package.json`, adding the following options to the existing config:
 
 ```diff
 {
+-  "main": "lib/vue-library.js",
++  "main": "lib/index.js",
 +  "types": "lib/index.d.ts",
   "scripts": {
 -    "test": "echo \"Error: run tests from root\" && exit 1"


### PR DESCRIPTION
this commit adds an additional change to the bootstrapping process
of a user's vue library, to ensure that the `main` field in `package.json`
is set to `lib/index.js`.

the reason for this change is that when users run `lerna create PROJ-NAME`,
by default, the `main` field takes on the value of 'PROJ-NAME', which isn't the
entrypoint we want folks to be using (I don't think)