### PR TITLE
fix(browser-support): restore styling of browser-support page

### DIFF
--- a/docs/reference/browser-support.md
+++ b/docs/reference/browser-support.md
@@ -18,19 +18,19 @@ Stencil builds Web Components that run natively or near-natively in all widely u
   <div class="bs-chart__group">
     <div class="bs-chart__cards">
       <div class="bs-chart__card">
-        <app-icon name="checkmark"></app-icon>
+        <ion-icon name="checkmark"></ion-icon>
         Chrome 79+
       </div>
       <div class="bs-chart__card">
-        <app-icon name="checkmark"></app-icon>
+        <ion-icon name="checkmark"></ion-icon>
         Safari 14+  
       </div>
       <div class="bs-chart__card">
-        <app-icon name="checkmark"></app-icon>
+        <ion-icon name="checkmark"></ion-icon>
         Firefox 70+
       </div>
       <div class="bs-chart__card">
-        <app-icon name="checkmark"></app-icon>
+        <ion-icon name="checkmark"></ion-icon>
         Edge 79+
       </div>
     </div>
@@ -41,7 +41,7 @@ Stencil builds Web Components that run natively or near-natively in all widely u
   <div class="bs-chart__group">
     <div class="bs-chart__cards">
       <div class="bs-chart__card">
-        <app-icon name="checkmark"></app-icon>
+        <ion-icon name="checkmark"></ion-icon>
         IE 11, Edge 16-18
       </div>
     </div>
@@ -61,93 +61,12 @@ Stencil uses a dynamic loader to load the custom elements polyfill only on brows
 
 |                                                                |               Chrome 79+               |               Safari 14+               |              Firefox 70+               |                Edge 79+                | Edge 16-18                             | IE 11                               |
 | -------------------------------------------------------------- |:--------------------------------------:|:--------------------------------------:|:--------------------------------------:|:--------------------------------------:| :------------------------------------: | :---------------------------------: |
-| [CSS Variables](https://caniuse.com/#feat=css-variables)       | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="circle"></app-icon> |
-| [Custom Elements](https://caniuse.com/#feat=custom-elementsv1) | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="circle"></app-icon>    | <app-icon name="circle"></app-icon> |
-| [Shadow Dom](https://caniuse.com/#feat=shadowdomv1)            | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="circle"></app-icon>    | <app-icon name="circle"></app-icon> |
-| [es2017](https://caniuse.com/#feat=async-functions)            | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="circle"></app-icon> |
-| [ES Modules](https://caniuse.com/#feat=es6-module)             | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="circle"></app-icon> |
+| [CSS Variables](https://caniuse.com/#feat=css-variables)       | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="circle"></ion-icon> |
+| [Custom Elements](https://caniuse.com/#feat=custom-elementsv1) | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="circle"></ion-icon>    | <ion-icon name="circle"></ion-icon> |
+| [Shadow Dom](https://caniuse.com/#feat=shadowdomv1)            | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="circle"></ion-icon>    | <ion-icon name="circle"></ion-icon> |
+| [es2017](https://caniuse.com/#feat=async-functions)            | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="circle"></ion-icon> |
+| [ES Modules](https://caniuse.com/#feat=es6-module)             | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="circle"></ion-icon> |
 
 <div class="align-right">
-  <app-icon name="circle"></app-icon> <span class="caption">Stencil compiles with polyfills for features not supported natively</span>
+  <ion-icon name="circle"></ion-icon> <span class="caption">Stencil compiles with polyfills for features not supported natively</span>
 </div>
-
-```
-==== DOCTODO ====
-<style>
-  .bs-chart,
-.bs-chart__cards,
-.bs-chart__card {
-  display: flex;
-}
-
-.bs-chart {
-  margin: 40px 0;
-  justify-content: space-between;
-}
-
-.bs-chart__group + .bs-chart__group,
-.bs-chart__card + .bs-chart__card {
-  margin-left: 8px;
-}
-
-.bs-chart__group:first-child .bs-chart__card {
-  background: #39B54A;
-}
-
-.bs-chart__group:last-child .bs-chart__card {
-  background: #d0901a;
-}
-
-.bs-chart__card {
-  width: 110px;
-  flex-direction: column;
-  align-items: center;
-  border-radius: 8px;
-  color: #fff;
-  padding: 8px;
-  font-size: 11px;
-  font-weight: 600;
-}
-
-.bs-chart__card app-icon {
-  background: rgba(255, 255, 255, 0.15);
-  padding: 8px;
-  border-radius: 100px;
-  margin: 6px 0 8px;
-}
-
-.bs-chart__card app-icon svg {
-  fill: #fff;
-}
-
-.bs-chart__group-label {
-  display: block;
-  text-align: center;
-  font-size: 11px;
-  color: #646464;
-  margin-top: 6px;
-}
-
-@media screen and (max-width: 872px) {
-  .bs-chart__card {
-    width: 100%;
-  }
-
-  .bs-chart,
-  .bs-chart__group,
-  .bs-chart__cards {
-    flex-direction: column;
-  }
-
-  .bs-chart__group + .bs-chart__group {
-    margin-left: 0;
-    margin-top: 20px;
-  }
-
-  .bs-chart__card + .bs-chart__card {
-    margin-left: 0;
-    margin-top: 8px;
-  }
-}
-</style>
-```

--- a/docs/reference/browser-support.md
+++ b/docs/reference/browser-support.md
@@ -14,38 +14,38 @@ contributors:
 
 Stencil builds Web Components that run natively or near-natively in all widely used desktop and mobile browsers.
 
-<div class="bs-chart">
-  <div class="bs-chart__group">
-    <div class="bs-chart__cards">
-      <div class="bs-chart__card">
+<div className="bs-chart">
+  <div className="bs-chart__group">
+    <div className="bs-chart__cards">
+      <div className="bs-chart__card">
         <ion-icon name="checkmark"></ion-icon>
         Chrome 79+
       </div>
-      <div class="bs-chart__card">
+      <div className="bs-chart__card">
         <ion-icon name="checkmark"></ion-icon>
         Safari 14+  
       </div>
-      <div class="bs-chart__card">
+      <div className="bs-chart__card">
         <ion-icon name="checkmark"></ion-icon>
         Firefox 70+
       </div>
-      <div class="bs-chart__card">
+      <div className="bs-chart__card">
         <ion-icon name="checkmark"></ion-icon>
         Edge 79+
       </div>
     </div>
-    <div class="bs-chart__group-label">
+    <div className="bs-chart__group-label">
       Full native support
     </div>
   </div>
-  <div class="bs-chart__group">
-    <div class="bs-chart__cards">
-      <div class="bs-chart__card">
+  <div className="bs-chart__group">
+    <div className="bs-chart__cards">
+      <div className="bs-chart__card">
         <ion-icon name="checkmark"></ion-icon>
         IE 11, Edge 16-18
       </div>
     </div>
-    <div class="bs-chart__group-label">
+    <div className="bs-chart__group-label">
       Deprecated in Stencil v3.
     </div>
   </div>
@@ -61,12 +61,16 @@ Stencil uses a dynamic loader to load the custom elements polyfill only on brows
 
 |                                                                |               Chrome 79+               |               Safari 14+               |              Firefox 70+               |                Edge 79+                | Edge 16-18                             | IE 11                               |
 | -------------------------------------------------------------- |:--------------------------------------:|:--------------------------------------:|:--------------------------------------:|:--------------------------------------:| :------------------------------------: | :---------------------------------: |
-| [CSS Variables](https://caniuse.com/#feat=css-variables)       | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="circle"></ion-icon> |
-| [Custom Elements](https://caniuse.com/#feat=custom-elementsv1) | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="circle"></ion-icon>    | <ion-icon name="circle"></ion-icon> |
-| [Shadow Dom](https://caniuse.com/#feat=shadowdomv1)            | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="circle"></ion-icon>    | <ion-icon name="circle"></ion-icon> |
-| [es2017](https://caniuse.com/#feat=async-functions)            | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="circle"></ion-icon> |
-| [ES Modules](https://caniuse.com/#feat=es6-module)             | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="circle"></ion-icon> |
+| [CSS Variables](https://caniuse.com/#feat=css-variables)       | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ |
+| [Custom Elements](https://caniuse.com/#feat=custom-elementsv1) | ✅ | ✅ | ✅ | ✅ | ⚠️    | ⚠️ |
+| [Shadow Dom](https://caniuse.com/#feat=shadowdomv1)            | ✅ | ✅ | ✅ | ✅ | ⚠️    | ⚠️ |
+| [es2017](https://caniuse.com/#feat=async-functions)            | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ |
+| [ES Modules](https://caniuse.com/#feat=es6-module)             | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ |
 
-<div class="align-right">
-  <ion-icon name="circle"></ion-icon> <span class="caption">Stencil compiles with polyfills for features not supported natively</span>
+<div className="align-right">
+  ⚠️ <span className="caption">Stencil compiles with polyfills for features not supported natively</span>
 </div>
+
+:::info
+As of Stencil v3, legacy browser support is deprecated, and will be removed in a future major version of Stencil.
+:::

--- a/src/css/bs-chart.scss
+++ b/src/css/bs-chart.scss
@@ -2,6 +2,7 @@
 .bs-chart__cards,
 .bs-chart__card {
   display: flex;
+  justify-content: center;
 }
 
 .bs-chart {
@@ -37,14 +38,6 @@
   padding: 8px;
   border-radius: 100px;
   margin: 6px 0 8px;
-}
-
-.bs-chart__card ion-icon svg {
-  // fill: #fff;
-}
-
-.bs-chart__card ion-icon[name="icon-checkmark"] {
-  color: var(--color-green-haze);
 }
 
 .bs-chart__group-label {

--- a/src/css/bs-chart.scss
+++ b/src/css/bs-chart.scss
@@ -1,0 +1,78 @@
+.bs-chart,
+.bs-chart__cards,
+.bs-chart__card {
+  display: flex;
+}
+
+.bs-chart {
+  margin: 40px 0;
+}
+
+.bs-chart__group + .bs-chart__group,
+.bs-chart__card + .bs-chart__card {
+  margin-left: 8px;
+}
+
+.bs-chart__group:first-child .bs-chart__card {
+  background: #39B54A;
+}
+
+.bs-chart__group:last-child .bs-chart__card {
+  background: #d0901a;
+}
+
+.bs-chart__card {
+  width: 110px;
+  flex-direction: column;
+  align-items: center;
+  border-radius: 8px;
+  color: #fff;
+  padding: 8px;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.bs-chart__card ion-icon {
+  background: rgba(255, 255, 255, 0.15);
+  padding: 8px;
+  border-radius: 100px;
+  margin: 6px 0 8px;
+}
+
+.bs-chart__card ion-icon svg {
+  // fill: #fff;
+}
+
+.bs-chart__card ion-icon[name="icon-checkmark"] {
+  color: var(--color-green-haze);
+}
+
+.bs-chart__group-label {
+  display: block;
+  text-align: center;
+  font-size: 11px;
+  color: #646464;
+  margin-top: 6px;
+}
+
+@media screen and (max-width: 872px) {
+  .bs-chart__card {
+    width: 100%;
+  }
+
+  .bs-chart,
+  .bs-chart__group,
+  .bs-chart__cards {
+    flex-direction: column;
+  }
+
+  .bs-chart__group + .bs-chart__group {
+    margin-left: 0;
+    margin-top: 20px;
+  }
+
+  .bs-chart__card + .bs-chart__card {
+    margin-left: 0;
+    margin-top: 8px;
+  }
+}

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -1,6 +1,7 @@
 @layer base, tokens, preset, site;
 
 @layer site {
+  @import "bs-chart";
   /**
   * Colors generated using the color range tool in the Docusaurus docs, here:
   * https://docusaurus.io/docs/styling-layout#styling-your-site-with-infima
@@ -32,80 +33,4 @@
     max-width: 50rem;
     margin: auto;
   }
-
-  .bs-chart,
-.bs-chart__cards,
-.bs-chart__card {
-  display: flex;
-}
-
-.bs-chart {
-  margin: 40px 0;
-  justify-content: space-between;
-}
-
-.bs-chart__group + .bs-chart__group,
-.bs-chart__card + .bs-chart__card {
-  margin-left: 8px;
-}
-
-.bs-chart__group:first-child .bs-chart__card {
-  background: #39B54A;
-}
-
-.bs-chart__group:last-child .bs-chart__card {
-  background: #d0901a;
-}
-
-.bs-chart__card {
-  width: 110px;
-  flex-direction: column;
-  align-items: center;
-  border-radius: 8px;
-  color: #fff;
-  padding: 8px;
-  font-size: 11px;
-  font-weight: 600;
-}
-
-.bs-chart__card ion-icon {
-  background: rgba(255, 255, 255, 0.15);
-  padding: 8px;
-  border-radius: 100px;
-  margin: 6px 0 8px;
-}
-
-.bs-chart__card ion-icon svg {
-  fill: #fff;
-}
-
-.bs-chart__group-label {
-  display: block;
-  text-align: center;
-  font-size: 11px;
-  color: #646464;
-  margin-top: 6px;
-}
-
-@media screen and (max-width: 872px) {
-  .bs-chart__card {
-    width: 100%;
-  }
-
-  .bs-chart,
-  .bs-chart__group,
-  .bs-chart__cards {
-    flex-direction: column;
-  }
-
-  .bs-chart__group + .bs-chart__group {
-    margin-left: 0;
-    margin-top: 20px;
-  }
-
-  .bs-chart__card + .bs-chart__card {
-    margin-left: 0;
-    margin-top: 8px;
-  }
-}
 }

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -32,4 +32,80 @@
     max-width: 50rem;
     margin: auto;
   }
+
+  .bs-chart,
+.bs-chart__cards,
+.bs-chart__card {
+  display: flex;
+}
+
+.bs-chart {
+  margin: 40px 0;
+  justify-content: space-between;
+}
+
+.bs-chart__group + .bs-chart__group,
+.bs-chart__card + .bs-chart__card {
+  margin-left: 8px;
+}
+
+.bs-chart__group:first-child .bs-chart__card {
+  background: #39B54A;
+}
+
+.bs-chart__group:last-child .bs-chart__card {
+  background: #d0901a;
+}
+
+.bs-chart__card {
+  width: 110px;
+  flex-direction: column;
+  align-items: center;
+  border-radius: 8px;
+  color: #fff;
+  padding: 8px;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.bs-chart__card ion-icon {
+  background: rgba(255, 255, 255, 0.15);
+  padding: 8px;
+  border-radius: 100px;
+  margin: 6px 0 8px;
+}
+
+.bs-chart__card ion-icon svg {
+  fill: #fff;
+}
+
+.bs-chart__group-label {
+  display: block;
+  text-align: center;
+  font-size: 11px;
+  color: #646464;
+  margin-top: 6px;
+}
+
+@media screen and (max-width: 872px) {
+  .bs-chart__card {
+    width: 100%;
+  }
+
+  .bs-chart,
+  .bs-chart__group,
+  .bs-chart__cards {
+    flex-direction: column;
+  }
+
+  .bs-chart__group + .bs-chart__group {
+    margin-left: 0;
+    margin-top: 20px;
+  }
+
+  .bs-chart__card + .bs-chart__card {
+    margin-left: 0;
+    margin-top: 8px;
+  }
+}
 }

--- a/src/css/headline.css
+++ b/src/css/headline.css
@@ -1,4 +1,3 @@
-
 .headline {
   margin-top: 0;
   margin-bottom: 80px;

--- a/versioned_docs/version-v2/reference/browser-support.md
+++ b/versioned_docs/version-v2/reference/browser-support.md
@@ -18,19 +18,19 @@ Stencil builds Web Components that run natively or near-natively in all widely u
   <div class="bs-chart__group">
     <div class="bs-chart__cards">
       <div class="bs-chart__card">
-        <app-icon name="checkmark"></app-icon>
+        <ion-icon name="checkmark"></ion-icon>
         Chrome 60+
       </div>
       <div class="bs-chart__card">
-        <app-icon name="checkmark"></app-icon>
+        <ion-icon name="checkmark"></ion-icon>
         Safari 10.1+
       </div>
       <div class="bs-chart__card">
-        <app-icon name="checkmark"></app-icon>
+        <ion-icon name="checkmark"></ion-icon>
         Firefox 63+
       </div>
       <div class="bs-chart__card">
-        <app-icon name="checkmark"></app-icon>
+        <ion-icon name="checkmark"></ion-icon>
         Edge 79+
       </div>
     </div>
@@ -41,7 +41,7 @@ Stencil builds Web Components that run natively or near-natively in all widely u
   <div class="bs-chart__group">
     <div class="bs-chart__cards">
       <div class="bs-chart__card">
-        <app-icon name="checkmark"></app-icon>
+        <ion-icon name="checkmark"></ion-icon>
         IE 11, Edge 16-18
       </div>
     </div>
@@ -61,93 +61,12 @@ Stencil uses a dynamic loader to load the custom elements polyfill only on brows
 
 |                                                                | Chrome 60+                             | Safari 10.1+                           | Firefox 63+                            | Edge 79+                               | Edge 16-18                             | IE 11                               |
 | -------------------------------------------------------------- | :------------------------------------: | :------------------------------------: | :------------------------------------: | :------------------------------------: | :------------------------------------: | :---------------------------------: |
-| [CSS Variables](https://caniuse.com/#feat=css-variables)       | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="circle"></app-icon> |
-| [Custom Elements](https://caniuse.com/#feat=custom-elementsv1) | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="circle"></app-icon>    | <app-icon name="circle"></app-icon> |
-| [Shadow Dom](https://caniuse.com/#feat=shadowdomv1)            | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="circle"></app-icon>    | <app-icon name="circle"></app-icon> |
-| [es2017](https://caniuse.com/#feat=async-functions)            | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="circle"></app-icon> |
-| [ES Modules](https://caniuse.com/#feat=es6-module)             | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="circle"></app-icon> |
+| [CSS Variables](https://caniuse.com/#feat=css-variables)       | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="circle"></ion-icon> |
+| [Custom Elements](https://caniuse.com/#feat=custom-elementsv1) | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="circle"></ion-icon>    | <ion-icon name="circle"></ion-icon> |
+| [Shadow Dom](https://caniuse.com/#feat=shadowdomv1)            | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="circle"></ion-icon>    | <ion-icon name="circle"></ion-icon> |
+| [es2017](https://caniuse.com/#feat=async-functions)            | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="circle"></ion-icon> |
+| [ES Modules](https://caniuse.com/#feat=es6-module)             | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="circle"></ion-icon> |
 
 <div class="align-right">
-  <app-icon name="circle"></app-icon> <span class="caption">Stencil compiles with polyfills for features not supported natively</span>
+  <ion-icon name="circle"></ion-icon> <span class="caption">Stencil compiles with polyfills for features not supported natively</span>
 </div>
-
-```
-==== DOCTODO ====
-<style>
-  .bs-chart,
-.bs-chart__cards,
-.bs-chart__card {
-  display: flex;
-}
-
-.bs-chart {
-  margin: 40px 0;
-  justify-content: space-between;
-}
-
-.bs-chart__group + .bs-chart__group,
-.bs-chart__card + .bs-chart__card {
-  margin-left: 8px;
-}
-
-.bs-chart__group:first-child .bs-chart__card {
-  background: #39B54A;
-}
-
-.bs-chart__group:last-child .bs-chart__card {
-  background: #96D01A;
-}
-
-.bs-chart__card {
-  width: 110px;
-  flex-direction: column;
-  align-items: center;
-  border-radius: 8px;
-  color: #fff;
-  padding: 8px;
-  font-size: 11px;
-  font-weight: 600;
-}
-
-.bs-chart__card app-icon {
-  background: rgba(255, 255, 255, 0.15);
-  padding: 8px;
-  border-radius: 100px;
-  margin: 6px 0 8px;
-}
-
-.bs-chart__card app-icon svg {
-  fill: #fff;
-}
-
-.bs-chart__group-label {
-  display: block;
-  text-align: center;
-  font-size: 11px;
-  color: #646464;
-  margin-top: 6px;
-}
-
-@media screen and (max-width: 872px) {
-  .bs-chart__card {
-    width: 100%;
-  }
-
-  .bs-chart,
-  .bs-chart__group,
-  .bs-chart__cards {
-    flex-direction: column;
-  }
-
-  .bs-chart__group + .bs-chart__group {
-    margin-left: 0;
-    margin-top: 20px;
-  }
-
-  .bs-chart__card + .bs-chart__card {
-    margin-left: 0;
-    margin-top: 8px;
-  }
-}
-</style>
-```

--- a/versioned_docs/version-v2/reference/browser-support.md
+++ b/versioned_docs/version-v2/reference/browser-support.md
@@ -61,12 +61,12 @@ Stencil uses a dynamic loader to load the custom elements polyfill only on brows
 
 |                                                                | Chrome 60+                             | Safari 10.1+                           | Firefox 63+                            | Edge 79+                               | Edge 16-18                             | IE 11                               |
 | -------------------------------------------------------------- | :------------------------------------: | :------------------------------------: | :------------------------------------: | :------------------------------------: | :------------------------------------: | :---------------------------------: |
-| [CSS Variables](https://caniuse.com/#feat=css-variables)       | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="circle"></ion-icon> |
-| [Custom Elements](https://caniuse.com/#feat=custom-elementsv1) | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="circle"></ion-icon>    | <ion-icon name="circle"></ion-icon> |
-| [Shadow Dom](https://caniuse.com/#feat=shadowdomv1)            | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="circle"></ion-icon>    | <ion-icon name="circle"></ion-icon> |
-| [es2017](https://caniuse.com/#feat=async-functions)            | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="circle"></ion-icon> |
-| [ES Modules](https://caniuse.com/#feat=es6-module)             | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="circle"></ion-icon> |
+| [CSS Variables](https://caniuse.com/#feat=css-variables)       | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ |
+| [Custom Elements](https://caniuse.com/#feat=custom-elementsv1) | ✅ | ✅ | ✅ | ✅ | ⚠️    | ⚠️ |
+| [Shadow Dom](https://caniuse.com/#feat=shadowdomv1)            | ✅ | ✅ | ✅ | ✅ | ⚠️    | ⚠️ |
+| [es2017](https://caniuse.com/#feat=async-functions)            | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ |
+| [ES Modules](https://caniuse.com/#feat=es6-module)             | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ |
 
 <div class="align-right">
-  <ion-icon name="circle"></ion-icon> <span class="caption">Stencil compiles with polyfills for features not supported natively</span>
+  ⚠️  <span class="caption">Stencil compiles with polyfills for features not supported natively</span>
 </div>

--- a/versioned_docs/version-v3.0/reference/browser-support.md
+++ b/versioned_docs/version-v3.0/reference/browser-support.md
@@ -61,12 +61,16 @@ Stencil uses a dynamic loader to load the custom elements polyfill only on brows
 
 |                                                                |               Chrome 79+               |               Safari 14+               |              Firefox 70+               |                Edge 79+                | Edge 16-18                             | IE 11                               |
 | -------------------------------------------------------------- |:--------------------------------------:|:--------------------------------------:|:--------------------------------------:|:--------------------------------------:| :------------------------------------: | :---------------------------------: |
-| [CSS Variables](https://caniuse.com/#feat=css-variables)       | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="circle"></ion-icon> |
-| [Custom Elements](https://caniuse.com/#feat=custom-elementsv1) | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="circle"></ion-icon>    | <ion-icon name="circle"></ion-icon> |
-| [Shadow Dom](https://caniuse.com/#feat=shadowdomv1)            | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="circle"></ion-icon>    | <ion-icon name="circle"></ion-icon> |
-| [es2017](https://caniuse.com/#feat=async-functions)            | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="circle"></ion-icon> |
-| [ES Modules](https://caniuse.com/#feat=es6-module)             | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="circle"></ion-icon> |
+| [CSS Variables](https://caniuse.com/#feat=css-variables)       | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ |
+| [Custom Elements](https://caniuse.com/#feat=custom-elementsv1) | ✅ | ✅ | ✅ | ✅ | ⚠️    | ⚠️ |
+| [Shadow Dom](https://caniuse.com/#feat=shadowdomv1)            | ✅ | ✅ | ✅ | ✅ | ⚠️    | ⚠️ |
+| [es2017](https://caniuse.com/#feat=async-functions)            | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ |
+| [ES Modules](https://caniuse.com/#feat=es6-module)             | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ |
 
-<div class="align-right">
-  <ion-icon name="circle"></ion-icon> <span class="caption">Stencil compiles with polyfills for features not supported natively</span>
+<div className="align-right">
+  ⚠️ <span className="caption">Stencil compiles with polyfills for features not supported natively</span>
 </div>
+
+:::info
+As of Stencil v3, legacy browser support is deprecated, and will be removed in a future major version of Stencil.
+:::

--- a/versioned_docs/version-v3.0/reference/browser-support.md
+++ b/versioned_docs/version-v3.0/reference/browser-support.md
@@ -18,19 +18,19 @@ Stencil builds Web Components that run natively or near-natively in all widely u
   <div class="bs-chart__group">
     <div class="bs-chart__cards">
       <div class="bs-chart__card">
-        <app-icon name="checkmark"></app-icon>
+        <ion-icon name="checkmark"></ion-icon>
         Chrome 79+
       </div>
       <div class="bs-chart__card">
-        <app-icon name="checkmark"></app-icon>
+        <ion-icon name="checkmark"></ion-icon>
         Safari 14+  
       </div>
       <div class="bs-chart__card">
-        <app-icon name="checkmark"></app-icon>
+        <ion-icon name="checkmark"></ion-icon>
         Firefox 70+
       </div>
       <div class="bs-chart__card">
-        <app-icon name="checkmark"></app-icon>
+        <ion-icon name="checkmark"></ion-icon>
         Edge 79+
       </div>
     </div>
@@ -41,7 +41,7 @@ Stencil builds Web Components that run natively or near-natively in all widely u
   <div class="bs-chart__group">
     <div class="bs-chart__cards">
       <div class="bs-chart__card">
-        <app-icon name="checkmark"></app-icon>
+        <ion-icon name="checkmark"></ion-icon>
         IE 11, Edge 16-18
       </div>
     </div>
@@ -61,93 +61,12 @@ Stencil uses a dynamic loader to load the custom elements polyfill only on brows
 
 |                                                                |               Chrome 79+               |               Safari 14+               |              Firefox 70+               |                Edge 79+                | Edge 16-18                             | IE 11                               |
 | -------------------------------------------------------------- |:--------------------------------------:|:--------------------------------------:|:--------------------------------------:|:--------------------------------------:| :------------------------------------: | :---------------------------------: |
-| [CSS Variables](https://caniuse.com/#feat=css-variables)       | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="circle"></app-icon> |
-| [Custom Elements](https://caniuse.com/#feat=custom-elementsv1) | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="circle"></app-icon>    | <app-icon name="circle"></app-icon> |
-| [Shadow Dom](https://caniuse.com/#feat=shadowdomv1)            | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="circle"></app-icon>    | <app-icon name="circle"></app-icon> |
-| [es2017](https://caniuse.com/#feat=async-functions)            | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="circle"></app-icon> |
-| [ES Modules](https://caniuse.com/#feat=es6-module)             | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="checkmark"></app-icon> | <app-icon name="circle"></app-icon> |
+| [CSS Variables](https://caniuse.com/#feat=css-variables)       | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="circle"></ion-icon> |
+| [Custom Elements](https://caniuse.com/#feat=custom-elementsv1) | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="circle"></ion-icon>    | <ion-icon name="circle"></ion-icon> |
+| [Shadow Dom](https://caniuse.com/#feat=shadowdomv1)            | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="circle"></ion-icon>    | <ion-icon name="circle"></ion-icon> |
+| [es2017](https://caniuse.com/#feat=async-functions)            | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="circle"></ion-icon> |
+| [ES Modules](https://caniuse.com/#feat=es6-module)             | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="checkmark"></ion-icon> | <ion-icon name="circle"></ion-icon> |
 
 <div class="align-right">
-  <app-icon name="circle"></app-icon> <span class="caption">Stencil compiles with polyfills for features not supported natively</span>
+  <ion-icon name="circle"></ion-icon> <span class="caption">Stencil compiles with polyfills for features not supported natively</span>
 </div>
-
-```
-==== DOCTODO ====
-<style>
-  .bs-chart,
-.bs-chart__cards,
-.bs-chart__card {
-  display: flex;
-}
-
-.bs-chart {
-  margin: 40px 0;
-  justify-content: space-between;
-}
-
-.bs-chart__group + .bs-chart__group,
-.bs-chart__card + .bs-chart__card {
-  margin-left: 8px;
-}
-
-.bs-chart__group:first-child .bs-chart__card {
-  background: #39B54A;
-}
-
-.bs-chart__group:last-child .bs-chart__card {
-  background: #d0901a;
-}
-
-.bs-chart__card {
-  width: 110px;
-  flex-direction: column;
-  align-items: center;
-  border-radius: 8px;
-  color: #fff;
-  padding: 8px;
-  font-size: 11px;
-  font-weight: 600;
-}
-
-.bs-chart__card app-icon {
-  background: rgba(255, 255, 255, 0.15);
-  padding: 8px;
-  border-radius: 100px;
-  margin: 6px 0 8px;
-}
-
-.bs-chart__card app-icon svg {
-  fill: #fff;
-}
-
-.bs-chart__group-label {
-  display: block;
-  text-align: center;
-  font-size: 11px;
-  color: #646464;
-  margin-top: 6px;
-}
-
-@media screen and (max-width: 872px) {
-  .bs-chart__card {
-    width: 100%;
-  }
-
-  .bs-chart,
-  .bs-chart__group,
-  .bs-chart__cards {
-    flex-direction: column;
-  }
-
-  .bs-chart__group + .bs-chart__group {
-    margin-left: 0;
-    margin-top: 20px;
-  }
-
-  .bs-chart__card + .bs-chart__card {
-    margin-left: 0;
-    margin-top: 8px;
-  }
-}
-</style>
-```


### PR DESCRIPTION
this is a quick-and-dirty restoration of the styling on the browser support page, where we had some custom stuff before. The web team should go over this in more detail at some point, but this at least gets us away from some unstyled text that is there atm.