### PR TITLE
docs(lifecycle): temp remove clock example

### DIFF
--- a/docs/components/component-lifecycle.md
+++ b/docs/components/component-lifecycle.md
@@ -182,8 +182,3 @@ export class CustomClock {
   }
 }
 ```
-
-:::note
-Here is the example running.  If you want to see it in action then just inspect it with dev tools.
-<custom-clock/>
-:::

--- a/versioned_docs/version-v2/components/component-lifecycle.md
+++ b/versioned_docs/version-v2/components/component-lifecycle.md
@@ -182,8 +182,3 @@ export class CustomClock {
   }
 }
 ```
-
-:::note
-Here is the example running.  If you want to see it in action then just inspect it with dev tools.
-<custom-clock/>
-:::

--- a/versioned_docs/version-v3.0/components/component-lifecycle.md
+++ b/versioned_docs/version-v3.0/components/component-lifecycle.md
@@ -182,8 +182,3 @@ export class CustomClock {
   }
 }
 ```
-
-:::note
-Here is the example running.  If you want to see it in action then just inspect it with dev tools.
-<custom-clock/>
-:::


### PR DESCRIPTION
in the migration to docusaurus, the live clock example broke. this commit temporarily removes it while we work through the best way to configure/load the stencil component in the future (that way the docs don't appear broken)

relates to: https://github.com/ionic-team/stencil-site/issues/1010, although it does _not_ close the issue