### PR TITLE
docs(extras): update extras config example

### DIFF
--- a/docs/config/extras.md
+++ b/docs/config/extras.md
@@ -33,10 +33,10 @@ Example `extras` config when __supporting__ legacy browsers:
 export const config: Config = {
   buildEs5: 'prod',
   extras: {
-    cssVarsShim: true,
+    __deprecated__cssVarsShim: true,
     __deprecated__dynamicImportShim: true,
-    shadowDomShim: true,
-    safari10: true,
+    __deprecated__shadowDomShim: true,
+    __deprecated__safari10: true,
     scriptDataOpts: true,
     appendChildSlotFix: false,
     cloneNodeFix: false,

--- a/versioned_docs/version-v3.0/config/extras.md
+++ b/versioned_docs/version-v3.0/config/extras.md
@@ -33,10 +33,10 @@ Example `extras` config when __supporting__ legacy browsers:
 export const config: Config = {
   buildEs5: 'prod',
   extras: {
-    cssVarsShim: true,
+    __deprecated__cssVarsShim: true,
     __deprecated__dynamicImportShim: true,
-    shadowDomShim: true,
-    safari10: true,
+    __deprecated__shadowDomShim: true,
+    __deprecated__safari10: true,
     scriptDataOpts: true,
     appendChildSlotFix: false,
     cloneNodeFix: false,


### PR DESCRIPTION
this commit updates the extras config example to use the '__deprecated__' prefix for deprecated fields (starting with v3.0.0)