### PR TITLE
docs(styles): update references to css plugins

### DIFF
--- a/src/docs/config/plugins.md
+++ b/src/docs/config/plugins.md
@@ -48,10 +48,10 @@ export const config = {
 
 ### Related Plugins
 
-- [@stencil/less](https://www.npmjs.com/package/@stencil/less)
-- [@stencil/postcss](https://www.npmjs.com/package/@stencil/postcss)
 - [@stencil/sass](https://www.npmjs.com/package/@stencil/sass)
-- [@stencil/stylus](https://www.npmjs.com/package/@stencil/stylus)
+- [@stencil-community/postcss](https://www.npmjs.com/package/@stencil-community/postcss)
+- (Deprecated) [@stencil/less](https://www.npmjs.com/package/@stencil/less)
+- (Deprecated) [@stencil/stylus](https://www.npmjs.com/package/@stencil/stylus)
 
 
 ## Node Polyfills


### PR DESCRIPTION
**Do not merge - I need to complete the postcss migration first **
# Desc
this commit updates the urls/names of various stencil-related css
plugins. specifically, it is a result of our investigation as to how to
handle moving css packages to the community (or archive them) as a part
of stencil-478.

in this commit:
- @stencil/postcss is renamed to @stencil-community/postcss to signify
  moving that package to the community
- @stencil/less and @stencil/stylus are marked as deprecated, as there
  was no interest in maintaining them from our call to action