### PR TITLE
docs(v3): add minimum supported versions for other stencil packages

### DIFF
--- a/docs/introduction/upgrading-to-stencil-three.md
+++ b/docs/introduction/upgrading-to-stencil-three.md
@@ -406,6 +406,19 @@ $ npm uninstall @types/puppeteer
 
 To see which versions of Puppeteer are supported by Stencil, please see our [support matrix](/docs/support-policy#puppeteer)
 
+## Additional Packages
+
+In order to guarantee that other `@stencil/` packages will continue to function as expected,
+it's recommended that a project that uses any of the packages listed below updates to the listed minimum package version.
+
+| Package                          | Minimum Package Version | GitHub                                                            | Documentation                                               |
+|----------------------------------|-------------------------|-------------------------------------------------------------------|-------------------------------------------------------------|
+| `@stencil-angular-output-target` | 0.5.0                   | [GitHub](https://github.com/ionic-team/stencil-ds-output-targets) | [Stencil Doc Site](/docs/angular)                           |
+| `@stencil/sass`                  | 2.0.3                   | [GitHub](https://github.com/ionic-team/stencil-sass)              | [GitHub README](https://github.com/ionic-team/stencil-sass) |
+| `@stencil/store`                 | 2.0.0                   | [GitHub](https://github.com/ionic-team/stencil-store)             | [Stencil Doc Site](/docs/stencil-store)                     |
+| `@stencil-react-output-target`   | 0.4.0                   | [GitHub](https://github.com/ionic-team/stencil-ds-output-targets) | [Stencil Doc Site](/docs/react)                             |
+| `@stencil-vue-output-target`     | 0.7.0                   | [GitHub](https://github.com/ionic-team/stencil-ds-output-targets) | [Stencil Doc Site](/docs/vue)                               |
+
 ## Need Help Upgrading?
 
 Be sure to look at the Stencil [v3.0.0 Breaking Changes Guide](https://github.com/ionic-team/stencil/blob/main/BREAKING_CHANGES.md#stencil-v300).

--- a/docs/introduction/upgrading-to-stencil-three.md
+++ b/docs/introduction/upgrading-to-stencil-three.md
@@ -411,13 +411,13 @@ To see which versions of Puppeteer are supported by Stencil, please see our [sup
 In order to guarantee that other `@stencil/` packages will continue to function as expected,
 it's recommended that a project that uses any of the packages listed below updates to the listed minimum package version.
 
-| Package                          | Minimum Package Version | GitHub                                                            | Documentation                                               |
-|----------------------------------|-------------------------|-------------------------------------------------------------------|-------------------------------------------------------------|
-| `@stencil-angular-output-target` | 0.5.0                   | [GitHub](https://github.com/ionic-team/stencil-ds-output-targets) | [Stencil Doc Site](/docs/angular)                           |
-| `@stencil/sass`                  | 2.0.3                   | [GitHub](https://github.com/ionic-team/stencil-sass)              | [GitHub README](https://github.com/ionic-team/stencil-sass) |
-| `@stencil/store`                 | 2.0.0                   | [GitHub](https://github.com/ionic-team/stencil-store)             | [Stencil Doc Site](/docs/stencil-store)                     |
-| `@stencil-react-output-target`   | 0.4.0                   | [GitHub](https://github.com/ionic-team/stencil-ds-output-targets) | [Stencil Doc Site](/docs/react)                             |
-| `@stencil-vue-output-target`     | 0.7.0                   | [GitHub](https://github.com/ionic-team/stencil-ds-output-targets) | [Stencil Doc Site](/docs/vue)                               |
+| Package                          | Minimum Package Version                                                                                                  | GitHub                                                            | Documentation                                               |
+|----------------------------------|--------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------|-------------------------------------------------------------|
+| `@stencil-angular-output-target` | [0.5.0](https://github.com/ionic-team/stencil-ds-output-targets/releases/tag/%40stencil%2Fangular-output-target%400.5.0) | [GitHub](https://github.com/ionic-team/stencil-ds-output-targets) | [Stencil Doc Site](/docs/angular)                           |
+| `@stencil/sass`                  | [2.0.3](https://github.com/ionic-team/stencil-sass/releases/tag/v2.0.3)                                                  | [GitHub](https://github.com/ionic-team/stencil-sass)              | [GitHub README](https://github.com/ionic-team/stencil-sass) |
+| `@stencil/store`                 | [2.0.0](https://github.com/ionic-team/stencil-store/releases/tag/v2.0.0)                                                 | [GitHub](https://github.com/ionic-team/stencil-store)             | [Stencil Doc Site](/docs/stencil-store)                     |
+| `@stencil-react-output-target`   | [0.4.0](https://github.com/ionic-team/stencil-ds-output-targets/releases/tag/%40stencil%2Freact-output-target%400.4.0)   | [GitHub](https://github.com/ionic-team/stencil-ds-output-targets) | [Stencil Doc Site](/docs/react)                             |
+| `@stencil-vue-output-target`     | [0.7.0](https://github.com/ionic-team/stencil-ds-output-targets/releases/tag/%40stencil%2Fvue-output-target%400.7.0)     | [GitHub](https://github.com/ionic-team/stencil-ds-output-targets) | [Stencil Doc Site](/docs/vue)                               |
 
 ## Need Help Upgrading?
 

--- a/versioned_docs/version-v2/introduction/upgrading-to-stencil-three.md
+++ b/versioned_docs/version-v2/introduction/upgrading-to-stencil-three.md
@@ -409,13 +409,13 @@ $ npm uninstall @types/puppeteer
 In order to guarantee that other `@stencil/` packages will continue to function as expected,
 it's recommended that a project that uses any of the packages listed below updates to the listed minimum package version.
 
-| Package                          | Minimum Package Version | GitHub                                                            | Documentation                                               |
-|----------------------------------|-------------------------|-------------------------------------------------------------------|-------------------------------------------------------------|
-| `@stencil-angular-output-target` | 0.5.0                   | [GitHub](https://github.com/ionic-team/stencil-ds-output-targets) | [Stencil Doc Site](/docs/angular)                           |
-| `@stencil/sass`                  | 2.0.3                   | [GitHub](https://github.com/ionic-team/stencil-sass)              | [GitHub README](https://github.com/ionic-team/stencil-sass) |
-| `@stencil/store`                 | 2.0.0                   | [GitHub](https://github.com/ionic-team/stencil-store)             | [Stencil Doc Site](/docs/stencil-store)                     |
-| `@stencil-react-output-target`   | 0.4.0                   | [GitHub](https://github.com/ionic-team/stencil-ds-output-targets) | [Stencil Doc Site](/docs/react)                             |
-| `@stencil-vue-output-target`     | 0.7.0                   | [GitHub](https://github.com/ionic-team/stencil-ds-output-targets) | [Stencil Doc Site](/docs/vue)                               |
+| Package                          | Minimum Package Version                                                                                                  | GitHub                                                            | Documentation                                               |
+|----------------------------------|--------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------|-------------------------------------------------------------|
+| `@stencil-angular-output-target` | [0.5.0](https://github.com/ionic-team/stencil-ds-output-targets/releases/tag/%40stencil%2Fangular-output-target%400.5.0) | [GitHub](https://github.com/ionic-team/stencil-ds-output-targets) | [Stencil Doc Site](/docs/angular)                           |
+| `@stencil/sass`                  | [2.0.3](https://github.com/ionic-team/stencil-sass/releases/tag/v2.0.3)                                                  | [GitHub](https://github.com/ionic-team/stencil-sass)              | [GitHub README](https://github.com/ionic-team/stencil-sass) |
+| `@stencil/store`                 | [2.0.0](https://github.com/ionic-team/stencil-store/releases/tag/v2.0.0)                                                 | [GitHub](https://github.com/ionic-team/stencil-store)             | [Stencil Doc Site](/docs/stencil-store)                     |
+| `@stencil-react-output-target`   | [0.4.0](https://github.com/ionic-team/stencil-ds-output-targets/releases/tag/%40stencil%2Freact-output-target%400.4.0)   | [GitHub](https://github.com/ionic-team/stencil-ds-output-targets) | [Stencil Doc Site](/docs/react)                             |
+| `@stencil-vue-output-target`     | [0.7.0](https://github.com/ionic-team/stencil-ds-output-targets/releases/tag/%40stencil%2Fvue-output-target%400.7.0)     | [GitHub](https://github.com/ionic-team/stencil-ds-output-targets) | [Stencil Doc Site](/docs/vue)                               |
 
 ## Need Help Upgrading?
 

--- a/versioned_docs/version-v2/introduction/upgrading-to-stencil-three.md
+++ b/versioned_docs/version-v2/introduction/upgrading-to-stencil-three.md
@@ -404,6 +404,19 @@ $ npm install puppeteer
 $ npm uninstall @types/puppeteer
 ```
 
+## Additional Packages
+
+In order to guarantee that other `@stencil/` packages will continue to function as expected,
+it's recommended that a project that uses any of the packages listed below updates to the listed minimum package version.
+
+| Package                          | Minimum Package Version | GitHub                                                            | Documentation                                               |
+|----------------------------------|-------------------------|-------------------------------------------------------------------|-------------------------------------------------------------|
+| `@stencil-angular-output-target` | 0.5.0                   | [GitHub](https://github.com/ionic-team/stencil-ds-output-targets) | [Stencil Doc Site](/docs/angular)                           |
+| `@stencil/sass`                  | 2.0.3                   | [GitHub](https://github.com/ionic-team/stencil-sass)              | [GitHub README](https://github.com/ionic-team/stencil-sass) |
+| `@stencil/store`                 | 2.0.0                   | [GitHub](https://github.com/ionic-team/stencil-store)             | [Stencil Doc Site](/docs/stencil-store)                     |
+| `@stencil-react-output-target`   | 0.4.0                   | [GitHub](https://github.com/ionic-team/stencil-ds-output-targets) | [Stencil Doc Site](/docs/react)                             |
+| `@stencil-vue-output-target`     | 0.7.0                   | [GitHub](https://github.com/ionic-team/stencil-ds-output-targets) | [Stencil Doc Site](/docs/vue)                               |
+
 ## Need Help Upgrading?
 
 Be sure to look at the Stencil [v3.0.0 Breaking Changes Guide](https://github.com/ionic-team/stencil/blob/v3.0.0-dev/BREAKING_CHANGES.md#stencil-v300).

--- a/versioned_docs/version-v3.0/introduction/upgrading-to-stencil-three.md
+++ b/versioned_docs/version-v3.0/introduction/upgrading-to-stencil-three.md
@@ -406,6 +406,19 @@ $ npm uninstall @types/puppeteer
 
 To see which versions of Puppeteer are supported by Stencil, please see our [support matrix](/docs/support-policy#puppeteer)
 
+## Additional Packages
+
+In order to guarantee that other `@stencil/` packages will continue to function as expected,
+it's recommended that a project that uses any of the packages listed below updates to the listed minimum package version.
+
+| Package                          | Minimum Package Version | GitHub                                                            | Documentation                                               |
+|----------------------------------|-------------------------|-------------------------------------------------------------------|-------------------------------------------------------------|
+| `@stencil-angular-output-target` | 0.5.0                   | [GitHub](https://github.com/ionic-team/stencil-ds-output-targets) | [Stencil Doc Site](/docs/angular)                           |
+| `@stencil/sass`                  | 2.0.3                   | [GitHub](https://github.com/ionic-team/stencil-sass)              | [GitHub README](https://github.com/ionic-team/stencil-sass) |
+| `@stencil/store`                 | 2.0.0                   | [GitHub](https://github.com/ionic-team/stencil-store)             | [Stencil Doc Site](/docs/stencil-store)                     |
+| `@stencil-react-output-target`   | 0.4.0                   | [GitHub](https://github.com/ionic-team/stencil-ds-output-targets) | [Stencil Doc Site](/docs/react)                             |
+| `@stencil-vue-output-target`     | 0.7.0                   | [GitHub](https://github.com/ionic-team/stencil-ds-output-targets) | [Stencil Doc Site](/docs/vue)                               |
+
 ## Need Help Upgrading?
 
 Be sure to look at the Stencil [v3.0.0 Breaking Changes Guide](https://github.com/ionic-team/stencil/blob/main/BREAKING_CHANGES.md#stencil-v300).

--- a/versioned_docs/version-v3.0/introduction/upgrading-to-stencil-three.md
+++ b/versioned_docs/version-v3.0/introduction/upgrading-to-stencil-three.md
@@ -411,13 +411,13 @@ To see which versions of Puppeteer are supported by Stencil, please see our [sup
 In order to guarantee that other `@stencil/` packages will continue to function as expected,
 it's recommended that a project that uses any of the packages listed below updates to the listed minimum package version.
 
-| Package                          | Minimum Package Version | GitHub                                                            | Documentation                                               |
-|----------------------------------|-------------------------|-------------------------------------------------------------------|-------------------------------------------------------------|
-| `@stencil-angular-output-target` | 0.5.0                   | [GitHub](https://github.com/ionic-team/stencil-ds-output-targets) | [Stencil Doc Site](/docs/angular)                           |
-| `@stencil/sass`                  | 2.0.3                   | [GitHub](https://github.com/ionic-team/stencil-sass)              | [GitHub README](https://github.com/ionic-team/stencil-sass) |
-| `@stencil/store`                 | 2.0.0                   | [GitHub](https://github.com/ionic-team/stencil-store)             | [Stencil Doc Site](/docs/stencil-store)                     |
-| `@stencil-react-output-target`   | 0.4.0                   | [GitHub](https://github.com/ionic-team/stencil-ds-output-targets) | [Stencil Doc Site](/docs/react)                             |
-| `@stencil-vue-output-target`     | 0.7.0                   | [GitHub](https://github.com/ionic-team/stencil-ds-output-targets) | [Stencil Doc Site](/docs/vue)                               |
+| Package                          | Minimum Package Version                                                                                                  | GitHub                                                            | Documentation                                               |
+|----------------------------------|--------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------|-------------------------------------------------------------|
+| `@stencil-angular-output-target` | [0.5.0](https://github.com/ionic-team/stencil-ds-output-targets/releases/tag/%40stencil%2Fangular-output-target%400.5.0) | [GitHub](https://github.com/ionic-team/stencil-ds-output-targets) | [Stencil Doc Site](/docs/angular)                           |
+| `@stencil/sass`                  | [2.0.3](https://github.com/ionic-team/stencil-sass/releases/tag/v2.0.3)                                                  | [GitHub](https://github.com/ionic-team/stencil-sass)              | [GitHub README](https://github.com/ionic-team/stencil-sass) |
+| `@stencil/store`                 | [2.0.0](https://github.com/ionic-team/stencil-store/releases/tag/v2.0.0)                                                 | [GitHub](https://github.com/ionic-team/stencil-store)             | [Stencil Doc Site](/docs/stencil-store)                     |
+| `@stencil-react-output-target`   | [0.4.0](https://github.com/ionic-team/stencil-ds-output-targets/releases/tag/%40stencil%2Freact-output-target%400.4.0)   | [GitHub](https://github.com/ionic-team/stencil-ds-output-targets) | [Stencil Doc Site](/docs/react)                             |
+| `@stencil-vue-output-target`     | [0.7.0](https://github.com/ionic-team/stencil-ds-output-targets/releases/tag/%40stencil%2Fvue-output-target%400.7.0)     | [GitHub](https://github.com/ionic-team/stencil-ds-output-targets) | [Stencil Doc Site](/docs/vue)                               |
 
 ## Need Help Upgrading?
 


### PR DESCRIPTION
this commit adds a table with the minimum supported versions (or, strongly recommeneded versions) of other `@stencil` scoped packages to upgrade

![Screenshot 2023-02-03 at 7 57 07 AM](https://user-images.githubusercontent.com/1930213/216608971-2cec4d52-171b-42d3-bcea-c5e84b5ac0e4.png)
