### PR TITLE
docs(support): add typescript 4.9 to support table 

### DIFF
--- a/src/docs/reference/support-policy.md
+++ b/src/docs/reference/support-policy.md
@@ -74,6 +74,7 @@ The table below describes recent versions of Stencil and the version of TypeScri
 
 | Stencil Version | TypeScript Version |
 |:---------------:|:------------------:|
+|     v2.21.0     |       v4.9.3       |
 |     v2.20.0     |       v4.8.4       |
 |     v2.18.0     |       v4.7.4       |
 |     v2.14.0     |       v4.5.4       |


### PR DESCRIPTION
this commit adds typescript 4.9 to the support table

~this PR has the commit for TS 4.8 support in it as well. I built this branch atop #934, to avoid merge conflicts in the future. this first commit will be gone on Monday after I merge the 4.8 PR.~ rebased following the v2.20 release
