### PR TITLE
chore(github): add dependabot to stencil docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: 'npm' # See documentation for possible values
+    directory: '/' # Location of package manifests
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 50
+    # Disable rebasing for pull requests, as having several open pull requests all get simultaneously rebased gets
+    # noisy from a notification standpoint
+    rebase-strategy: 'disabled'


### PR DESCRIPTION
this commit adds a dependabot configuration to the stencil site to check for updated packages used by the site itself.

at the time of this commit, the ionic-preset-classic project was intentionally excluded from this configuration, as we expect it to be a separate npm package in the near future.

this configuration checks weekly (as oppposed to daily in other stencil projects) in order to see how a weekly-based notification might help balance providing the team more time to work on stencil, rather than dependabot updates.