### PR TITLE
Docs/v3 default flag values

### DIFF
--- a/src/docs/config/overview.md
+++ b/src/docs/config/overview.md
@@ -180,9 +180,9 @@ Will generate the following comment:
 
 ## sourceMap
 
-*default: `false`*
+*default: `true`*
 
-When set to `true`, sourcemaps will be generated for a project.
+When set to `false`, sourcemaps will not be generated for a project.
 
 ```tsx
 sourceMap: true
@@ -200,8 +200,6 @@ compared to the minified result produced when `sourceMap` is not enabled.
 
 Developers are responsible for determining whether or not they choose to serve sourcemaps in each environment their
 components are served and implementing their decision accordingly.
-
-When omitted or set to `false`, sourcemaps will not be generated.
 
 ## srcDir
 

--- a/src/docs/config/overview.md
+++ b/src/docs/config/overview.md
@@ -182,10 +182,11 @@ Will generate the following comment:
 
 *default: `true`*
 
-When set to `false`, sourcemaps will not be generated for a project.
+When omitted or set to `true`, sourcemaps will be generated for a project.
+When set to `false`, sourcemaps will not be generated.
 
 ```tsx
-sourceMap: true
+sourceMap: true | false
 ```
 
 Sourcemaps create a translation between Stencil components that are written in TypeScript/JSX and the resulting 

--- a/src/docs/output-targets/custom-elements.md
+++ b/src/docs/output-targets/custom-elements.md
@@ -71,7 +71,7 @@ This flag defaults to `false` when omitted from a Stencil configuration file.
 
 ### generateTypeDeclarations
 
-By default, Stencil will generate type declaration files (`.d.ts` files) as a part of the `dist-custom-elements` output target through the `generateTypeDeclarations` field on the target options. Type declaration files will be placed in the `dist/types` directory in the root of a Stencil project At this time, this output destination is not able to be configured.
+By default, Stencil will generate type declaration files (`.d.ts` files) as a part of the `dist-custom-elements` output target through the `generateTypeDeclarations` field on the target options. Type declaration files will be placed in the `dist/types` directory in the root of a Stencil project. At this time, this output destination is not able to be configured.
 
 Setting this flag to `false` will not generate type declaration files for the `dist-custom-elements` output target.
 

--- a/src/docs/output-targets/custom-elements.md
+++ b/src/docs/output-targets/custom-elements.md
@@ -71,17 +71,11 @@ This flag defaults to `false` when omitted from a Stencil configuration file.
 
 ### generateTypeDeclarations
 
-By default, type declaration files (`.d.ts` files) are only generated for the `dist-custom-elements` output target when
-the [`dist` output target](/docs/distribution) is also declared in a Stencil project's configuration. This behavior
-isn't always desirable, as not all users need the files emitted by the `dist` output target. To generate type
-declaration files for the `dist-custom-elements`, the experimental `generateTypeDeclarations` field can be set to 
-`true`.
+By default, Stencil will generate type declaration files (`.d.ts` files) as a part of the `dist-custom-elements` output target through the `generateTypeDeclarations` field on the target options. Type declaration files will be placed in the `dist/types` directory in the root of a Stencil project At this time, this output destination is not able to be configured.
 
-Setting this flag to `true` will generate type declaration files for the `dist-custom-elements` output target. Type
-declaration files will be placed in the `dist/types` directory in the root of a Stencil project. At this time, this
-output destination is not able to be configured.
+Setting this flag to `false` will not generate type declaration files for the `dist-custom-elements` output target.
 
-This flag defaults to `false` when omitted from a Stencil configuration file.
+This flag defaults to `true` when omitted from a Stencil configuration file.
 
 ## Making Assets Available
 


### PR DESCRIPTION
- Updates docs around config `sourceMaps` flag to callout new V3 default as `true`
- Updates docs around `dist-custom-elements` to default `generateTypeDeclarations` to `true` in V3