### PR TITLE
docs(helmet): deprecate stencil helmet 

### DIFF
--- a/src/docs/static-site-generation/meta.md
+++ b/src/docs/static-site-generation/meta.md
@@ -15,7 +15,7 @@ Web Apps need to list detailed meta information about content in order to maximi
 One of the benefits to Stencil's prerendering is that most DOM apis are available in the NodeJS environment too.
 For example, to set the document title, simply run `document.title = "Page Title"`.
 Similarly, meta tags can be set using standard DOM APIs as found in the browser, such as `document.head` and `document.createElement('meta')`.
-This mean your components runtime may already be able to do much of the custom work throughout prerendering.
+For this reason, your component's runtime can take care of much of this custom work during prerendering.
 
 That said, the Prerender Config also comes with many options that allows individual pages to be modified.
 For example, the `afterHydrate(document, url)` hook can be used to update the parsed `document`, before it is serialized into an HTML string.

--- a/src/docs/static-site-generation/meta.md
+++ b/src/docs/static-site-generation/meta.md
@@ -12,9 +12,14 @@ contributors:
 
 Web Apps need to list detailed meta information about content in order to maximize SEO and provide good social media embed experiences.
 
-One of the benefits to Stencil's prerendering is that most DOM apis are available in the NodeJS environment too. For example, to set the document title, simply run `document.title = "Page Title"`. Or meta tags can be added and updated no differently than using the usual DOM APIs found in the browser, such as `document.head` and `document.createElement('meta')`. This mean your components runtime may already be able to do much of the custom work throughout prerendering.
+One of the benefits to Stencil's prerendering is that most DOM apis are available in the NodeJS environment too.
+For example, to set the document title, simply run `document.title = "Page Title"`.
+Or meta tags can be added and updated no differently than using the usual DOM APIs found in the browser, such as `document.head` and `document.createElement('meta')`.
+This mean your components runtime may already be able to do much of the custom work throughout prerendering.
 
-That said, the Prerender Config also comes with many options that allows individual pages to be modified. For example, the `afterHydrate(document, url)` hook can be used to update the parsed `document`, before it is serialized into an HTML string. The `document` argument can be used no different than the `document` found in a webpage, and the `url` argument is a `URL` location of the page being rendered.
+That said, the Prerender Config also comes with many options that allows individual pages to be modified.
+For example, the `afterHydrate(document, url)` hook can be used to update the parsed `document`, before it is serialized into an HTML string.
+The `document` argument can be used no different from the `document` found in a webpage, and the `url` argument is a `URL` location of the page being rendered.
 
 In the example below, the `afterHydrate(document, url)` hook is setting the document title from url's pathname.
 

--- a/src/docs/static-site-generation/meta.md
+++ b/src/docs/static-site-generation/meta.md
@@ -17,7 +17,7 @@ For example, to set the document title, simply run `document.title = "Page Title
 Similarly, meta tags can be set using standard DOM APIs as found in the browser, such as `document.head` and `document.createElement('meta')`.
 For this reason, your component's runtime can take care of much of this custom work during prerendering.
 
-That said, the Prerender Config also comes with many options that allows individual pages to be modified.
+That said, the Prerender Config also includes options that allow individual pages to be modified arbitrarily during prerendering.
 For example, the `afterHydrate(document, url)` hook can be used to update the parsed `document`, before it is serialized into an HTML string.
 The `document` argument can be used no different from the `document` found in a webpage, and the `url` argument is a `URL` location of the page being rendered.
 

--- a/src/docs/static-site-generation/meta.md
+++ b/src/docs/static-site-generation/meta.md
@@ -5,6 +5,7 @@ url: /docs/static-site-generation-meta-tags
 contributors:
   - mlynch
   - adamdbradley
+  - rwaskiewicz
 ---
 
 # SEO Meta Tags and Static Site Generation
@@ -29,42 +30,6 @@ export const config: PrerenderConfig = {
 
 ## @stencil/helmet
 
-When building a static site with Stencil, managing meta tags dynamically can be made easier by using the `@stencil/helmet` package.
-
-To start, install the package:
-
-```bash
-npm install --save-dev @stencil/helmet
-```
-
-Then, to update meta tags in the `<head>` of the document, use the `<Helmet>` function component:
-
-```typescript
-import Helmet from '@stencil/helmet';
-
-const MyComponent = ({ title, description }: Props) => (
-  <Helmet>
-    <title>{title}</title>
-    <meta name="description" content={description} />
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:site" content="..." />
-    <meta name="twitter:creator" content="..." />
-    <meta name="twitter:title" content={title} />
-    <meta name="twitter:description" content={description} />
-    <meta name="twitter:image" content="..." />
-
-    <meta property="fb:page_id" content="..." />
-    <meta property="og:url" content="..." />
-    <meta property="og:type" content="..." />
-    <meta property="og:title" content="..." />
-
-    <meta property="og:image" content="..." />
-    <meta property="og:description" content="..." />
-    <meta property="og:site_name" content="..." />
-    <meta property="article:publisher" content="..." />
-    <meta property="og:locale" content="..." />
-  </Helmet>
-)
-```
-
-Use this on any component that is visible and the meta tags in `<head>` will be updated.
+The `@stencil/helmet` package was a library for managing meta tags dynamically.
+It has since been deprecated.
+For additional information regarding this package, please see its [GitHub page](https://github.com/ionic-team/stencil-helmet) 

--- a/src/docs/static-site-generation/meta.md
+++ b/src/docs/static-site-generation/meta.md
@@ -19,7 +19,7 @@ For this reason, your component's runtime can take care of much of this custom w
 
 That said, the Prerender Config also includes options that allow individual pages to be modified arbitrarily during prerendering.
 For example, the `afterHydrate(document, url)` hook can be used to update the parsed `document` before it is serialized into an HTML string.
-The `document` argument can be used no different from the `document` found in a webpage, and the `url` argument is a `URL` location of the page being rendered.
+The `document` argument is a [standard `Document`](https://developer.mozilla.org/en-US/docs/Web/API/Document), while the `url` argument is a [`URL`](https://developer.mozilla.org/en-US/docs/Web/API/URL) for the location of the page being rendered.
 
 In the example below, the `afterHydrate(document, url)` hook is setting the document title from url's pathname.
 

--- a/src/docs/static-site-generation/meta.md
+++ b/src/docs/static-site-generation/meta.md
@@ -14,7 +14,7 @@ Web Apps need to list detailed meta information about content in order to maximi
 
 One of the benefits to Stencil's prerendering is that most DOM apis are available in the NodeJS environment too.
 For example, to set the document title, simply run `document.title = "Page Title"`.
-Or meta tags can be added and updated no differently than using the usual DOM APIs found in the browser, such as `document.head` and `document.createElement('meta')`.
+Similarly, meta tags can be set using standard DOM APIs as found in the browser, such as `document.head` and `document.createElement('meta')`.
 This mean your components runtime may already be able to do much of the custom work throughout prerendering.
 
 That said, the Prerender Config also comes with many options that allows individual pages to be modified.

--- a/src/docs/static-site-generation/meta.md
+++ b/src/docs/static-site-generation/meta.md
@@ -18,7 +18,7 @@ Similarly, meta tags can be set using standard DOM APIs as found in the browser,
 For this reason, your component's runtime can take care of much of this custom work during prerendering.
 
 That said, the Prerender Config also includes options that allow individual pages to be modified arbitrarily during prerendering.
-For example, the `afterHydrate(document, url)` hook can be used to update the parsed `document`, before it is serialized into an HTML string.
+For example, the `afterHydrate(document, url)` hook can be used to update the parsed `document` before it is serialized into an HTML string.
 The `document` argument can be used no different from the `document` found in a webpage, and the `url` argument is a `URL` location of the page being rendered.
 
 In the example below, the `afterHydrate(document, url)` hook is setting the document title from url's pathname.


### PR DESCRIPTION
this commit designates stencil helmet as deprecated. since links to this
section of the docs may still exist, in conjunction with the fact that
vercel does not allow redirects using anchor tags, we keep the section
in the docs, but link to the github page (which will soon see the
project marked as deprecated)

newlines were added to the markdown to improve "readability" of the
page. (although that word leaves a sour taste in my mouth)

