### PR TITLE
fix(docs-hiding): update logic for excluding docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -54,7 +54,11 @@ const config = {
 
             const EXCLUDE_TOP_LEVEL_IDS = ['build-variables', 'telemetry']
 
-            const filteredSidebar = defaultSidebar.filter(item => !EXCLUDE_TOP_LEVEL_IDS.includes(item.id));
+            // remove the items in `EXCLUDE_TOP_LEVEL_IDS`, which may exist in 1+ subdirectories for versioned docs
+            // note: this removes any `EXCLUDE_TOP_LEVEL_IDS` entry for _all_ versioned docs and the top level `./docs`
+            const filteredSidebar = defaultSidebar.filter((item) =>
+               !EXCLUDE_TOP_LEVEL_IDS.find((toExclude) => item.id?.match(`.*${toExclude}$`))
+            );
 
             return filteredSidebar;
           },


### PR DESCRIPTION
this commit updates the logic for excluding docs to account for docs that are in versioned docs directories. prior to this commit, docs in the v2 and v3.0 directories wouldn't be excluded, causing for an incorrect sidebar to be generated

## Before
![Screenshot 2023-01-25 at 4 58 01 PM](https://user-images.githubusercontent.com/1930213/214701124-595351c8-29a2-4c20-aca6-11e38eb9a142.png)


## After
![Screenshot 2023-01-25 at 4 57 49 PM](https://user-images.githubusercontent.com/1930213/214701093-a7456ad0-3a5e-4843-8d2b-3cb4e32009c5.png)
