### PR TITLE
Update reactive-data.md | Documentation typo

### DIFF
--- a/docs/components/reactive-data.md
+++ b/docs/components/reactive-data.md
@@ -120,7 +120,7 @@ export class RandomNumbers {
        * This does not create a new array. When stencil
        * attempts to see if any Watched members have changed,
        * it sees the reference to its `randNumbers` State is
-       * the same, and will not trigger `@Watch` or are-render
+       * the same, and will not trigger `@Watch` or a re-render
        */
       // this.randNumbers.push(newVal)
 

--- a/versioned_docs/version-v2/components/reactive-data.md
+++ b/versioned_docs/version-v2/components/reactive-data.md
@@ -120,7 +120,7 @@ export class RandomNumbers {
        * This does not create a new array. When stencil
        * attempts to see if any Watched members have changed,
        * it sees the reference to its `randNumbers` State is
-       * the same, and will not trigger `@Watch` or are-render
+       * the same, and will not trigger `@Watch` or a re-render
        */
       // this.randNumbers.push(newVal)
 

--- a/versioned_docs/version-v3.0/components/reactive-data.md
+++ b/versioned_docs/version-v3.0/components/reactive-data.md
@@ -120,7 +120,7 @@ export class RandomNumbers {
        * This does not create a new array. When stencil
        * attempts to see if any Watched members have changed,
        * it sees the reference to its `randNumbers` State is
-       * the same, and will not trigger `@Watch` or are-render
+       * the same, and will not trigger `@Watch` or a re-render
        */
       // this.randNumbers.push(newVal)
 


### PR DESCRIPTION

## Changes

- add missing space replacing "are-render" with "a re-render"

## Closes

https://github.com/ionic-team/stencil-site/issues/1042