### PR TITLE
docs(angular): add "defining custom elements" section header

### DIFF
--- a/docs/framework-integration/angular.md
+++ b/docs/framework-integration/angular.md
@@ -213,6 +213,8 @@ export { DIRECTIVES } from './lib/stencil-generated';
 export * from './lib/stencil-generated/components';
 ```
 
+### Registering Custom Elements
+
 The default behavior for this output target does not handle automatically defining/registering the custom elements. One strategy (and the approach
 the [Ionic Framework](https://github.com/ionic-team/ionic-framework/blob/main/angular/src/app-initialize.ts#L21-L34) takes) is to use the loader to define all custom elements during app initialization:
 

--- a/versioned_docs/version-v2/framework-integration/angular.md
+++ b/versioned_docs/version-v2/framework-integration/angular.md
@@ -213,6 +213,8 @@ export { DIRECTIVES } from './lib/stencil-generated';
 export * from './lib/stencil-generated/components';
 ```
 
+### Registering Custom Elements
+
 The default behavior for this output target does not handle automatically defining/registering the custom elements. One strategy (and the approach
 the [Ionic Framework](https://github.com/ionic-team/ionic-framework/blob/main/angular/src/app-initialize.ts#L21-L34) takes) is to use the loader to define all custom elements during app initialization:
 

--- a/versioned_docs/version-v3.0/framework-integration/angular.md
+++ b/versioned_docs/version-v3.0/framework-integration/angular.md
@@ -213,6 +213,8 @@ export { DIRECTIVES } from './lib/stencil-generated';
 export * from './lib/stencil-generated/components';
 ```
 
+### Registering Custom Elements
+
 The default behavior for this output target does not handle automatically defining/registering the custom elements. One strategy (and the approach
 the [Ionic Framework](https://github.com/ionic-team/ionic-framework/blob/main/angular/src/app-initialize.ts#L21-L34) takes) is to use the loader to define all custom elements during app initialization:
 


### PR DESCRIPTION
Adds a section header for "defining custom elements" to the Angular guide. This aligns the "setup" sections of all three guides to have (mostly) the same structure.