### PR TITLE
chore(docs): add npm2yarn directives to code blocks in a few places

### DIFF
--- a/docs/guides/module-bundling.md
+++ b/docs/guides/module-bundling.md
@@ -159,7 +159,7 @@ This is caused by some third-party dependencies that use [Node APIs](https://nod
 
 ### 1. Install `rollup-plugin-node-polyfills`:
 
-```bash
+```bash npm2yarn
 npm install rollup-plugin-node-polyfills --save-dev
 ```
 

--- a/docs/introduction/03-getting-started.md
+++ b/docs/introduction/03-getting-started.md
@@ -19,7 +19,7 @@ updated Node before continuing.
 Note that you will need to use npm 6 or higher.
 :::
 
-```bash
+```bash npm2yarn
  npm init stencil
 ```
 
@@ -114,6 +114,6 @@ $ git commit -m "initialize project using stencil cli"
 
 To get the latest version of @stencil/core you can run:
 
-```bash
+```bash npm2yarn
 npm install @stencil/core@latest --save-exact
 ```

--- a/docs/introduction/04-my-first-component.md
+++ b/docs/introduction/04-my-first-component.md
@@ -84,7 +84,7 @@ If a user of our component were to change the element's `name` property, our com
 
 The Stencil CLI can generate new components for you. If you used one of the starters, you can simply run the `generate` npm script in your project, which will start the interactive generator.
 
-```shell
+```shell npm2yarn
 npm run generate
 ```
 

--- a/docs/introduction/upgrading-to-stencil-three.md
+++ b/docs/introduction/upgrading-to-stencil-three.md
@@ -397,7 +397,7 @@ The functionality of these methods remains the same.
 Versions of Puppeteer prior to Puppeteer version 10 are no longer supported.
 In newer versions of Puppeteer, the library provides its own types, making `@types/puppeteer` no longer necessary.
 Ensure that Puppeteer v10 or higher is installed, and that its typings are not:
-```bash
+```bash npm2yarn
 $ npm install puppeteer
 $ npm uninstall @types/puppeteer
 ```

--- a/versioned_docs/version-v2/guides/module-bundling.md
+++ b/versioned_docs/version-v2/guides/module-bundling.md
@@ -159,7 +159,7 @@ This is caused by some third-party dependencies that use [Node APIs](https://nod
 
 ### 1. Install `rollup-plugin-node-polyfills`:
 
-```bash
+```bash npm2yarn
 npm install rollup-plugin-node-polyfills --save-dev
 ```
 

--- a/versioned_docs/version-v2/introduction/03-getting-started.md
+++ b/versioned_docs/version-v2/introduction/03-getting-started.md
@@ -19,7 +19,7 @@ updated Node before continuing.
 Note that you will need to use npm 6 or higher.
 :::
 
-```bash
+```bash npm2yarn
  npm init stencil
 ```
 
@@ -114,6 +114,6 @@ $ git commit -m "initialize project using stencil cli"
 
 To get the latest version of @stencil/core you can run:
 
-```bash
+```bash npm2yarn
 npm install @stencil/core@latest --save-exact
 ```

--- a/versioned_docs/version-v2/introduction/04-my-first-component.md
+++ b/versioned_docs/version-v2/introduction/04-my-first-component.md
@@ -84,7 +84,7 @@ If a user of our component were to change the element's `name` property, our com
 
 The Stencil CLI can generate new components for you. If you used one of the starters, you can simply run the `generate` npm script in your project, which will start the interactive generator.
 
-```shell
+```shell npm2yarn
 npm run generate
 ```
 

--- a/versioned_docs/version-v2/introduction/upgrading-to-stencil-three.md
+++ b/versioned_docs/version-v2/introduction/upgrading-to-stencil-three.md
@@ -399,7 +399,7 @@ The functionality of these methods remains the same.
 Versions of Puppeteer prior to Puppeteer version 10 are no longer supported.
 In newer versions of Puppeteer, the library provides its own types, making `@types/puppeteer` no longer necessary.
 Ensure that Puppeteer v10 or higher is installed, and that its typings are not:
-```bash
+```bash npm2yarn
 $ npm install puppeteer
 $ npm uninstall @types/puppeteer
 ```

--- a/versioned_docs/version-v3.0/guides/module-bundling.md
+++ b/versioned_docs/version-v3.0/guides/module-bundling.md
@@ -159,7 +159,7 @@ This is caused by some third-party dependencies that use [Node APIs](https://nod
 
 ### 1. Install `rollup-plugin-node-polyfills`:
 
-```bash
+```bash npm2yarn
 npm install rollup-plugin-node-polyfills --save-dev
 ```
 

--- a/versioned_docs/version-v3.0/introduction/03-getting-started.md
+++ b/versioned_docs/version-v3.0/introduction/03-getting-started.md
@@ -19,7 +19,7 @@ updated Node before continuing.
 Note that you will need to use npm 6 or higher.
 :::
 
-```bash
+```bash npm2yarn
  npm init stencil
 ```
 
@@ -114,6 +114,6 @@ $ git commit -m "initialize project using stencil cli"
 
 To get the latest version of @stencil/core you can run:
 
-```bash
+```bash npm2yarn
 npm install @stencil/core@latest --save-exact
 ```

--- a/versioned_docs/version-v3.0/introduction/04-my-first-component.md
+++ b/versioned_docs/version-v3.0/introduction/04-my-first-component.md
@@ -84,7 +84,7 @@ If a user of our component were to change the element's `name` property, our com
 
 The Stencil CLI can generate new components for you. If you used one of the starters, you can simply run the `generate` npm script in your project, which will start the interactive generator.
 
-```shell
+```shell npm2yarn
 npm run generate
 ```
 

--- a/versioned_docs/version-v3.0/introduction/upgrading-to-stencil-three.md
+++ b/versioned_docs/version-v3.0/introduction/upgrading-to-stencil-three.md
@@ -397,7 +397,7 @@ The functionality of these methods remains the same.
 Versions of Puppeteer prior to Puppeteer version 10 are no longer supported.
 In newer versions of Puppeteer, the library provides its own types, making `@types/puppeteer` no longer necessary.
 Ensure that Puppeteer v10 or higher is installed, and that its typings are not:
-```bash
+```bash npm2yarn
 $ npm install puppeteer
 $ npm uninstall @types/puppeteer
 ```


### PR DESCRIPTION
This adds the little `npm2yarn` directive on a few code blocks where we tell the user to run comands.