### PR TITLE
docs(style): update eslint references

### DIFF
--- a/docs/guides/style-guide.md
+++ b/docs/guides/style-guide.md
@@ -16,7 +16,7 @@ contributors:
 This is a component style guide created and enforced internally by the core team of Stencil, for the purpose of standardizing Stencil components. This should only be used as a reference for other teams in creating their own style guides. Feel free to modify to your team's own preference.
 
 :::note
-In order to enforce this (or your team's) style guide, we recommend leveraging a static analysis tool like [ESLint](https://eslint.org/). [@stencil/eslint-plugin](https://www.npmjs.com/package/@stencil/eslint-plugin) provides rules specifically for writing Stencil components.
+In order to enforce this (or your team's) style guide, we recommend leveraging a static analysis tool like [ESLint](https://eslint.org/). [@stencil-community/eslint-plugin](https://www.npmjs.com/package/@stencil-community/eslint-plugin) provides rules specifically for writing Stencil components.
 :::
 
 :::note

--- a/versioned_docs/version-v2/guides/style-guide.md
+++ b/versioned_docs/version-v2/guides/style-guide.md
@@ -16,7 +16,7 @@ contributors:
 This is a component style guide created and enforced internally by the core team of Stencil, for the purpose of standardizing Stencil components. This should only be used as a reference for other teams in creating their own style guides. Feel free to modify to your team's own preference.
 
 :::note
-In order to enforce this (or your team's) style guide, we recommend leveraging a static analysis tool like [ESLint](https://eslint.org/). [@stencil/eslint-plugin](https://www.npmjs.com/package/@stencil/eslint-plugin) provides rules specifically for writing Stencil components.
+In order to enforce this (or your team's) style guide, we recommend leveraging a static analysis tool like [ESLint](https://eslint.org/). [@stencil-community/eslint-plugin](https://www.npmjs.com/package/@stencil-community/eslint-plugin) provides rules specifically for writing Stencil components.
 :::
 
 :::note

--- a/versioned_docs/version-v3.0/guides/style-guide.md
+++ b/versioned_docs/version-v3.0/guides/style-guide.md
@@ -16,7 +16,7 @@ contributors:
 This is a component style guide created and enforced internally by the core team of Stencil, for the purpose of standardizing Stencil components. This should only be used as a reference for other teams in creating their own style guides. Feel free to modify to your team's own preference.
 
 :::note
-In order to enforce this (or your team's) style guide, we recommend leveraging a static analysis tool like [ESLint](https://eslint.org/). [@stencil/eslint-plugin](https://www.npmjs.com/package/@stencil/eslint-plugin) provides rules specifically for writing Stencil components.
+In order to enforce this (or your team's) style guide, we recommend leveraging a static analysis tool like [ESLint](https://eslint.org/). [@stencil-community/eslint-plugin](https://www.npmjs.com/package/@stencil-community/eslint-plugin) provides rules specifically for writing Stencil components.
 :::
 
 :::note


### PR DESCRIPTION
this commit fixes the references to `@stencil-community/eslint-plugin` that were originally applied in
https://github.com/ionic-team/stencil-site/pull/968 and accidentally lost in https://github.com/ionic-team/stencil-site/pull/902

![Screenshot 2023-01-26 at 8 58 54 AM](https://user-images.githubusercontent.com/1930213/214855065-8a90461e-c910-46fe-977b-0b5c16aa28c3.png)
