### PR TITLE
chore: remove enterprise links

### DIFF
--- a/docs/guides/design-systems.md
+++ b/docs/guides/design-systems.md
@@ -78,7 +78,3 @@ Learn more about why web components are ideal for design systems in [this blog p
 ### How to Get Started
 Stencil’s out-the-box features will help you build your own library of universal UI components that will work across platforms, devices, and front-end frameworks.
 Review the documentation on this site to get started.
-
-__Need help building and scaling your company's design system?__
-With Ionic as your development partner, you can reduce design debt, connect disparate tech teams, and get assistance enforcing brand consistency at scale.
-[Learn more about Stencil Enterprise](https://ionic.io/products/stencil).

--- a/docs/reference/support-policy.md
+++ b/docs/reference/support-policy.md
@@ -32,9 +32,6 @@ The current status of each Stencil version is:
 
 **Maintenance Period**: Only critical bug and security fixes. No major feature improvements.
 
-**Extended Support Period**: For teams and organizations that require additional long term support, Ionic has extended 
-support options available. To learn more, see our
-[Enterprise offerings](https://ionicframework.com/sales?product_of_interest=Design%20Systems).
 
 ### Stencil Support Details
 

--- a/docs/reference/support-policy.md
+++ b/docs/reference/support-policy.md
@@ -32,6 +32,7 @@ The current status of each Stencil version is:
 
 **Maintenance Period**: Only critical bug and security fixes. No major feature improvements.
 
+**Extended Support Period**: Available to Stencil Enterprise customers.
 
 ### Stencil Support Details
 

--- a/versioned_docs/version-v2/guides/design-systems.md
+++ b/versioned_docs/version-v2/guides/design-systems.md
@@ -78,7 +78,3 @@ Learn more about why web components are ideal for design systems in [this blog p
 ### How to Get Started
 Stencil’s out-the-box features will help you build your own library of universal UI components that will work across platforms, devices, and front-end frameworks.
 Review the documentation on this site to get started.
-
-__Need help building and scaling your company's design system?__
-With Ionic as your development partner, you can reduce design debt, connect disparate tech teams, and get assistance enforcing brand consistency at scale.
-[Learn more about Stencil Enterprise](https://ionic.io/products/stencil).

--- a/versioned_docs/version-v2/reference/support-policy.md
+++ b/versioned_docs/version-v2/reference/support-policy.md
@@ -31,21 +31,12 @@ The current status of each Stencil version is:
 
 **Maintenance Period**: Only critical bug and security fixes. No major feature improvements.
 
-**Extended Support Period**: For teams and organizations that require additional long term support, Ionic has extended 
-support options available. To learn more, see our
-[Enterprise offerings](https://ionicframework.com/sales?product_of_interest=Design%20Systems).
-
 ### Stencil Support Details
 
 Starting with Stencil v2, the Stencil team is adopting a newly revised maintenance policy. When a new major version of
 Stencil is released, the previous major version release will enter maintenance mode. While a version of Stencil is in
 maintenance mode, only critical bug & security fixes will be applied to that version, and no major feature improvements
 will be added. The maintenance period shall last six months from the release of the new major version.
-
-Once the maintenance period has ended for a version of Stencil, that version enters the extended support period. During
-the extended support period, only critical bug and security fixes will be applied for teams and organizations using
-Stencil's Enterprise offerings. The extended support period lasts for six months from the release of the new major 
-version.
 
 The table below describes a theoretical timeline of releases:
 

--- a/versioned_docs/version-v2/reference/support-policy.md
+++ b/versioned_docs/version-v2/reference/support-policy.md
@@ -31,6 +31,8 @@ The current status of each Stencil version is:
 
 **Maintenance Period**: Only critical bug and security fixes. No major feature improvements.
 
+**Extended Support Period**: Available to Stencil Enterprise customers.
+
 ### Stencil Support Details
 
 Starting with Stencil v2, the Stencil team is adopting a newly revised maintenance policy. When a new major version of

--- a/versioned_docs/version-v2/reference/support-policy.md
+++ b/versioned_docs/version-v2/reference/support-policy.md
@@ -40,6 +40,11 @@ Stencil is released, the previous major version release will enter maintenance m
 maintenance mode, only critical bug & security fixes will be applied to that version, and no major feature improvements
 will be added. The maintenance period shall last six months from the release of the new major version.
 
+Once the maintenance period has ended for a version of Stencil, that version enters the extended support period. During
+the extended support period, only critical bug and security fixes will be applied for teams and organizations using
+Stencil's Enterprise offerings. The extended support period lasts for six months from the release of the new major 
+version.
+
 The table below describes a theoretical timeline of releases:
 
 | Version |        Status         |   Released   | Maintenance Ends | Ext. Support Ends |

--- a/versioned_docs/version-v3.0/guides/design-systems.md
+++ b/versioned_docs/version-v3.0/guides/design-systems.md
@@ -78,7 +78,3 @@ Learn more about why web components are ideal for design systems in [this blog p
 ### How to Get Started
 Stencil’s out-the-box features will help you build your own library of universal UI components that will work across platforms, devices, and front-end frameworks.
 Review the documentation on this site to get started.
-
-__Need help building and scaling your company's design system?__
-With Ionic as your development partner, you can reduce design debt, connect disparate tech teams, and get assistance enforcing brand consistency at scale.
-[Learn more about Stencil Enterprise](https://ionic.io/products/stencil).

--- a/versioned_docs/version-v3.0/reference/support-policy.md
+++ b/versioned_docs/version-v3.0/reference/support-policy.md
@@ -32,6 +32,8 @@ The current status of each Stencil version is:
 
 **Maintenance Period**: Only critical bug and security fixes. No major feature improvements.
 
+**Extended Support Period**: Available to Stencil Enterprise customers.
+
 ### Stencil Support Details
 
 Starting with Stencil v2, the Stencil team is adopting a newly revised maintenance policy. When a new major version of

--- a/versioned_docs/version-v3.0/reference/support-policy.md
+++ b/versioned_docs/version-v3.0/reference/support-policy.md
@@ -32,21 +32,12 @@ The current status of each Stencil version is:
 
 **Maintenance Period**: Only critical bug and security fixes. No major feature improvements.
 
-**Extended Support Period**: For teams and organizations that require additional long term support, Ionic has extended 
-support options available. To learn more, see our
-[Enterprise offerings](https://ionicframework.com/sales?product_of_interest=Design%20Systems).
-
 ### Stencil Support Details
 
 Starting with Stencil v2, the Stencil team is adopting a newly revised maintenance policy. When a new major version of
 Stencil is released, the previous major version release will enter maintenance mode. While a version of Stencil is in
 maintenance mode, only critical bug & security fixes will be applied to that version, and no major feature improvements
 will be added. The maintenance period shall last six months from the release of the new major version.
-
-Once the maintenance period has ended for a version of Stencil, that version enters the extended support period. During
-the extended support period, only critical bug and security fixes will be applied for teams and organizations using
-Stencil's Enterprise offerings. The extended support period lasts for six months from the release of the new major 
-version.
 
 The table below describes a theoretical timeline of releases:
 

--- a/versioned_docs/version-v3.0/reference/support-policy.md
+++ b/versioned_docs/version-v3.0/reference/support-policy.md
@@ -41,6 +41,11 @@ Stencil is released, the previous major version release will enter maintenance m
 maintenance mode, only critical bug & security fixes will be applied to that version, and no major feature improvements
 will be added. The maintenance period shall last six months from the release of the new major version.
 
+Once the maintenance period has ended for a version of Stencil, that version enters the extended support period. During
+the extended support period, only critical bug and security fixes will be applied for teams and organizations using
+Stencil's Enterprise offerings. The extended support period lasts for six months from the release of the new major 
+version.
+
 The table below describes a theoretical timeline of releases:
 
 | Version |        Status         |   Released   | Maintenance Ends | Ext. Support Ends |


### PR DESCRIPTION
Removes enterprise related links/language from the docs:
- Removes the "Enterprise support" links from the design system page(s)
- Updates the text copy in the extended enterprise support section and support policy