### PR TITLE
docs(v3): updated v3 version designation to beta

### DIFF
--- a/src/docs/introduction/upgrading-to-stencil-three.md
+++ b/src/docs/introduction/upgrading-to-stencil-three.md
@@ -8,7 +8,7 @@ contributors:
 
 # Upgrading to Stencil v3.0.0
 
-> Stencil 3.0.0 is still in alpha. These instructions are for users looking to try an early version of the software
+> Stencil 3.0.0 is still in beta. These instructions are for users looking to try an early version of the software
 
 ## Getting Started
 


### PR DESCRIPTION
this commit updates the notification stating that stencil v3 is in beta, now that beta.0 has been released (https://github.com/ionic-team/stencil/releases/tag/v3.0.0-beta.0)
![Screenshot 2023-01-03 at 9 07 43 AM](https://user-images.githubusercontent.com/1930213/210373448-02a73c4a-d8e8-4574-8a73-0452f1576e01.png)

