### PR TITLE
docs(output-targets): update dist-custom-elements docs

### DIFF
--- a/src/docs/config/overview.md
+++ b/src/docs/config/overview.md
@@ -48,6 +48,9 @@ bundles: [
 ]
 ```
 
+## devServer
+
+Please see the [Dev-Server docs](/docs/dev-server).
 
 ## enableCache
 
@@ -59,6 +62,9 @@ Stencil will cache build results in order to speed up rebuilds. To disable this 
 enableCache: true
 ```
 
+## extras
+
+Please see the [Extras docs](/docs/config-extras).
 
 ## globalScript
 
@@ -99,14 +105,14 @@ globalStyle: 'src/global/app.css'
 
 Check out the [styling docs](/docs/styling#global-styles) of how to use global styles in your app.
 
-## invisiblePrehydration
+## hashedFileNameLength
 
-*default: `true`*
+*default: `8`*
 
-When true, `invisiblePrehydration` will use Ionic's opinion to visually hide components before they are hydrated by adding an automatically injected style tag to the document's head. Setting `invisiblePrehydration` to `false` will not inject the style tag into the head, allowing you to style your web components pre-hydration. Please note that setting `invisiblePrehydration` to false will cause everything to be visible when your page is loaded, causing more prominent Flash of Unstyled Content (FOUC), however you can style your web component's fallback content to your preference.
+When the `hashFileNames` config is set to `true`, and it is a production build, the `hashedFileNameLength` config is used to determine how many characters the file name's hash should be.
 
 ```tsx
-invisiblePrehydration: true
+hashedFileNameLength: 8
 ```
 
 ## hashFileNames
@@ -119,17 +125,29 @@ During production builds, the content of each generated file is hashed to repres
 hashFileNames: true
 ```
 
+## invisiblePrehydration
 
-## hashedFileNameLength
+*default: `true`*
 
-*default: `8`*
+When `true`, `invisiblePrehydration` will visually hide components before they are hydrated by adding an automatically injected style tag to the document's head. Setting `invisiblePrehydration` to `false` will not inject the style tag into the head, allowing you to style your web components pre-hydration. 
 
-When the `hashFileNames` config is set to `true`, and it is a production build, the `hashedFileNameLength` config is used to determine how many characters the file name's hash should be.
+> Note: Setting `invisiblePrehydration` to `false` will cause everything to be visible when your page is loaded, causing a more prominent Flash of Unstyled Content (FOUC). However, you can style your web component's fallback content to your preference.
 
 ```tsx
-hashedFileNameLength: 8
+invisiblePrehydration: true
 ```
 
+## minifyCss
+
+_default: `true` in production_
+
+When `true`, the browser CSS file will be minified.
+
+## minifyJs
+
+_default: `true` in production_
+
+When `true`, the browser JS files will be minified. Stencil uses [Terser](https://terser.org/) under-the-hood for file minification.
 
 ## namespace
 
@@ -140,22 +158,13 @@ The `namespace` config is a `string` representing a namespace for the app. For a
 ```tsx
 namespace: "Ionic"
 ```
-
-
 ## outputTargets
 
 Please see the [Output Target docs](/docs/output-targets).
 
-
 ## plugins
 
 Please see the [Plugin docs](/docs/plugins).
-
-
-## devServer
-
-Please see the [Dev-Server docs](/docs/dev-server).
-
 
 ## preamble
 
@@ -212,7 +221,6 @@ The `srcDir` config specifies the directory which should contain the source type
 srcDir: 'src'
 ```
 
-
 ## taskQueue
 
 *default: `async`*
@@ -250,8 +258,3 @@ taskQueue: 'async'
 ## testing
 
 Please see the [testing config docs](/docs/testing-config).
-
-
-## extras
-
-Please see the [Extras docs](/docs/config-extras).

--- a/src/docs/output-targets/custom-elements.md
+++ b/src/docs/output-targets/custom-elements.md
@@ -11,9 +11,9 @@ contributors:
 
 # Custom Elements
 
-The `dist-custom-elements` output target is used to generate custom elements in a more optimized way for tree shaking, and it's the recommended approach when using any frontend framework integrations.
+The `dist-custom-elements` output target is used to generate custom elements in a more optimized way for tree shaking, and it's the recommended approach when using any frontend framework integrations. This output target creates custom elements that directly extend `HTMLElement` and provides simple utility functions for easily defining these elements on the [Custom Element Registry](https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry). As stated, this output target excels in use in frontend frameworks and projects that will handle bundling, lazy-loading, and custom element registration themselves.
 
-This target can be used outside of frameworks as well, if lazy-loading functionality is not required or desired. For using lazily loaded Stencil components, please refer to the [www output target](/docs/www).
+This target can be used outside of frameworks as well, if lazy-loading functionality is not required or desired. For using lazily loaded Stencil components, please refer to the [dist output target](/docs/distribution).
 
 To generate components using the `dist-custom-elements` output target, add it to a project's `stencil.config.ts` file like so:
 
@@ -47,7 +47,7 @@ _default: `'default'`_
 
 By default, the `dist-custom-elements` output target generates a single file per component, and exports each of those files individually.
 
-In some cases, library authors may want to change this behavior, either to automatically define component children, provide a single file containing all component exports, etc.
+In some cases, library authors may want to change this behavior, for instance to automatically define component children, provide a single file containing all component exports, etc.
 
 This config option provides additional behaviors that will alter the default component export _OR_ custom element definition behaviors
 for this target. The desired behavior can be set via the following in a project's Stencil config:
@@ -86,13 +86,13 @@ This config option allows you to change the output directory where the compiled 
 
 _default: `true`_
 
-If `true`, this config option will remove the contents of the [output directory](#dir) between builds.
+Setting this flag to `true` will remove the contents of the [output directory](#dir) between builds.
 
 ### externalRuntime
 
 _default: `true`_
 
-When `true`, this flag results in the following behaviors:
+Setting this flag to `true` results in the following behaviors:
 
 1. Minification will follow what is specified in the [Stencil config](docs/config#minifyJs).
 2. Filenames will not be hashed
@@ -106,7 +106,7 @@ By default, Stencil will generate type declaration files (`.d.ts` files) as a pa
 
 Setting this flag to `false` will not generate type declaration files for the `dist-custom-elements` output target.
 
-> When set to generate type declarations, Stencil respects the export behavior selected via `customElementsExportBehavior` and generates type declarations specific to the content of the generated `component.d.ts` file.
+> When set to generate type declarations, Stencil respects the export behavior selected via `customElementsExportBehavior` and generates type declarations specific to the content of the generated [output directory's](#dir) `index.js` file.
 
 ### inlineDynamicImports
 
@@ -325,7 +325,7 @@ export default {
 };
 ```
 
-<!-- TODO: remove once custom elements bundle is officially not supported -->
+<!-- TODO(STENCIL-561): remove once custom elements bundle is officially not supported -->
 
 ## How is this different from the "dist" and the "dist-custom-element-bundle" output targets?
 

--- a/src/docs/output-targets/custom-elements.md
+++ b/src/docs/output-targets/custom-elements.md
@@ -11,7 +11,7 @@ contributors:
 
 # Custom Elements
 
-The `dist-custom-elements` output target is used to generate custom elements in a more optimized way for tree shaking, and it's the recommended approach when using any frontend framework integrations. This output target creates custom elements that directly extend `HTMLElement` and provides simple utility functions for easily defining these elements on the [Custom Element Registry](https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry). As stated, this output target excels in use in frontend frameworks and projects that will handle bundling, lazy-loading, and custom element registration themselves.
+The `dist-custom-elements` output target creates custom elements that directly extend `HTMLElement` and provides simple utility functions for easily defining these elements on the [Custom Element Registry](https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry). This output target excels in use in frontend frameworks and projects that will handle bundling, lazy-loading, and custom element registration themselves.
 
 This target can be used outside of frameworks as well, if lazy-loading functionality is not required or desired. For using lazily loaded Stencil components, please refer to the [dist output target](/docs/distribution).
 


### PR DESCRIPTION
This commit rewrites and restructures portions of the dist-custom-elements output target docs. Additional config options are documented, and more context for when/how to use the target has been added.