### PR TITLE
docs(blog): redirect on blog/

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -6,7 +6,7 @@
       "statusCode": 301
     },
     {
-      "source": "/blog/:path*",
+      "source": "/blog/:path*(/)?",
       "destination": "https://ionicframework.com/blog/tag/stencil/",
       "statusCode": 301
     },


### PR DESCRIPTION
this commit updates the redirect for https://stenciljs.com/blog/ (note the
trailing slash) to redirect to the Ionic blog.

STENCIL-287: Fixup Blog Redirect