### PR TITLE
docs(v3-upgrade): add note about deprecating fields in extras

### DIFF
--- a/src/docs/introduction/upgrading-to-stencil-three.md
+++ b/src/docs/introduction/upgrading-to-stencil-three.md
@@ -87,6 +87,25 @@ export const config: Config = {
 };
 ```
 
+#### `shadowDomShim`
+
+If `extras.shadowDomShim` is set to `true` the Stencil runtime will check
+whether a shim for [shadow
+DOM](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM)
+is needed in the current browser, and include one if so. For Stencil v3.0.0
+this field is renamed to `__deprecated__shadowDomShim`. To retain the previous
+behavior the new option can be set in your project's `stencil.config.ts`:
+
+```ts
+// stencil.config.ts
+import { Config } from '@stencil/core';
+export const config: Config = {
+  extras: {
+    __deprecated__shadowDomShim: true
+  }
+};
+```
+
 ### Deprecated `assetsDir` Removed from `@Component()` decorator
 The `assetsDir` field was [deprecated in Stencil v2.0.0](https://github.com/ionic-team/stencil/blob/main/BREAKING_CHANGES.md#componentassetsdir), but some backwards compatibility was retained with a warning message.
 It has been fully removed in Stencil v3.0.0 in favor of `assetsDirs`.

--- a/src/docs/introduction/upgrading-to-stencil-three.md
+++ b/src/docs/introduction/upgrading-to-stencil-three.md
@@ -106,6 +106,24 @@ export const config: Config = {
 };
 ```
 
+#### `cssVarShim`
+
+`extras.cssVarShim` causes Stencil to include a polyfill for [CSS
+variables](https://developer.mozilla.org/en-US/docs/Web/CSS/--*). For Stencil
+v3.0.0 this field is renamed to `__deprecated__cssVarsShim`. To retain the
+previous behavior the new option can be set in your project's
+`stencil.config.ts`:
+
+```ts
+// stencil.config.ts
+import { Config } from '@stencil/core';
+export const config: Config = {
+  extras: {
+    __deprecated__cssVarsShim: true
+  }
+};
+```
+
 ### Deprecated `assetsDir` Removed from `@Component()` decorator
 The `assetsDir` field was [deprecated in Stencil v2.0.0](https://github.com/ionic-team/stencil/blob/main/BREAKING_CHANGES.md#componentassetsdir), but some backwards compatibility was retained with a warning message.
 It has been fully removed in Stencil v3.0.0 in favor of `assetsDirs`.

--- a/src/docs/introduction/upgrading-to-stencil-three.md
+++ b/src/docs/introduction/upgrading-to-stencil-three.md
@@ -62,6 +62,31 @@ export const config: Config = {
 };
 ```
 
+### Legacy Browser Support Fields Deprecated
+
+Several configuration options related to support for Safari <11, IE11, and Edge
+<19 have been marked as deprecated, and will be removed entirely in a future
+version of Stencil.
+
+#### `dynamicImportShim`
+
+The `extras.dynamicImportShim` option causes Stencil to include a polyfill for
+the [dynamic `import()`
+function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import)
+for use at runtime. The field is renamed to `__deprecated__dynamicImportShim`
+to indicate deprecation. To retain the previous behavior the new option can be
+set in your project's `stencil.config.ts`:
+
+```ts
+// stencil.config.ts
+import { Config } from '@stencil/core';
+export const config: Config = {
+  extras: {
+    __deprecated__dynamicImportShim: true
+  }
+};
+```
+
 ### Deprecated `assetsDir` Removed from `@Component()` decorator
 The `assetsDir` field was [deprecated in Stencil v2.0.0](https://github.com/ionic-team/stencil/blob/main/BREAKING_CHANGES.md#componentassetsdir), but some backwards compatibility was retained with a warning message.
 It has been fully removed in Stencil v3.0.0 in favor of `assetsDirs`.

--- a/src/docs/introduction/upgrading-to-stencil-three.md
+++ b/src/docs/introduction/upgrading-to-stencil-three.md
@@ -124,6 +124,23 @@ export const config: Config = {
 };
 ```
 
+#### `safari10`
+
+If `extras.safari10` is set to `true` the Stencil runtime will patch ES module
+support for Safari 10. For Stencil v3.0.0 this field is renamed to
+`__deprecated__safari10`. To retain the previous behavior the new option can be
+set in your project's `stencil.config.ts`:
+
+```ts
+// stencil.config.ts
+import { Config } from '@stencil/core';
+export const config: Config = {
+  extras: {
+    __deprecated__safari10: true
+  }
+};
+```
+
 ### Deprecated `assetsDir` Removed from `@Component()` decorator
 The `assetsDir` field was [deprecated in Stencil v2.0.0](https://github.com/ionic-team/stencil/blob/main/BREAKING_CHANGES.md#componentassetsdir), but some backwards compatibility was retained with a warning message.
 It has been fully removed in Stencil v3.0.0 in favor of `assetsDirs`.


### PR DESCRIPTION
first commit: This starts a new section in the v3 upgrade docs for the fields in `config.extras` which will be marked as deprecated in Stencil v3. This first commit includes notes about the `dynamicImportShim` field. See https://github.com/ionic-team/stencil/pull/3895