### PR TITLE
docs(angular-output-target): update path for proxy output

### DIFF
--- a/src/docs/framework-integration/angular.md
+++ b/src/docs/framework-integration/angular.md
@@ -91,8 +91,8 @@ export const config: Config = {
   outputTargets: [
     angularOutputTarget({
       componentCorePackage: 'your-stencil-library-package-name',
-      directivesProxyFile: '../angular-workspace/projects/component-library/src/lib/stencil-generated/components.ts',
-      directivesArrayFile: '../angular-workspace/projects/component-library/src/lib/stencil-generated/index.ts',
+      directivesProxyFile: '../projects/component-library/src/lib/stencil-generated/components.ts',
+      directivesArrayFile: '../projects/component-library/src/lib/stencil-generated/index.ts',
     }),
   ],
 };


### PR DESCRIPTION
Fixes the relative path for generating the proxy files.

The project directory structure is:
```
angular-workspace/
  projects/
    component-lib/src/lib/stencil-generated/
  stencil-library/
    stencil.config.ts
```

When generating the proxies (from the Stencil library) it only needs to move one directory up and into the `projects/` directory. Currently it is writing to:

```
angular-workspace/
  angular-workspace/
    projects/
      component-lib/src/lib/stencil-generated/
```