### PR TITLE
docs(docs-custom): add overview field

### DIFF
--- a/src/docs/output-targets/docs-custom.md
+++ b/src/docs/output-targets/docs-custom.md
@@ -62,8 +62,9 @@ The generated docs JSON data will in the type of `JsonDocs` which consists of ma
 | `encapsulation`    | Component `encapsulation` type. Possible values are `shadow`, `scoped`, `none`  |
 | `tag`    | Component tag described in `.tsx` file  |
 | `readme`    | Component readme file first line content  |
-| `docs`    | Description written in top of `@Component` e.g. /**  Documentation Example */ |
+| `docs`    | Description written in top of `@Component` e.g. /**  Documentation Example */. If no JSDoc is present, default to any manually written text in the component's markdown file. Empty otherwise. |
 | `docsTags`    | Annotations (In the way of JSDoc ) written in `.tsx` file will be collected here   |
+| `overview`    | Description written in top of `@Component` e.g. /**  Documentation Example */ |
 | `usage`    |    |
 | `props`    | Array of component properties information   |
 | `methods`    | Array of component methods information   |


### PR DESCRIPTION
this commit adds the 'overview' field on the `JsonDocsComponent` model, introduced in https://github.com/ionic-team/stencil/pull/3766. it also updates the description of the 'docs' field in the same model to better reflect its functionality
![Screen Shot 2022-10-25 at 1 43 27 PM](https://user-images.githubusercontent.com/1930213/197845040-79b31f13-3c50-414e-8125-edbf4df7c2d1.png)

