### PR TITLE
docs(support): add typescript 4.7 to table

### DIFF
--- a/src/docs/reference/support-policy.md
+++ b/src/docs/reference/support-policy.md
@@ -74,6 +74,7 @@ The table below describes recent versions of Stencil and the version of TypeScri
 
 | Stencil Version | TypeScript Version |
 |:---------------:|:------------------:|
+|     v2.18.0     |       v4.7.4       |
 |     v2.14.0     |       v4.5.4       |
 |     v2.10.0     |       v4.3.5       |
 |     v2.5.0      |       v4.2.3       |


### PR DESCRIPTION
this commit adds a row to the typescript support table to specify the
update to typescript 4.7 in an upcoming version of stencil. see
ionic-team/stencil/pull/3530 for the implementation

STENCIL-435: Upgrade TypeScript to v4.7

tested locally to verify the table was still properly formatted:
![Screen Shot 2022-08-18 at 5 07 06 PM](https://user-images.githubusercontent.com/1930213/185495469-d22a9f2f-214c-4e7d-956d-4165ffe1edd3.png)

