### PR TITLE
docs(host-element): add snippet for definite assignment assertion

### DIFF
--- a/docs/components/host-element.md
+++ b/docs/components/host-element.md
@@ -100,6 +100,20 @@ export class TodoList {
 }
 ```
 
+You can also use the host element reference when initializing class members by using Typescript's definite assignment assertion modifiers:
+
+```tsx
+import { Element } from '@stencil/core';
+
+...
+export class TodoList {
+
+  @Element() el!: HTMLElement;
+
+  private listHeight = this.el.getBoundingClientRect().height;
+}
+```
+
 If you need to update the host element in response to prop or state changes, you should do so in the `render()` method using the `<Host>` element.
 
 ## Styling

--- a/docs/components/host-element.md
+++ b/docs/components/host-element.md
@@ -100,7 +100,8 @@ export class TodoList {
 }
 ```
 
-You can also use the host element reference when initializing class members by using Typescript's definite assignment assertion modifiers:
+In order to reference the host element when initializing a class member you'll need to use TypeScript's definite assignment assertion modifier to avoid a 
+type error:
 
 ```tsx
 import { Element } from '@stencil/core';

--- a/versioned_docs/version-v2/components/host-element.md
+++ b/versioned_docs/version-v2/components/host-element.md
@@ -100,6 +100,20 @@ export class TodoList {
 }
 ```
 
+You can also use the host element reference when initializing class members by using Typescript's definite assignment assertion modifiers:
+
+```tsx
+import { Element } from '@stencil/core';
+
+...
+export class TodoList {
+
+  @Element() el!: HTMLElement;
+
+  private listHeight = this.el.getBoundingClientRect().height;
+}
+```
+
 If you need to update the host element in response to prop or state changes, you should do so in the `render()` method using the `<Host>` element.
 
 ## Styling

--- a/versioned_docs/version-v2/components/host-element.md
+++ b/versioned_docs/version-v2/components/host-element.md
@@ -100,7 +100,8 @@ export class TodoList {
 }
 ```
 
-You can also use the host element reference when initializing class members by using Typescript's definite assignment assertion modifiers:
+In order to reference the host element when initializing a class member you'll need to use TypeScript's definite assignment assertion modifier to avoid a 
+type error:
 
 ```tsx
 import { Element } from '@stencil/core';

--- a/versioned_docs/version-v3.0/components/host-element.md
+++ b/versioned_docs/version-v3.0/components/host-element.md
@@ -100,6 +100,20 @@ export class TodoList {
 }
 ```
 
+You can also use the host element reference when initializing class members by using Typescript's definite assignment assertion modifiers:
+
+```tsx
+import { Element } from '@stencil/core';
+
+...
+export class TodoList {
+
+  @Element() el!: HTMLElement;
+
+  private listHeight = this.el.getBoundingClientRect().height;
+}
+```
+
 If you need to update the host element in response to prop or state changes, you should do so in the `render()` method using the `<Host>` element.
 
 ## Styling

--- a/versioned_docs/version-v3.0/components/host-element.md
+++ b/versioned_docs/version-v3.0/components/host-element.md
@@ -100,7 +100,8 @@ export class TodoList {
 }
 ```
 
-You can also use the host element reference when initializing class members by using Typescript's definite assignment assertion modifiers:
+In order to reference the host element when initializing a class member you'll need to use TypeScript's definite assignment assertion modifier to avoid a 
+type error:
 
 ```tsx
 import { Element } from '@stencil/core';


### PR DESCRIPTION
This commit adds a small snippet to the host element docs to show using TS's definite assignment assertion modifiers for class member initialization. Closes [#2660](https://github.com/ionic-team/stencil/issues/2660)