### PR TITLE
chore(versioning): fix a weird line-break due to an anchor tag

### DIFF
--- a/docs/reference/versioning.md
+++ b/docs/reference/versioning.md
@@ -41,6 +41,6 @@ to team priorities. There may be times where patch releases need to released mor
 
 ## Changelog
 
-To see a list of all notable changes to Stencil, please refer to the 
-<a href="https://github.com/ionic-team/stencil/releases" target="_blank" rel="noreferrer noopener">releases page</a>.
-This contains an ordered list of all bug fixes and new features under each release.
+To see a list of all notable changes to Stencil, please refer to the [releases
+page](https://github.com/ionic-team/stencil/releases). This contains an ordered
+list of all bug fixes and new features under each release.

--- a/versioned_docs/version-v2/reference/versioning.md
+++ b/versioned_docs/version-v2/reference/versioning.md
@@ -41,6 +41,6 @@ to team priorities. There may be times where patch releases need to released mor
 
 ## Changelog
 
-To see a list of all notable changes to Stencil, please refer to the 
-<a href="https://github.com/ionic-team/stencil/releases" target="_blank" rel="noreferrer noopener">releases page</a>.
-This contains an ordered list of all bug fixes and new features under each release.
+To see a list of all notable changes to Stencil, please refer to the [releases
+page](https://github.com/ionic-team/stencil/releases). This contains an ordered
+list of all bug fixes and new features under each release.

--- a/versioned_docs/version-v3.0/reference/versioning.md
+++ b/versioned_docs/version-v3.0/reference/versioning.md
@@ -41,6 +41,6 @@ to team priorities. There may be times where patch releases need to released mor
 
 ## Changelog
 
-To see a list of all notable changes to Stencil, please refer to the 
-<a href="https://github.com/ionic-team/stencil/releases" target="_blank" rel="noreferrer noopener">releases page</a>.
-This contains an ordered list of all bug fixes and new features under each release.
+To see a list of all notable changes to Stencil, please refer to the [releases
+page](https://github.com/ionic-team/stencil/releases). This contains an ordered
+list of all bug fixes and new features under each release.


### PR DESCRIPTION
Docusaurus opens external links in a new tab anyway, so we don't need the anchor tag.

Check that this looks normal on all three versions!