### PR TITLE
chore(infra): add volta to the project

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,5 +47,9 @@
       "last 1 safari version"
     ]
   },
-  "prettier": "@ionic/prettier-config"
+  "prettier": "@ionic/prettier-config",
+  "volta": {
+    "node": "18.14.2",
+    "npm": "9.5.0"
+  }
 }


### PR DESCRIPTION
this commit adds volta to the project, allowing for the team to be using a consistent version of node/npm when working on the site. when volta is on the developers PATH, the version of npm/node will be set automatically for them. this is being done to align with the rest of the stencil developer environments found in stencil, stencil-sass, etc