### PR TITLE
docs(angular): generating single component angular modules

### DIFF
--- a/src/docs/framework-integration/angular.md
+++ b/src/docs/framework-integration/angular.md
@@ -295,6 +295,8 @@ The relative or absolute path to the file that will contain all of the generated
 
 If `true`, Angular modules will be generated for each Stencil component included in the compilation process. When using this option, library maintainers should export the entire contents of the `proxyDeclarationFile` from the entry point of their library.
 
+Single component Angular modules (SCAM) are a convention in the Angular community of having a single component declared and exported on an Angular module. This allows Angular's treeshaking to eliminate unused components and modules from the bundle and leads to reduced coupling and bundle sizes.
+
 ### includeImportCustomElements
 
 If `true`, Angular components will import and define elements from the `dist-custom-elements` build, rather than `dist`.

--- a/src/docs/framework-integration/angular.md
+++ b/src/docs/framework-integration/angular.md
@@ -285,9 +285,11 @@ The title of the Stencil package where components are available for consumers. T
 import { IonApp } from '@ionic/core/components/ion-app.js';
 ```
 
-### proxyDeclarationFile
+### proxyDeclarationFile (previously `directivesProxyFile`)
 
 The relative or absolute path to the file that will contain all of the generated component wrapper definitions and optionally Angular modules during the compilation process. This file should be either exported to the consumers of your library or directly referenced in your entry point module of the library.
+
+> In `@stencil/angular-output-target@0.5.0` `directivesProxyFile` was replaced with `proxyDeclarationFile`.
 
 ### createSingleComponentAngularModules
 

--- a/src/docs/framework-integration/angular.md
+++ b/src/docs/framework-integration/angular.md
@@ -285,7 +285,7 @@ The title of the Stencil package where components are available for consumers. T
 import { IonApp } from '@ionic/core/components/ion-app.js';
 ```
 
-### proxyDeclarationFile (previously `directivesProxyFile`)
+### proxyDeclarationFile
 
 The relative or absolute path to the file that will contain all of the generated component wrapper definitions and optionally Angular modules during the compilation process. This file should be either exported to the consumers of your library or directly referenced in your entry point module of the library.
 


### PR DESCRIPTION
Updates the documentation of the resulting refactoring and feature behind single component Angular module generation. 

Link to the modified doc page: https://stencil-site-git-docs-angular-scam-ionic1.vercel.app/docs/angular