### PR TITLE
docs(v3-upgrade): add note about deprecating `cssVarsShim`

### DIFF
--- a/src/docs/introduction/upgrading-to-stencil-three.md
+++ b/src/docs/introduction/upgrading-to-stencil-three.md
@@ -106,6 +106,24 @@ export const config: Config = {
 };
 ```
 
+#### `cssVarShim`
+
+`extras.cssVarShim` causes Stencil to include a polyfill for [CSS
+variables](https://developer.mozilla.org/en-US/docs/Web/CSS/--*). For Stencil
+v3.0.0 this field is renamed to `__deprecated__cssVarsShim`, and thus to retain
+the previous behavior the new option can be set in your projects
+`stencil.config.ts`:
+
+```ts
+// stencil.config.ts
+import { Config } from '@stencil/core';
+export const config: Config = {
+  extras: {
+    __deprecated__cssVarsShim: true
+  }
+};
+```
+
 ### Deprecated `assetsDir` Removed from `@Component()` decorator
 The `assetsDir` field was [deprecated in Stencil v2.0.0](https://github.com/ionic-team/stencil/blob/main/BREAKING_CHANGES.md#componentassetsdir), but some backwards compatibility was retained with a warning message.
 It has been fully removed in Stencil v3.0.0 in favor of `assetsDirs`.

--- a/src/docs/introduction/upgrading-to-stencil-three.md
+++ b/src/docs/introduction/upgrading-to-stencil-three.md
@@ -110,8 +110,8 @@ export const config: Config = {
 
 `extras.cssVarShim` causes Stencil to include a polyfill for [CSS
 variables](https://developer.mozilla.org/en-US/docs/Web/CSS/--*). For Stencil
-v3.0.0 this field is renamed to `__deprecated__cssVarsShim`, and thus to retain
-the previous behavior the new option can be set in your projects
+v3.0.0 this field is renamed to `__deprecated__cssVarsShim`. To retain the
+previous behavior the new option can be set in your project's
 `stencil.config.ts`:
 
 ```ts


### PR DESCRIPTION
This adds a note to the v3 upgrade guide about deprecating `extras.cssVarShim`.

**NOTE**: this PR has https://github.com/ionic-team/stencil-site/pull/948 as its base.