### PR TITLE
chore(github): add mdx-js to dependabot ignore list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,7 @@ updates:
         versions: ['>=18']
       - dependency-name: 'react-dom'
         versions: ['>=18']
+      # Docusaurus does not support v2 of mdx at the time of this writing.
+      # See: https://github.com/facebook/docusaurus/issues/4029
+      - dependency-name: '@mdx-js/react'
+        versions: ['>=2']


### PR DESCRIPTION
this commit adds `@mdx-js/react` v2+ to the dependabot ignore list. at the time of this writing, we're on the latest version of docusaurus, which does not support the latest version of mdx. ignore it so dependabot does not keep rebasing an upgrade pr for us

Supersedes: https://github.com/ionic-team/stencil-site/pull/1030