### PR TITLE
docs(support): add node 18 to support policy

### DIFF
--- a/docs/reference/support-policy.md
+++ b/docs/reference/support-policy.md
@@ -104,17 +104,19 @@ compatibility tables to describe the interoperability requirements of these piec
 
 ### JavaScript Runtime
 
-| Stencil Version | Node v10 | Node v12 | Node v14 | Node v16 | Node v18 |  Deno*  |
-|:---------------:|:--------:|:--------:|:--------:|:--------:|:--------:|:-------:|
-|       V3        | &#10060; | &#10060; | &#9989;  | &#9989;  | &#10060; | &#9888; |
-|       V2        | &#10060; | &#9989;  | &#9989;  | &#9989;  | &#10060; | &#9888; |
-|       V1        | &#9989;  | &#9989;  | &#9989;  | &#9989;  | &#10060; | &#9888; |
+| Stencil Version | Node v10 | Node v12 | Node v14 | Node v16 | Node v18  |  Deno*  |
+|:---------------:|:--------:|:--------:|:--------:|:--------:|:---------:|:-------:|
+|       V3        | &#10060; | &#10060; | &#9989;  | &#9989;  |  &#9989;  | &#9888; |
+|       V2        | &#10060; | &#9989;  | &#9989;  | &#9989;  | &#9888;** | &#9888; |
+|       V1        | &#9989;  | &#9989;  | &#9989;  | &#9989;  | &#10060;  | &#9888; |
 
 \* Experimental Deno support was available in Stencil
 [v1.16.0](https://github.com/ionic-team/stencil/releases/tag/v1.16.0) through
-[v2.8.1](https://github.com/ionic-team/stencil/releases/tag/v2.8.1). This experimental support was removed in 
-[v2.9.0](https://github.com/ionic-team/stencil/releases/tag/v2.9.0). For additional reasoning behind this decision, 
+[v2.8.1](https://github.com/ionic-team/stencil/releases/tag/v2.8.1). This experimental support was removed in
+[v2.9.0](https://github.com/ionic-team/stencil/releases/tag/v2.9.0). For additional reasoning behind this decision,
 please see [this document](https://github.com/ionic-team/stencil/blob/main/docs/adr/0013-deno-removal.md).
+
+\** Node 18 is likely to work with Stencil v2, although it was never formally supported
 
 ### Testing Libraries
 

--- a/versioned_docs/version-v2/reference/support-policy.md
+++ b/versioned_docs/version-v2/reference/support-policy.md
@@ -102,16 +102,18 @@ compatibility tables to describe the interoperability requirements of these piec
 
 ### JavaScript Runtime
 
-| Stencil Version | Node v10 | Node v12 | Node v14 | Node v16 | Node v18 |  Deno*  |
-|:---------------:|:--------:|:--------:|:--------:|:--------:|:--------:|:-------:|
-|       V2        | &#10060; | &#9989;  | &#9989;  | &#9989;  | &#10060; | &#9888; |
-|       V1        | &#9989;  | &#9989;  | &#9989;  | &#9989;  | &#10060; | &#9888; |
+| Stencil Version | Node v10 | Node v12 | Node v14 | Node v16 | Node v18  |  Deno*  |
+|:---------------:|:--------:|:--------:|:--------:|:--------:|:---------:|:-------:|
+|       V2        | &#10060; | &#9989;  | &#9989;  | &#9989;  | &#9888;** | &#9888; |
+|       V1        | &#9989;  | &#9989;  | &#9989;  | &#9989;  | &#10060;  | &#9888; |
 
 \* Experimental Deno support was available in Stencil
 [v1.16.0](https://github.com/ionic-team/stencil/releases/tag/v1.16.0) through
-[v2.8.1](https://github.com/ionic-team/stencil/releases/tag/v2.8.1). This experimental support was removed in 
-[v2.9.0](https://github.com/ionic-team/stencil/releases/tag/v2.9.0). For additional reasoning behind this decision, 
+[v2.8.1](https://github.com/ionic-team/stencil/releases/tag/v2.8.1). This experimental support was removed in
+[v2.9.0](https://github.com/ionic-team/stencil/releases/tag/v2.9.0). For additional reasoning behind this decision,
 please see [this document](https://github.com/ionic-team/stencil/blob/main/docs/adr/0013-deno-removal.md).
+
+\** Node 18 is likely to work with Stencil v2, although it was never formally supported
 
 ### Testing Libraries
 

--- a/versioned_docs/version-v3.0/reference/support-policy.md
+++ b/versioned_docs/version-v3.0/reference/support-policy.md
@@ -104,17 +104,19 @@ compatibility tables to describe the interoperability requirements of these piec
 
 ### JavaScript Runtime
 
-| Stencil Version | Node v10 | Node v12 | Node v14 | Node v16 | Node v18 |  Deno*  |
-|:---------------:|:--------:|:--------:|:--------:|:--------:|:--------:|:-------:|
-|       V3        | &#10060; | &#10060; | &#9989;  | &#9989;  | &#10060; | &#9888; |
-|       V2        | &#10060; | &#9989;  | &#9989;  | &#9989;  | &#10060; | &#9888; |
-|       V1        | &#9989;  | &#9989;  | &#9989;  | &#9989;  | &#10060; | &#9888; |
+| Stencil Version | Node v10 | Node v12 | Node v14 | Node v16 | Node v18  |  Deno*  |
+|:---------------:|:--------:|:--------:|:--------:|:--------:|:---------:|:-------:|
+|       V3        | &#10060; | &#10060; | &#9989;  | &#9989;  |  &#9989;  | &#9888; |
+|       V2        | &#10060; | &#9989;  | &#9989;  | &#9989;  | &#9888;** | &#9888; |
+|       V1        | &#9989;  | &#9989;  | &#9989;  | &#9989;  | &#10060;  | &#9888; |
 
 \* Experimental Deno support was available in Stencil
 [v1.16.0](https://github.com/ionic-team/stencil/releases/tag/v1.16.0) through
-[v2.8.1](https://github.com/ionic-team/stencil/releases/tag/v2.8.1). This experimental support was removed in 
-[v2.9.0](https://github.com/ionic-team/stencil/releases/tag/v2.9.0). For additional reasoning behind this decision, 
+[v2.8.1](https://github.com/ionic-team/stencil/releases/tag/v2.8.1). This experimental support was removed in
+[v2.9.0](https://github.com/ionic-team/stencil/releases/tag/v2.9.0). For additional reasoning behind this decision,
 please see [this document](https://github.com/ionic-team/stencil/blob/main/docs/adr/0013-deno-removal.md).
+
+\** Node 18 is likely to work with Stencil v2, although it was never formally supported
 
 ### Testing Libraries
 


### PR DESCRIPTION
this commit designates node 18 support in stencil 3. it also adds a
footnote that stencil 2 may be able to support node 18, as no known
issues have been reported when using the two.

the v2 version of the docs are slightly different from v3.0 and 'next',
as it omits the v3 row.

Images of Changes for each Version (see screenshot, version in header of site):
![Screenshot 2023-02-17 at 1 12 06 PM](https://user-images.githubusercontent.com/1930213/219744816-065cf380-5977-4392-aa06-092cfa3cc597.png)
![Screenshot 2023-02-17 at 1 11 59 PM](https://user-images.githubusercontent.com/1930213/219744821-0ea422d8-cff5-45cc-9af5-a5cad1803cfa.png)
![Screenshot 2023-02-17 at 1 11 50 PM](https://user-images.githubusercontent.com/1930213/219744824-94197183-fe72-48a9-96ae-3b3aa4fc2305.png)
