### PR TITLE
docs(v3): format codeblock for install command

### DIFF
--- a/src/docs/introduction/upgrading-to-stencil-three.md
+++ b/src/docs/introduction/upgrading-to-stencil-three.md
@@ -18,10 +18,7 @@ For breaking changes introduced in previous major versions of the library, see:
 - [Stencil v2 Breaking Changes](https://github.com/ionic-team/stencil/blob/main/BREAKING_CHANGES.md#stencil-two)
 - [Stencil v1 Breaking Changes](https://github.com/ionic-team/stencil/blob/main/BREAKING_CHANGES.md#stencil-one)
 
-For projects that are on Stencil v2, install the latest version of Stencil v3:
-```bash
-npm install @stencil/core@v3-next
-```
+For projects that are on Stencil v2, install the latest version of Stencil v3: `npm install @stencil/core@v3-next`
 
 ## Updating Your Code
 


### PR DESCRIPTION
this commit changes the codeblock for installing `@stencil/core@v3-next` to use inline, monospaced font. this is due to a bug in the hydration of code blocks that include forward slashes. today, a code block with the original content, '@stencil/core@v3-next', may be rendered as:
```
@stencil/core@v3-nextcore@v3-next
```
where the content following the slash ('core@v3-next') is added as an additional text node in the DOM (without any line breaks).

with the upcoming migration to docusaurus for the stencil site, we choose to 'patch' this by moving away from the text block. it's slightly less readable, but ensures the install command is always correct
![Screenshot 2022-12-19 at 10 16 05 AM](https://user-images.githubusercontent.com/1930213/208460279-128b9fe9-a98b-424d-bdf5-420c0dab12de.png)

