### PR TITLE
fix wrong import guidance

### DIFF
--- a/versioned_docs/version-v3.2/output-targets/dist.md
+++ b/versioned_docs/version-v3.2/output-targets/dist.md
@@ -88,13 +88,13 @@ Each output target's form of bundling and distribution has its own pros and cons
 ### Importing the `dist` library using a bundler
 
 - Run `npm install my-name --save`
-- Add an `import` within the root component: `import my-component`;
+- Add an `import` within the root component: `import { MyComponent } from 'my-lib'`;
 - Stencil will automatically setup the lazy-loading capabilities for the Stencil library.
 - Then you can use the element anywhere in your template, JSX, HTML etc.
 
 ### Importing the `dist` library into another Stencil app
 
 - Run `npm install my-name --save`
-- Add an `import` within the root component: `import my-component`;
+- Add an `import` within the root component: `import { MyComponent } from 'my-lib'`;
 - Stencil will automatically setup the lazy-loading capabilities for the Stencil library.
 - Then you can use the element anywhere in your template, JSX, HTML etc.


### PR DESCRIPTION
it is not possible to import something that has a name with a dash.  it's not accurate to suggest to import without curly braces.  it's incomplete to not show the "from" clause of the import statement.