### PR TITLE
chore(contributing): update contributing for docusaurus

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,8 @@ We have very precise rules over how our git commit messages should be formatted.
 Should be `docs`
 
 #### Scope
-The scope can be anything specifying the place of the commit change. For example `props`, `angular`, etc. If you make multiple commits for the same doc, please keep the naming of this doc consistent. For example, if you make a change to the `@Prop` docs and the first commit is `docs(prop)`, you should continue to use `prop` for any more commits related to navigation.
+The scope can be anything specifying the place of the commit change.
+For example `@Prop`, `angular`, etc.
 
 #### Subject
 The subject contains a succinct description of the change:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Thanks for your interest in contributing to the Stencil Docs! :tada:
 
 * Issues with no clear steps to reproduce will not be triaged. If an issue is labeled with "needs reply" and receives no further replies from the author of the issue for more than 5 days, it will be closed.
 
-* If you think you have found a bug, or have a new feature idea, please start by making sure it hasn't already been [reported](https://github.com/ionic-team/ionic/issues?utf8=%E2%9C%93&q=is%3Aissue). You can search through existing issues to see if there is a similar one reported. Include closed issues as it may have been closed with a solution.
+* If you think you have found a bug, or have a new feature idea, please start by making sure it hasn't already been [reported](https://github.com/ionic-team/stencil-site/issues). You can search through existing issues to see if there is a similar one reported. Include closed issues as it may have been closed with a solution.
 
 * Next, [create a new issue](https://github.com/ionic-team/stencil-site/issues/new) that thoroughly explains the problem.
 
@@ -29,22 +29,43 @@ Thanks for your interest in contributing to the Stencil Docs! :tada:
 2. Clone your fork.
 3. Make a branch for your change.
 4. Run `npm install` (make sure you have [node](https://nodejs.org/en/) and [npm](http://blog.npmjs.org/post/85484771375/how-to-install-npm) installed first).
-5. Run `npm run docs` to build the documentation files.
-6. Run `npm start`.
+5. Run `npm run build` to build the documentation files.
+6. Run `npm run serve` to serve the built site.
+
+#### Directory Structure
+
+This repository contains versioned documentation for Stencil.
+Starting with Stencil v3.0, a new "version" of the doc is created for every minor version.
+These docs are found in the [`./version_docs`](./versioned_docs) directory.
+Each subdirectory corresponds to a version of the docs site that can be viewed in the Stencil Docs site.
+
+```
+versioned_docs
+├── version-v2    <- All docs for Stencil version 2
+├── version-v3.0  <- All docs for Stencil version 3.0, including patch versions (e.g. 3.0.1)
+├── version-v3.1  <- All docs for Stencil version 3.1, including patch versions (e.g. 3.1.1)
+└── etc.
+```
+
+The "next", or "upcoming" version of the docs can be found in the [`./docs`](./docs) directory.
+When it comes time to release a new minor version of Stencil, the contents of `./docs` will be copied to a new directory under the [`./version_docs`](./versioned_docs) directory with that version's name.
 
 #### Adding Documentation
 
-1. To add documentation first create a new markdown file in `docs` in the folder that fits your doc best. For example, if your doc is a guide, you would put it in `docs/guides`.
+1. To add documentation first create a new markdown file under `./versioned_docs/[version_of_docs_to_change]` in the folder that fits your doc best.
+   1. For example, if your doc is a guide for Stencil v3.0, you would put it in `./versioned_docs/version-v3.0/guides`.
+   2. Depending on the nature of the documentation, the Stencil team may wish to "port" this change to other versions of the Stencil documentation. During a review of your PR, the team will be able to give guidance how to propagate this change.
 2. Write your documentation following the style in the other docs markdown files. Try to aim for being as clear and concise as possible. We recommend checking out the [vue.js docs](https://vuejs.org/) for examples of good docs.
 3. Make sure the page header contains title, description, url and contributors. See other docs files for examples.
-4. Add your page to `src/docs/README.md` to have it appear in the table of contents.
-5. Run `npm run site.structure` then start the app with `npm start`. You should see your new page in the table of contents and be able to access it.
+4. Run `npm run build` then start the app with `npm run serve`. You should see your new page in the table of contents and be able to access it.
 
 #### Modifying documentation
 
-1. Locate the doc you want to modify in `docs/`.
+1. Locate the doc you want to modify in `./versioned_docs/[version_of_docs_to_change]`.
+   1. For example, if you wish to make changes to the Stencil v3.0 docs, you would make the change under `./versioned_docs/version-v3.0` .
+   2. Depending on the nature of the documentation, the Stencil team may wish to "port" this change to other versions of the Stencil documentation. During a review of your PR, the team will be able to give guidance how to propagate this change.
 2. Modify the documentation, making sure to keep the format the same as the rest of the doc.
-3. Run `npm run docs` then `npm start` to make sure your changes look correct.
+3. Run `npm run build` then start the app with `npm run serve`. You should see your new page in the table of contents and be able to access it.
 
 Alternatively, modify documentation through the GitHub interface.
 
@@ -58,7 +79,7 @@ We have very precise rules over how our git commit messages should be formatted.
 Should be `docs`
 
 #### Scope
-The scope can be anything specifying the place of the commit change. For example `router`, `prerendering`, etc. If you make multiple commits for the same doc, please keep the naming of this doc consistent. For example, if you make a change to the router docs and the first commit is `docs(router)`, you should continue to use `router` for any more commits related to navigation.
+The scope can be anything specifying the place of the commit change. For example `props`, `angular`, etc. If you make multiple commits for the same doc, please keep the naming of this doc consistent. For example, if you make a change to the `@Prop` docs and the first commit is `docs(prop)`, you should continue to use `prop` for any more commits related to navigation.
 
 #### Subject
 The subject contains a succinct description of the change:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,8 +29,12 @@ Thanks for your interest in contributing to the Stencil Docs! :tada:
 2. Clone your fork.
 3. Make a branch for your change.
 4. Run `npm install` (make sure you have [node](https://nodejs.org/en/) and [npm](http://blog.npmjs.org/post/85484771375/how-to-install-npm) installed first).
-5. Run `npm run build` to build the documentation files.
-6. Run `npm run serve` to serve the built site.
+5. Run `npm start` to serve the doc site
+
+Note: When running `npm start`, anchor links may not work.
+If your pull request includes anchor links, you can test them by:
+1. Run `npm run build` to build the documentation files.
+2. Run `npm run serve` to serve the built site.
 
 #### Directory Structure
 
@@ -57,7 +61,12 @@ When it comes time to release a new minor version of Stencil, the contents of `.
    2. Depending on the nature of the documentation, the Stencil team may wish to "port" this change to other versions of the Stencil documentation. During a review of your PR, the team will be able to give guidance how to propagate this change.
 2. Write your documentation following the style in the other docs markdown files. Try to aim for being as clear and concise as possible. We recommend checking out the [vue.js docs](https://vuejs.org/) for examples of good docs.
 3. Make sure the page header contains title, description, url and contributors. See other docs files for examples.
-4. Run `npm run build` then start the app with `npm run serve`. You should see your new page in the table of contents and be able to access it.
+4. Run `npm start` to start the app. You should see your new page in the table of contents and be able to access it.
+
+Note: When running `npm start`, anchor links may not work.
+If your pull request includes anchor links, you can test them by:
+1. Run `npm run build` to build the documentation files.
+2. Run `npm run serve` to serve the built site.
 
 #### Modifying documentation
 


### PR DESCRIPTION
this commit updates our contributing guide to align with the docusaurus versioning scheme that the site is now using. it updates the commands folks are expected to run, and provides details as to how to navigate the site/change the correct files for the version of stencil they are using