### PR TITLE
docs(typescript): add v4.8.4 to ts support table

### DIFF
--- a/src/docs/reference/support-policy.md
+++ b/src/docs/reference/support-policy.md
@@ -74,6 +74,7 @@ The table below describes recent versions of Stencil and the version of TypeScri
 
 | Stencil Version | TypeScript Version |
 |:---------------:|:------------------:|
+|     v2.20.0     |       v4.8.4       |
 |     v2.18.0     |       v4.7.4       |
 |     v2.14.0     |       v4.5.4       |
 |     v2.10.0     |       v4.3.5       |


### PR DESCRIPTION
this commit updates the typescript/stencil support table to account for typescript v4.8.4 support.

this commit is dependent on https://github.com/ionic-team/stencil/pull/3743

![Screen Shot 2022-11-16 at 8 58 19 AM](https://user-images.githubusercontent.com/1930213/202199968-cbcc5305-c89b-4005-b2eb-7185c43bd8d1.png)
