### PR TITLE
chore(git): add editors to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ yarn-debug.log*
 yarn-error.log*
 
 www
+
+# IDEs
+.idea/
+.vscode/


### PR DESCRIPTION
this commit adds directories created by code editors to the gitignore to prevent them from being pushed to the repo