### PR TITLE
docs(breaking_changes): port puppeteer 19 support to v2 site

### DIFF
--- a/src/docs/introduction/upgrading-to-stencil-three.md
+++ b/src/docs/introduction/upgrading-to-stencil-three.md
@@ -283,12 +283,12 @@ Replace all instances of `addDestory` with `addDestroy` and all instances of `re
 The functionality of these methods remains the same.
 
 ## End-to-End Testing
-### Puppeteer v10 Required
+### Puppeteer v10+ Required
 Versions of Puppeteer prior to Puppeteer version 10 are no longer supported.
 In newer versions of Puppeteer, the library provides its own types, making `@types/puppeteer` no longer necessary.
-Ensure that Puppeteer v10 is installed, and that its typings are not:
+Ensure that Puppeteer v10 or higher is installed, and that its typings are not:
 ```bash
-$ npm install puppeteer@10
+$ npm install puppeteer
 $ npm uninstall @types/puppeteer
 ```
 


### PR DESCRIPTION
this commit ports the documentation changes from https://github.com/ionic-team/stencil/pull/3810 (https://github.com/ionic-team/stencil/commit/22c74241ebb471123680d6629d7fa9c17b86c897) to the v2 version of the stencil site