### PR TITLE
docs(react): update supported react version to 16.7

### DIFF
--- a/src/docs/framework-integration/react.md
+++ b/src/docs/framework-integration/react.md
@@ -15,7 +15,7 @@ contributors:
 
 # React Integration
 
-**Support: React v17+ • TypeScript 3.7+ • Stencil v2.9.0+**
+**Support: React v16.7+ • TypeScript 3.7+ • Stencil v2.9.0+**
 
 Stencil provides a wrapper for your custom elements to be used as first-class React components. The goal of a wrapper is to easily integrate your Stencil components into a specific framework. Wrappers provide a function that you can use within Stencil’s Output Targets to automatically create components for the targeted framework that wrap the web components you create in a Stencil project.
 

--- a/src/docs/framework-integration/react.md
+++ b/src/docs/framework-integration/react.md
@@ -15,7 +15,7 @@ contributors:
 
 # React Integration
 
-**Support: React v16.7+ • TypeScript 3.7+ • Stencil v2.9.0+**
+**Supports: React v16.7+ • TypeScript 3.7+ • Stencil v2.9.0+**
 
 Stencil provides a wrapper for your custom elements to be used as first-class React components. The goal of a wrapper is to easily integrate your Stencil components into a specific framework. Wrappers provide a function that you can use within Stencil’s Output Targets to automatically create components for the targeted framework that wrap the web components you create in a Stencil project.
 


### PR DESCRIPTION
this commit updates the supported version of react to
v16.7.0. our current framework wrapper implementation 
declares a minimum of v16.7.0 (https://github.com/ionic-team/stencil-ds-output-targets/blob/bc8878f5ccd1890ec378a57f8e69a44b15213102/packages/react-output-target/package.json#L39-L43).
this commit aligns the dependencies of the framework wrapper
and the documentation.