### PR TITLE
docs(upgrade): add v3 alpha note

### DIFF
--- a/src/docs/introduction/upgrading-to-stencil-three.md
+++ b/src/docs/introduction/upgrading-to-stencil-three.md
@@ -8,6 +8,8 @@ contributors:
 
 # Upgrading to Stencil v3.0.0
 
+> Stencil 3.0.0 is still in alpha. These instructions are for users looking to try an early version of the software
+
 ## Getting Started
 
 It's recommended that your projects start their upgrade from Stencil v2.


### PR DESCRIPTION
this commit adds a note to the documentation stating that v3.0.0 is still a work in progress, to avoid confusion should someone stumble upon this page