### PR TITLE
docs(v3-upgrade): update npm tag for v3 prereleases

### DIFF
--- a/src/docs/introduction/upgrading-to-stencil-three.md
+++ b/src/docs/introduction/upgrading-to-stencil-three.md
@@ -20,7 +20,7 @@ For breaking changes introduced in previous major versions of the library, see:
 
 For projects that are on Stencil v2, install the latest version of Stencil v3:
 ```bash
-npm install @stencil/core@3
+npm install @stencil/core@v3-next
 ```
 
 ## Updating Your Code


### PR DESCRIPTION
this commit updates the upgrade guide for the v2 version of the site. specifically, it changes the `npm install` scripts in the 'Getting Started' section to use teh `v3-next` tag, rather than a semver compliant version (`3`). we do this as v3 has not been officially released, making the script useless.

instead, we use an intentionally vague tag number that allows the dev team to update v3-next behind the scenes (from v3.0.0-alpha.0 to v3.0.0-alpha.1, etc.) without having to change the documentation for every release