### PR TITLE
docs(getting-started): make global install explicit

### DIFF
--- a/docs/introduction/03-getting-started.md
+++ b/docs/introduction/03-getting-started.md
@@ -218,14 +218,16 @@ If you used one of the starters, you can simply run the `generate` npm script in
 npm run generate
 ```
 
-Or, you can invoke the Stencil CLI directly with the `generate` command (`g` for short).
-If you don't have `stencil` installed globally, prefix the command with `npx`.
+Alternatively, you can invoke the Stencil CLI directly with the `generate` command (`g` for short).
 
 ```shell
 stencil generate
 # or
 stencil g
 ```
+
+If you don't have `stencil` installed globally, prefix the command with [`npx`](https://docs.npmjs.com/cli/v9/commands/npx).
+Running a command prefixed with `npx` will fetch the package for you automatically and prompt you to install it.
 
 You can optionally pass the component tag name directly to the command.
 The component tag name needs to be lowercase and contain at least one dash ('-').

--- a/docs/introduction/03-getting-started.md
+++ b/docs/introduction/03-getting-started.md
@@ -218,7 +218,7 @@ If you used one of the starters, you can simply run the `generate` npm script in
 npm run generate
 ```
 
-Alternatively, you can invoke the Stencil CLI directly with the `generate` command (`g` for short).
+You can invoke the Stencil CLI directly with the `generate` command (`g` for short).
 
 ```shell
 stencil generate
@@ -226,8 +226,13 @@ stencil generate
 stencil g
 ```
 
-If you don't have `stencil` installed globally, prefix the command with [`npx`](https://docs.npmjs.com/cli/v9/commands/npx).
+If you would like to run `stencil generate` outside of a Stencil project, it can be installed globally.
+To do so, prefix the command above with [`npx`](https://docs.npmjs.com/cli/v9/commands/npx), like so:
+```shell
+npx stencil generate
+```
 Running a command prefixed with `npx` will fetch the package for you automatically and prompt you to install it.
+Once installed, Stencil will run the task to scaffold a new component.
 
 You can optionally pass the component tag name directly to the command.
 The component tag name needs to be lowercase and contain at least one dash ('-').

--- a/versioned_docs/version-v2/introduction/03-getting-started.md
+++ b/versioned_docs/version-v2/introduction/03-getting-started.md
@@ -218,14 +218,16 @@ If you used one of the starters, you can simply run the `generate` npm script in
 npm run generate
 ```
 
-Or, you can invoke the Stencil CLI directly with the `generate` command (`g` for short).
-If you don't have `stencil` installed globally, prefix the command with `npx`.
+Alternatively, you can invoke the Stencil CLI directly with the `generate` command (`g` for short).
 
 ```shell
 stencil generate
 # or
 stencil g
 ```
+
+If you don't have `stencil` installed globally, prefix the command with [`npx`](https://docs.npmjs.com/cli/v9/commands/npx).
+Running a command prefixed with `npx` will fetch the package for you automatically and prompt you to install it.
 
 You can optionally pass the component tag name directly to the command.
 The component tag name needs to be lowercase and contain at least one dash ('-').

--- a/versioned_docs/version-v2/introduction/03-getting-started.md
+++ b/versioned_docs/version-v2/introduction/03-getting-started.md
@@ -218,7 +218,7 @@ If you used one of the starters, you can simply run the `generate` npm script in
 npm run generate
 ```
 
-Alternatively, you can invoke the Stencil CLI directly with the `generate` command (`g` for short).
+You can invoke the Stencil CLI directly with the `generate` command (`g` for short).
 
 ```shell
 stencil generate
@@ -226,8 +226,13 @@ stencil generate
 stencil g
 ```
 
-If you don't have `stencil` installed globally, prefix the command with [`npx`](https://docs.npmjs.com/cli/v9/commands/npx).
+If you would like to run `stencil generate` outside of a Stencil project, it can be installed globally.
+To do so, prefix the command above with [`npx`](https://docs.npmjs.com/cli/v9/commands/npx), like so:
+```shell
+npx stencil generate
+```
 Running a command prefixed with `npx` will fetch the package for you automatically and prompt you to install it.
+Once installed, Stencil will run the task to scaffold a new component.
 
 You can optionally pass the component tag name directly to the command.
 The component tag name needs to be lowercase and contain at least one dash ('-').

--- a/versioned_docs/version-v3.0/introduction/03-getting-started.md
+++ b/versioned_docs/version-v3.0/introduction/03-getting-started.md
@@ -218,14 +218,16 @@ If you used one of the starters, you can simply run the `generate` npm script in
 npm run generate
 ```
 
-Or, you can invoke the Stencil CLI directly with the `generate` command (`g` for short).
-If you don't have `stencil` installed globally, prefix the command with `npx`.
+Alternatively, you can invoke the Stencil CLI directly with the `generate` command (`g` for short).
 
 ```shell
 stencil generate
 # or
 stencil g
 ```
+
+If you don't have `stencil` installed globally, prefix the command with [`npx`](https://docs.npmjs.com/cli/v9/commands/npx).
+Running a command prefixed with `npx` will fetch the package for you automatically and prompt you to install it.
 
 You can optionally pass the component tag name directly to the command.
 The component tag name needs to be lowercase and contain at least one dash ('-').

--- a/versioned_docs/version-v3.0/introduction/03-getting-started.md
+++ b/versioned_docs/version-v3.0/introduction/03-getting-started.md
@@ -218,7 +218,7 @@ If you used one of the starters, you can simply run the `generate` npm script in
 npm run generate
 ```
 
-Alternatively, you can invoke the Stencil CLI directly with the `generate` command (`g` for short).
+You can invoke the Stencil CLI directly with the `generate` command (`g` for short).
 
 ```shell
 stencil generate
@@ -226,8 +226,13 @@ stencil generate
 stencil g
 ```
 
-If you don't have `stencil` installed globally, prefix the command with [`npx`](https://docs.npmjs.com/cli/v9/commands/npx).
+If you would like to run `stencil generate` outside of a Stencil project, it can be installed globally.
+To do so, prefix the command above with [`npx`](https://docs.npmjs.com/cli/v9/commands/npx), like so:
+```shell
+npx stencil generate
+```
 Running a command prefixed with `npx` will fetch the package for you automatically and prompt you to install it.
+Once installed, Stencil will run the task to scaffold a new component.
 
 You can optionally pass the component tag name directly to the command.
 The component tag name needs to be lowercase and contain at least one dash ('-').

--- a/versioned_docs/version-v3.1/introduction/03-getting-started.md
+++ b/versioned_docs/version-v3.1/introduction/03-getting-started.md
@@ -218,14 +218,16 @@ If you used one of the starters, you can simply run the `generate` npm script in
 npm run generate
 ```
 
-Or, you can invoke the Stencil CLI directly with the `generate` command (`g` for short).
-If you don't have `stencil` installed globally, prefix the command with `npx`.
+Alternatively, you can invoke the Stencil CLI directly with the `generate` command (`g` for short).
 
 ```shell
 stencil generate
 # or
 stencil g
 ```
+
+If you don't have `stencil` installed globally, prefix the command with [`npx`](https://docs.npmjs.com/cli/v9/commands/npx).
+Running a command prefixed with `npx` will fetch the package for you automatically and prompt you to install it.
 
 You can optionally pass the component tag name directly to the command.
 The component tag name needs to be lowercase and contain at least one dash ('-').

--- a/versioned_docs/version-v3.1/introduction/03-getting-started.md
+++ b/versioned_docs/version-v3.1/introduction/03-getting-started.md
@@ -218,7 +218,7 @@ If you used one of the starters, you can simply run the `generate` npm script in
 npm run generate
 ```
 
-Alternatively, you can invoke the Stencil CLI directly with the `generate` command (`g` for short).
+You can invoke the Stencil CLI directly with the `generate` command (`g` for short).
 
 ```shell
 stencil generate
@@ -226,8 +226,13 @@ stencil generate
 stencil g
 ```
 
-If you don't have `stencil` installed globally, prefix the command with [`npx`](https://docs.npmjs.com/cli/v9/commands/npx).
+If you would like to run `stencil generate` outside of a Stencil project, it can be installed globally.
+To do so, prefix the command above with [`npx`](https://docs.npmjs.com/cli/v9/commands/npx), like so:
+```shell
+npx stencil generate
+```
 Running a command prefixed with `npx` will fetch the package for you automatically and prompt you to install it.
+Once installed, Stencil will run the task to scaffold a new component.
 
 You can optionally pass the component tag name directly to the command.
 The component tag name needs to be lowercase and contain at least one dash ('-').


### PR DESCRIPTION
this commit updates the getting started documentation to clearly state that `npx` will fetch the package for you, in an attempt to make it clear how stencil can be install globally

Closes: https://github.com/ionic-team/stencil/issues/2189