### PR TITLE
docs(csp-guide): updates guide to remove `autoDefineCustomElements` ref

### DIFF
--- a/docs/guides/csp-nonce.md
+++ b/docs/guides/csp-nonce.md
@@ -80,7 +80,7 @@ This is an example of consuming the `dist-custom-elements` output in an Angular 
 // main.ts
 
 import { defineCustomElements, setNonce } from 'my-lib/dist/components';
-// Assume `autoDefineCustomElements` is enabled enabled
+// Assume `autoDefineCustomElements` is enabled
 import 'my-lib/dist/components/my-component';
 
 // Will set the `nonce` attribute for all scripts/style tags

--- a/docs/guides/csp-nonce.md
+++ b/docs/guides/csp-nonce.md
@@ -80,7 +80,7 @@ This is an example of consuming the `dist-custom-elements` output in an Angular 
 // main.ts
 
 import { defineCustomElements, setNonce } from 'my-lib/dist/components';
-// Assume `autoDefineCustomElements` is enabled
+// Assume `customElementsExportBehavior: 'auto-define-custom-elements'` is set
 import 'my-lib/dist/components/my-component';
 
 // Will set the `nonce` attribute for all scripts/style tags

--- a/versioned_docs/version-v2/guides/csp-nonce.md
+++ b/versioned_docs/version-v2/guides/csp-nonce.md
@@ -80,7 +80,7 @@ This is an example of consuming the `dist-custom-elements` output in an Angular 
 // main.ts
 
 import { defineCustomElements, setNonce } from 'my-lib/dist/components';
-// Assume `autoDefineCustomElements` is enabled enabled
+// Assume `autoDefineCustomElements` is enabled
 import 'my-lib/dist/components/my-component';
 
 // Will set the `nonce` attribute for all scripts/style tags

--- a/versioned_docs/version-v3.0/guides/csp-nonce.md
+++ b/versioned_docs/version-v3.0/guides/csp-nonce.md
@@ -80,7 +80,7 @@ This is an example of consuming the `dist-custom-elements` output in an Angular 
 // main.ts
 
 import { defineCustomElements, setNonce } from 'my-lib/dist/components';
-// Assume `autoDefineCustomElements` is enabled enabled
+// Assume `customElementsExportBehavior: 'auto-define-custom-elements'` is set
 import 'my-lib/dist/components/my-component';
 
 // Will set the `nonce` attribute for all scripts/style tags


### PR DESCRIPTION
- Removes a reference to `autoDefineCustomElements` in the CSP nonce guide in favor of the new `customElementsExportBehavior` option
- Removes some redundant wording in older docs versions