### PR TITLE
chore(docs): remove unused frontmatter 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ When it comes time to release a new minor version of Stencil, the contents of `.
    1. For example, if your doc is a guide for Stencil v3.0, you would put it in `./versioned_docs/version-v3.0/guides`.
    2. Depending on the nature of the documentation, the Stencil team may wish to "port" this change to other versions of the Stencil documentation. During a review of your PR, the team will be able to give guidance how to propagate this change.
 2. Write your documentation following the style in the other docs markdown files. Try to aim for being as clear and concise as possible. We recommend checking out the [vue.js docs](https://vuejs.org/) for examples of good docs.
-3. Make sure the page header contains title, description, url and contributors. See other docs files for examples.
+3. Make sure the page header contains title, description, and url. See other docs files for examples.
 4. Run `npm start` to start the app. You should see your new page in the table of contents and be able to access it.
 
 Note: When running `npm start`, anchor links may not work.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ When it comes time to release a new minor version of Stencil, the contents of `.
    1. For example, if your doc is a guide for Stencil v3.0, you would put it in `./versioned_docs/version-v3.0/guides`.
    2. Depending on the nature of the documentation, the Stencil team may wish to "port" this change to other versions of the Stencil documentation. During a review of your PR, the team will be able to give guidance how to propagate this change.
 2. Write your documentation following the style in the other docs markdown files. Try to aim for being as clear and concise as possible. We recommend checking out the [vue.js docs](https://vuejs.org/) for examples of good docs.
-3. Make sure the page header contains title, description, and url. See other docs files for examples.
+3. Make sure the page header contains title, description, and slug. See other docs files for examples.
 4. Run `npm start` to start the app. You should see your new page in the table of contents and be able to access it.
 
 Note: When running `npm start`, anchor links may not work.

--- a/docs/build-variables.md
+++ b/docs/build-variables.md
@@ -2,8 +2,6 @@
 title: Build Constants
 description: Stencil has a number of add-ons that you can use with the build process.
 slug: /build-variables
-contributors:
-  - jthoms1
 ---
 
 # Build Constants

--- a/docs/components/api.md
+++ b/docs/components/api.md
@@ -3,14 +3,6 @@ title: Component API
 sidebar_label: API
 description: Component API
 slug: /api
-contributors:
-  - manucorporat
-  - Mawulijo
-  - hashcrof
-  - ZenPylon
-  - danjohnson95
-  - rezaabedian
-  - CookieCookson
 ---
 
 # Component API

--- a/docs/components/component-lifecycle.md
+++ b/docs/components/component-lifecycle.md
@@ -3,8 +3,6 @@ title: Component Lifecycle Methods
 sidebar_label: Lifecycle Methods
 description: Component Lifecycle Methods
 slug: /component-lifecycle
-contributors:
-  - jthoms1
 ---
 
 # Component Lifecycle Methods

--- a/docs/components/component.md
+++ b/docs/components/component.md
@@ -3,9 +3,6 @@ title: Component Decorator
 sidebar_label: Component
 description: Documentation for the @Component decorator
 slug: /component
-contributors:
-- jthoms1
-- rwaskiewicz
 ---
 
 # Component Decorator

--- a/docs/components/events.md
+++ b/docs/components/events.md
@@ -3,12 +3,6 @@ title: Events
 sidebar_label: Events
 description: Events
 slug: /events
-contributors:
-  - jthoms1
-  - mgalic
-  - BDav24
-  - mattcosta7
-  - noherczeg
 ---
 
 # Events

--- a/docs/components/functional-components.md
+++ b/docs/components/functional-components.md
@@ -3,8 +3,6 @@ title: Functional Components
 sidebar_label: Functional Components
 description: Functional Components
 slug: /functional-components
-contributors:
-  - simonhaenisch
 ---
 
 # Working with Functional Components

--- a/docs/components/host-element.md
+++ b/docs/components/host-element.md
@@ -3,8 +3,6 @@ title: Working with host elements
 sidebar_label: Host Element
 description: Working with host elements
 slug: /host-element
-contributors:
-  - jthoms1
 ---
 
 # Working with host elements

--- a/docs/components/methods.md
+++ b/docs/components/methods.md
@@ -3,9 +3,6 @@ title: Methods
 sidebar_label: Methods
 description: methods
 slug: /methods
-contributors:
-  - jthoms1
-  - manucorporat
 ---
 
 # Method Decorator

--- a/docs/components/properties.md
+++ b/docs/components/properties.md
@@ -3,9 +3,6 @@ title: Properties
 sidebar_label: Properties
 description: Properties
 slug: /properties
-contributors:
-  - jthoms1
-  - rwaskiewicz
 ---
 
 # Properties

--- a/docs/components/reactive-data.md
+++ b/docs/components/reactive-data.md
@@ -3,9 +3,6 @@ title: Reactive Data, Handling arrays and objects
 sidebar_label: Reactive Data
 description: Reactive Data, Handling arrays and objects
 slug: /reactive-data
-contributors:
-  - jthoms1
-  - rwaskiewicz
 ---
 
 # Reactive Data

--- a/docs/components/state.md
+++ b/docs/components/state.md
@@ -3,9 +3,6 @@ title: Internal state
 sidebar_label: Internal State
 description: Use the State() for component's internal state
 slug: /state
-contributors:
-  - jthoms1
-  - rwaskiewicz
 ---
 
 # State

--- a/docs/components/styling.md
+++ b/docs/components/styling.md
@@ -3,10 +3,6 @@ title: Styling Components
 sidebar_label: Styling
 description: Styling Components
 slug: /styling
-contributors:
-  - jthoms1
-  - shreeshbhat
-  - a-giuliano
 ---
 
 # Styling Components

--- a/docs/components/templating-and-jsx.md
+++ b/docs/components/templating-and-jsx.md
@@ -3,10 +3,6 @@ title: Using JSX
 sidebar_label: Using JSX
 description: Using JSX
 slug: /templating-jsx
-contributors:
-  - jthoms1
-  - simonhaenisch
-  - arjunyel
 ---
 
 # Using JSX

--- a/docs/config/01-overview.md
+++ b/docs/config/01-overview.md
@@ -3,14 +3,6 @@ title: Config
 sidebar_label: Overview
 description: Config
 slug: /config
-contributors:
-  - adamdbradley
-  - jthoms1
-  - flawyte
-  - BDav24
-  - rwaskiewicz
-  - simonhaenisch
-  - splitinfinities
 ---
 
 # Stencil Config

--- a/docs/config/cli.md
+++ b/docs/config/cli.md
@@ -3,9 +3,6 @@ title: Stencil CLI
 sidebar_label: CLI
 description: Stencil CLI
 slug: /cli
-contributors:
-  - miguelyoobic95
-  - adamdbradley
 ---
 
 # Command Line Interface (CLI)

--- a/docs/config/dev-server.md
+++ b/docs/config/dev-server.md
@@ -3,11 +3,6 @@ title: Integrated Dev Server Config
 sidebar_label: Dev Server
 description: Integrated Dev Server Config
 slug: /dev-server
-contributors:
-  - adamdbradley
-  - BDav24
-  - feerglas
-  - simonhaenisch
 ---
 
 # Integrated Dev Server

--- a/docs/config/extras.md
+++ b/docs/config/extras.md
@@ -3,10 +3,6 @@ title: Extras Config
 sidebar_label: Extras
 description: Extras Config
 slug: /config-extras
-contributors:
-  - mattdsteele
-  - rwaskiewicz
-  - alicewriteswrongs
 ---
 
 # Extras

--- a/docs/config/plugins.md
+++ b/docs/config/plugins.md
@@ -3,10 +3,6 @@ title: Plugin Config
 sidebar_label: Plugins
 description: Plugin Config
 slug: /plugins
-contributors:
-  - adamdbradley
-  - jthoms1
-  - mgalic
 ---
 
 # Plugins

--- a/docs/core/cli-api.md
+++ b/docs/core/cli-api.md
@@ -3,8 +3,6 @@ title: Stencil Core CLI API
 sidebar_label: CLI API
 description:  Stencil Core CLI API
 slug: /cli-api
-contributors:
-  - adamdbradley
 ---
 
 # Stencil Core CLI API

--- a/docs/core/compiler-api.md
+++ b/docs/core/compiler-api.md
@@ -3,8 +3,6 @@ title: Stencil Core Compiler API
 sidebar_label: Compiler API
 description:  Stencil Core Compiler API
 slug: /compiler-api
-contributors:
-  - adamdbradley
 ---
 
 # Stencil Core Compiler API

--- a/docs/core/dev-server-api.md
+++ b/docs/core/dev-server-api.md
@@ -3,9 +3,6 @@ title: Stencil Core Dev Server API
 sidebar_label: Dev Server API
 description:  Stencil Core Dev Server API
 slug: /dev-server-api
-contributors:
-  - adamdbradley
-  - dominikpieper
 ---
 
 # Stencil Core Dev Server API

--- a/docs/framework-integration/01-overview.md
+++ b/docs/framework-integration/01-overview.md
@@ -3,9 +3,6 @@ title: Framework Integration
 sidebar_label: Overview
 description: Framework Integration
 slug: /overview
-contributors:
-  - adamdbradley
-  - brandyscarney
 ---
 
 # Framework Integration

--- a/docs/framework-integration/angular.md
+++ b/docs/framework-integration/angular.md
@@ -3,15 +3,6 @@ title: Angular Integration with Stencil
 sidebar_label: Angular
 description: Learn how to wrap your components so that people can use them natively in Angular
 slug: /angular
-contributors:
-  - jthoms1
-  - adamdbradley
-  - kensodemann
-  - peterpeterparker
-  - jeanbenitez
-  - mburger81
-  - splitinfinities
-  - tanner-reits
 ---
 
 # Angular Integration

--- a/docs/framework-integration/ember.md
+++ b/docs/framework-integration/ember.md
@@ -3,9 +3,6 @@ title: Ember Integration with Stencil
 sidebar_label: Ember
 description: Ember Integration with Stencil
 slug: /ember
-contributors:
-  - jthoms1
-  - adamdbradley
 ---
 
 # Ember

--- a/docs/framework-integration/javascript.md
+++ b/docs/framework-integration/javascript.md
@@ -3,12 +3,6 @@ title: Components without a Framework
 sidebar_label: JavaScript
 description: Components without a Framework
 slug: /javascript
-contributors:
-  - mhartington
-  - jthoms1
-  - adamdbradley
-  - BDav24
-  - DaniAcu
 ---
 
 # Components without a Framework

--- a/docs/framework-integration/react.md
+++ b/docs/framework-integration/react.md
@@ -3,16 +3,6 @@ title: React Integration with Stencil
 sidebar_label: React
 description: Learn how to wrap your components so that people can use them natively in React
 slug: /react
-contributors:
-  - jthoms1
-  - adamdbradley
-  - kensodemann
-  - ErikSchierboom
-  - brentertz
-  - danawoodman
-  - a-giuliano
-  - rwaskiewicz
-  - tanner-reits
 ---
 
 # React Integration

--- a/docs/framework-integration/vue.md
+++ b/docs/framework-integration/vue.md
@@ -3,14 +3,6 @@ title: VueJS Integration with Stencil
 sidebar_label: Vue
 description: Learn how to wrap your components so that people can use them natively in Vue
 slug: /vue
-contributors:
-  - jthoms1
-  - adamdbradley
-  - kensodemann
-  - brysalazar12
-  - iskanderbroere
-  - sean-perkins
-  - tanner-reits
 ---
 
 # Vue Integration

--- a/docs/guides/assets.md
+++ b/docs/guides/assets.md
@@ -3,10 +3,6 @@ title: Assets
 sidebar_label: Assets
 description: Learn how to reference assets in your components
 slug: /assets
-contributors:
-  - splitinfinities
-  - simonhaenisch
-  - rwaskiewicz
 ---
 
 # Assets

--- a/docs/guides/build-conditionals.md
+++ b/docs/guides/build-conditionals.md
@@ -1,8 +1,6 @@
 ---
 title: Build Conditionals
 description: Build Conditionals
-contributors:
-  - jthoms1
 ---
 
 # Build Conditionals

--- a/docs/guides/csp-nonce.md
+++ b/docs/guides/csp-nonce.md
@@ -2,8 +2,6 @@
 title: Content Security Policy Nonces
 description: How to leverage CSP nonces in Stencil projects.
 slug: /csp-nonce
-contributors:
-  - tanner-reits
 ---
 
 # Using Content Security Policy Nonces in Stencil

--- a/docs/guides/design-systems.md
+++ b/docs/guides/design-systems.md
@@ -3,9 +3,6 @@ title: Design Systems
 sidebar_label: Design Systems
 description: Design Systems in Stencil
 slug: /design-systems
-contributors:
-  - dotNetkow
-  - rwaskiewicz
 ---
 
 # Design Systems

--- a/docs/guides/forms.md
+++ b/docs/guides/forms.md
@@ -3,8 +3,6 @@ title: Forms
 sidebar_label: Forms
 description: Forms
 slug: /forms
-contributors:
-  - jthoms1
 ---
 
 # Forms

--- a/docs/guides/hydrate-app.md
+++ b/docs/guides/hydrate-app.md
@@ -3,10 +3,6 @@ title: Hydrate App
 sidebar_label: Hydrate App
 description: Hydrate App
 slug: /hydrate-app
-contributors:
-  - adamdbradley
-  - dgautsch
-  - bitflower
 ---
 
 # Hydrate App

--- a/docs/guides/module-bundling.md
+++ b/docs/guides/module-bundling.md
@@ -3,12 +3,6 @@ title: Module Bundling
 sidebar_label: Bundling
 description: Module Bundling
 slug: /module-bundling
-contributors:
-  - jthoms1
-  - adamdbradley
-  - kensodemann
-  - manucorporat
-  - ryan3E0
 ---
 
 # Module Bundling

--- a/docs/guides/publishing.md
+++ b/docs/guides/publishing.md
@@ -3,8 +3,6 @@ title: Publishing A Component Library
 sidebar_label: Publishing
 description: Publishing A Component Library
 slug: /publishing
-contributors:
-  - adamdbradley
 ---
 
 # Publishing A Component Library

--- a/docs/guides/service-workers.md
+++ b/docs/guides/service-workers.md
@@ -3,10 +3,6 @@ title: Service Workers
 sidebar_label: Service Workers
 description: Service Workers
 slug: /service-workers
-contributors:
-  - jthoms1
-  - simonhaenisch
-  - DavidFrahm
 ---
 
 # Service Workers

--- a/docs/guides/style-guide.md
+++ b/docs/guides/style-guide.md
@@ -3,12 +3,6 @@ title: Stencil Style Guide
 sidebar_label: Style Guide
 description: Stencil Style Guide
 slug: /style-guide
-contributors:
-  - jthoms1
-  - natemoo-re
-  - larionov
-  - joestrouth1
-  - rwaskiewicz
 ---
 
 # Stencil Style Guide

--- a/docs/guides/typed-components.md
+++ b/docs/guides/typed-components.md
@@ -3,10 +3,6 @@ title: Typed Components
 sidebar_label: Typed Components
 description: Typed Components
 slug: /typed-components
-contributors:
-  - adamdbradley
-  - manucorporat
-  - rwaskiewicz
 ---
 
 # Typed Components

--- a/docs/introduction/01-overview.md
+++ b/docs/introduction/01-overview.md
@@ -3,10 +3,6 @@ title: Stencil - A Compiler for Web Components
 sidebar_label: Overview
 description: Stencil has a number of add-ons that you can use with the build process.
 slug: /introduction
-contributors:
-  - jthoms1
-  - splitinfinities
-  - a-giuliano
 ---
 
 # Overview

--- a/docs/introduction/02-goals-and-objectives.md
+++ b/docs/introduction/02-goals-and-objectives.md
@@ -3,9 +3,6 @@ title: Stencil Goals and Objectives
 sidebar_label: Goals and Objectives
 description: Stencil aims to combine the best concepts of the most popular frontend frameworks into a compile-time tool rather than run-time tool.
 slug: /goals-and-objectives
-contributors:
-  - adamdbradley
-  - sri-ni
 ---
 
 # Stencil Goals And Objectives

--- a/docs/introduction/03-getting-started.md
+++ b/docs/introduction/03-getting-started.md
@@ -3,9 +3,6 @@ title: Getting Started
 sidebar_label: Getting Started
 description: Getting Started
 slug: /getting-started
-contributors:
-  - jthoms1
-  - rwaskiewicz
 ---
 
 # Getting Started

--- a/docs/introduction/upgrading-to-stencil-three.md
+++ b/docs/introduction/upgrading-to-stencil-three.md
@@ -2,8 +2,6 @@
 title: Upgrading to Stencil v3.0.0
 description: Upgrading to Stencil v3.0.0
 url: /docs/upgrading-to-stencil-3
-contributors:
-  - rwaskiewicz
 ---
 
 # Upgrading to Stencil v3.0.0

--- a/docs/output-targets/01-overview.md
+++ b/docs/output-targets/01-overview.md
@@ -3,10 +3,6 @@ title: Stencil Output Targets
 sidebar_label: Overview
 description: Stencil Output Targets
 slug: /output-targets
-contributors:
-  - adamdbradley
-  - manucorporat
-  - rwaskiewicz
 ---
 
 # Output Targets

--- a/docs/output-targets/copy-tasks.md
+++ b/docs/output-targets/copy-tasks.md
@@ -3,10 +3,6 @@ title: Stencil Copy Tasks
 sidebar_label: Copy Tasks
 description: Stencil Copy Tasks
 slug: /copy-tasks
-contributors:
-  - adamdbradley
-  - manucorporat
-  - jeanbenitez
 ---
 
 

--- a/docs/output-targets/custom-elements.md
+++ b/docs/output-targets/custom-elements.md
@@ -3,11 +3,6 @@ title: Custom Elements with Stencil
 sidebar_label: dist-custom-elements
 description: Custom Elements with Stencil
 slug: /custom-elements
-contributors:
-  - adamdbradley
-  - rwaskiewicz
-  - splitinfinities
-  - tanner-reits
 ---
 
 # Custom Elements

--- a/docs/output-targets/dist.md
+++ b/docs/output-targets/dist.md
@@ -3,9 +3,6 @@ title: Distributing Web Components Built with Stencil
 sidebar_label: dist
 description: Distributing Web Components Built with Stencil
 slug: /distribution
-contributors:
-  - adamdbradley
-  - jthoms1
 ---
 
 # Distribution Output Target

--- a/docs/output-targets/docs-custom.md
+++ b/docs/output-targets/docs-custom.md
@@ -3,10 +3,6 @@ title: Custom Docs Generation
 sidebar_label: docs-custom
 description: Custom Docs Generation
 slug: /docs-custom
-contributors:
-  - adamdbradley
-  - manucorporat
-  - arayik-yervandyan
 ---
 
 # Custom Docs Generation

--- a/docs/output-targets/docs-json.md
+++ b/docs/output-targets/docs-json.md
@@ -3,14 +3,6 @@ title: Docs JSON Data Output Target
 sidebar_label: docs-json
 description: Docs JSON Output Target
 slug: /docs-json
-contributors:
-  - adamdbradley
-  - snaptopixel
-  - manucorporat
-  - amwmedia
-  - mrtnmgs
-  - marcjulian
-  - seanwuapps
 ---
 
 # Docs Json Data

--- a/docs/output-targets/docs-readme.md
+++ b/docs/output-targets/docs-readme.md
@@ -3,13 +3,6 @@ title: Docs Readme Auto-Generation
 sidebar_label: docs-readme
 description: Docs Readme Auto-Generation
 slug: /docs-readme
-contributors:
-  - adamdbradley
-  - snaptopixel
-  - manucorporat
-  - amwmedia
-  - mrtnmgs
-  - marcjulian
 ---
 
 # Docs Readme Markdown File Auto-Generation

--- a/docs/output-targets/docs-stats.md
+++ b/docs/output-targets/docs-stats.md
@@ -3,9 +3,6 @@ title: Docs Stats Auto-Generation
 sidebar_label: stats
 description: Docs Stats Auto-Generation
 slug: /stats
-contributors:
-  - adamdbradley
-  - splitinfinities
 ---
 
 # Stats

--- a/docs/output-targets/docs-vscode.md
+++ b/docs/output-targets/docs-vscode.md
@@ -2,8 +2,6 @@
 title: VS Code Documentation
 description: VS Code Documentation
 slug: /docs-vscode
-contributors:
-  - rwaskiewicz
 ---
 
 # VS Code Documentation

--- a/docs/output-targets/www.md
+++ b/docs/output-targets/www.md
@@ -3,10 +3,6 @@ title: Webapp Output Target
 sidebar_label: www
 description: Webapp Output Target
 slug: /www
-contributors:
-  - jthoms1
-  - simonhaenisch
-  - DavidFrahm
 ---
 
 # Webapp Output Target: `www`

--- a/docs/reference/browser-support.md
+++ b/docs/reference/browser-support.md
@@ -3,11 +3,6 @@ title: Stencil Web Component Browser Support
 sidebar_label: Browser Support
 description: Out-of-the-box browser support provided by Stencil web components.
 slug: /browser-support
-contributors:
-  - adamdbradley
-  - kevinports
-  - jthoms1
-  - arjunyel
 ---
 
 # Browser Support

--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -3,9 +3,6 @@ title: Stencil Frequently Asked Questions
 sidebar_label: FAQ
 description: Stencil is a developer-focused toolchain for building reusable, scalable component libraries, applications and design systems.
 slug: /faq
-contributors:
-  - adamdbradley
-  - rwaskiewicz
 ---
 
 # FAQ

--- a/docs/reference/support-policy.md
+++ b/docs/reference/support-policy.md
@@ -3,8 +3,6 @@ title: Support Policy
 sidebar_label: Support Policy
 description: Support Policy
 slug: /support-policy
-contributors:
-- rwaskiewicz
 ---
 
 # Support Policy

--- a/docs/reference/versioning.md
+++ b/docs/reference/versioning.md
@@ -3,8 +3,6 @@ title: Versioning
 sidebar_label: Versioning
 description: Versioning
 slug: /versioning
-contributors:
-- rwaskiewicz
 ---
 
 # Versioning

--- a/docs/static-site-generation/01-overview.md
+++ b/docs/static-site-generation/01-overview.md
@@ -2,10 +2,6 @@
 title: Static Site Generation
 sidebar_label: Overview
 slug: /static-site-generation
-contributors:
-  - mlynch
-  - adamdbradley
-  - bitflower
 ---
 
 # Static Site Generation with Stencil

--- a/docs/static-site-generation/basics.md
+++ b/docs/static-site-generation/basics.md
@@ -3,9 +3,6 @@ title: Static Site Generation Basics in Stencil
 sidebar_label: Basics
 description: Quick introduction to configuring and using Static Site Generation in Stencil
 slug: /static-site-generation-basics
-contributors:
-  - mlynch
-  - adamdbradley
 ---
 
 # Static Site Generation Basics

--- a/docs/static-site-generation/debugging.md
+++ b/docs/static-site-generation/debugging.md
@@ -3,9 +3,6 @@ title: Debugging Static Site Generation in Stencil
 sidebar_label: Debugging
 description: How to debug a prerendering or Static Site Generation step in Stencil
 slug: /static-site-generation-debugging
-contributors:
-  - mlynch
-  - adamdbradley
 ---
 
 # Debugging Static Site Generation

--- a/docs/static-site-generation/deployment.md
+++ b/docs/static-site-generation/deployment.md
@@ -3,8 +3,6 @@ title: Deploying a Static Site
 sidebar_label: Deployment
 description: Deploying a Static Site
 slug: /static-site-generation-deployment
-contributors:
-  - mlynch
 ---
 
 # Deploying a Stencil Static Site

--- a/docs/static-site-generation/meta.md
+++ b/docs/static-site-generation/meta.md
@@ -3,10 +3,6 @@ title: SEO Meta Tags in SSG
 sidebar_label: Meta tags
 description: Managing meta tags for SEO and social media embedding in Stencil Static Sites
 slug: /static-site-generation-meta-tags
-contributors:
-  - mlynch
-  - adamdbradley
-  - rwaskiewicz
 ---
 
 # SEO Meta Tags and Static Site Generation

--- a/docs/static-site-generation/prerender-config.md
+++ b/docs/static-site-generation/prerender-config.md
@@ -3,10 +3,6 @@ title: Prerender Config
 sidebar_label: Prerender Config
 description: Prerender Config
 slug: /prerender-config
-contributors:
-  - adamdbradley
-  - ryan3E0
-  - dgautsch
 ---
 
 

--- a/docs/static-site-generation/server-side-rendering-ssr.md
+++ b/docs/static-site-generation/server-side-rendering-ssr.md
@@ -3,8 +3,6 @@ title: Combining Server Side Rendering and Static Site Generation
 sidebar_label: Server Side Rendering
 description: How to combine both Server Side Rendering and Static Site Generation approaches
 slug: /static-site-generation-server-side-rendering-ssr
-contributors:
-  - mlynch
 ---
 
 # Combining Server Side Rendering and Static Site Generation

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,8 +1,6 @@
 ---
 title: Telemetry
 description: Stencil Telemetry usage information
-contributors:
-  - splitinfinities
 ---
 
 # Stencil CLI telemetry

--- a/docs/testing/01-overview.md
+++ b/docs/testing/01-overview.md
@@ -3,12 +3,6 @@ title: Testing
 sidebar_label: Overview
 description: Testing overview.
 slug: /testing-overview
-contributors:
-  - adamdbradley
-  - brandyscarney
-  - camwiegert
-  - kensodemann
-  - rwaskiewicz
 ---
 
 # Testing

--- a/docs/testing/config.md
+++ b/docs/testing/config.md
@@ -3,10 +3,6 @@ title: Testing Config
 sidebar_label: Config
 description: Testing Config
 slug: /testing-config
-contributors:
-  - adamdbradley
-  - mattcosta7
-  - viernullvier
 ---
 
 # Testing Config

--- a/docs/testing/e2e-testing.md
+++ b/docs/testing/e2e-testing.md
@@ -3,10 +3,6 @@ title: End-to-end Testing
 sidebar_label: End-to-end Testing
 description: End-to-end Testing
 slug: /end-to-end-testing
-contributors:
-  - adamdbradley
-  - mattdsteele
-  - simonhaenisch
 ---
 
 # End-to-end Testing

--- a/docs/testing/mocking.md
+++ b/docs/testing/mocking.md
@@ -3,8 +3,6 @@ title: Mocking
 sidebar_label: Mocking
 description: Mocking
 slug: /mocking
-contributors:
-  - simonhaenisch
 ---
 
 # Mocking

--- a/docs/testing/screenshot-connector.md
+++ b/docs/testing/screenshot-connector.md
@@ -3,8 +3,6 @@ title: Screenshot Connector
 sidebar_label: Screenshot Connector
 description: Screenshot Connector
 slug: /screenshot-connector
-contributors:
-  - SheepFromHeaven
 ---
 
 # Screenshot connector

--- a/docs/testing/screenshot-visual-diff.md
+++ b/docs/testing/screenshot-visual-diff.md
@@ -3,8 +3,6 @@ title: Screenshot Visual Diff
 sidebar_label: Visual Screenshot Diff
 description: Screenshot Visual Diff
 slug: /screenshot-visual-diff
-contributors:
-  - adamdbradley
 ---
 
 # Screenshot Visual Diff

--- a/docs/testing/unit-testing.md
+++ b/docs/testing/unit-testing.md
@@ -3,10 +3,6 @@ title: Unit Testing
 sidebar_label: Unit Testing
 description: Unit Testing
 slug: /unit-testing
-contributors:
-  - adamdbradley
-  - mattdsteele
-  - bassettsj
 ---
 
 # Unit Testing

--- a/versioned_docs/version-v2/build-variables.md
+++ b/versioned_docs/version-v2/build-variables.md
@@ -2,8 +2,6 @@
 title: Build Constants
 description: Stencil has a number of add-ons that you can use with the build process.
 slug: /build-variables
-contributors:
-  - jthoms1
 ---
 
 # Build Constants

--- a/versioned_docs/version-v2/components/api.md
+++ b/versioned_docs/version-v2/components/api.md
@@ -3,14 +3,6 @@ title: Component API
 sidebar_label: API
 description: Component API
 slug: /api
-contributors:
-  - manucorporat
-  - Mawulijo
-  - hashcrof
-  - ZenPylon
-  - danjohnson95
-  - rezaabedian
-  - CookieCookson
 ---
 
 # Component API

--- a/versioned_docs/version-v2/components/component-lifecycle.md
+++ b/versioned_docs/version-v2/components/component-lifecycle.md
@@ -3,8 +3,6 @@ title: Component Lifecycle Methods
 sidebar_label: Lifecycle Methods
 description: Component Lifecycle Methods
 slug: /component-lifecycle
-contributors:
-  - jthoms1
 ---
 
 # Component Lifecycle Methods

--- a/versioned_docs/version-v2/components/component.md
+++ b/versioned_docs/version-v2/components/component.md
@@ -3,9 +3,6 @@ title: Component Decorator
 sidebar_label: Component
 description: Documentation for the @Component decorator
 slug: /component
-contributors:
-- jthoms1
-- rwaskiewicz
 ---
 
 # Component Decorator

--- a/versioned_docs/version-v2/components/events.md
+++ b/versioned_docs/version-v2/components/events.md
@@ -3,12 +3,6 @@ title: Events
 sidebar_label: Events
 description: Events
 slug: /events
-contributors:
-  - jthoms1
-  - mgalic
-  - BDav24
-  - mattcosta7
-  - noherczeg
 ---
 
 # Events

--- a/versioned_docs/version-v2/components/functional-components.md
+++ b/versioned_docs/version-v2/components/functional-components.md
@@ -3,8 +3,6 @@ title: Functional Components
 sidebar_label: Functional Components
 description: Functional Components
 slug: /functional-components
-contributors:
-  - simonhaenisch
 ---
 
 # Working with Functional Components

--- a/versioned_docs/version-v2/components/host-element.md
+++ b/versioned_docs/version-v2/components/host-element.md
@@ -3,8 +3,6 @@ title: Working with host elements
 sidebar_label: Host Element
 description: Working with host elements
 slug: /host-element
-contributors:
-  - jthoms1
 ---
 
 # Working with host elements

--- a/versioned_docs/version-v2/components/methods.md
+++ b/versioned_docs/version-v2/components/methods.md
@@ -3,9 +3,6 @@ title: Methods
 sidebar_label: Methods
 description: methods
 slug: /methods
-contributors:
-  - jthoms1
-  - manucorporat
 ---
 
 # Method Decorator

--- a/versioned_docs/version-v2/components/properties.md
+++ b/versioned_docs/version-v2/components/properties.md
@@ -3,9 +3,6 @@ title: Properties
 sidebar_label: Properties
 description: Properties
 slug: /properties
-contributors:
-  - jthoms1
-  - rwaskiewicz
 ---
 
 # Properties

--- a/versioned_docs/version-v2/components/reactive-data.md
+++ b/versioned_docs/version-v2/components/reactive-data.md
@@ -3,9 +3,6 @@ title: Reactive Data, Handling arrays and objects
 sidebar_label: Reactive Data
 description: Reactive Data, Handling arrays and objects
 slug: /reactive-data
-contributors:
-  - jthoms1
-  - rwaskiewicz
 ---
 
 # Reactive Data

--- a/versioned_docs/version-v2/components/state.md
+++ b/versioned_docs/version-v2/components/state.md
@@ -3,9 +3,6 @@ title: Internal state
 sidebar_label: Internal State
 description: Use the State() for component's internal state
 slug: /state
-contributors:
-  - jthoms1
-  - rwaskiewicz
 ---
 
 # State

--- a/versioned_docs/version-v2/components/styling.md
+++ b/versioned_docs/version-v2/components/styling.md
@@ -3,10 +3,6 @@ title: Styling Components
 sidebar_label: Styling
 description: Styling Components
 slug: /styling
-contributors:
-  - jthoms1
-  - shreeshbhat
-  - a-giuliano
 ---
 
 # Styling Components

--- a/versioned_docs/version-v2/components/templating-and-jsx.md
+++ b/versioned_docs/version-v2/components/templating-and-jsx.md
@@ -3,10 +3,6 @@ title: Using JSX
 sidebar_label: Using JSX
 description: Using JSX
 slug: /templating-jsx
-contributors:
-  - jthoms1
-  - simonhaenisch
-  - arjunyel
 ---
 
 # Using JSX

--- a/versioned_docs/version-v2/config/01-overview.md
+++ b/versioned_docs/version-v2/config/01-overview.md
@@ -3,14 +3,6 @@ title: Config
 sidebar_label: Overview
 description: Config
 slug: /config
-contributors:
-  - adamdbradley
-  - jthoms1
-  - flawyte
-  - BDav24
-  - rwaskiewicz
-  - simonhaenisch
-  - splitinfinities
 ---
 
 # Stencil Config

--- a/versioned_docs/version-v2/config/cli.md
+++ b/versioned_docs/version-v2/config/cli.md
@@ -3,9 +3,6 @@ title: Stencil CLI
 sidebar_label: CLI
 description: Stencil CLI
 slug: /cli
-contributors:
-  - miguelyoobic95
-  - adamdbradley
 ---
 
 # Command Line Interface (CLI)

--- a/versioned_docs/version-v2/config/dev-server.md
+++ b/versioned_docs/version-v2/config/dev-server.md
@@ -3,11 +3,6 @@ title: Integrated Dev Server Config
 sidebar_label: Dev Server
 description: Integrated Dev Server Config
 slug: /dev-server
-contributors:
-  - adamdbradley
-  - BDav24
-  - feerglas
-  - simonhaenisch
 ---
 
 # Integrated Dev Server

--- a/versioned_docs/version-v2/config/extras.md
+++ b/versioned_docs/version-v2/config/extras.md
@@ -3,9 +3,6 @@ title: Extras Config
 sidebar_label: Extras
 description: Extras Config
 slug: /config-extras
-contributors:
-  - mattdsteele
-  - rwaskiewicz
 ---
 
 # Extras

--- a/versioned_docs/version-v2/config/plugins.md
+++ b/versioned_docs/version-v2/config/plugins.md
@@ -3,10 +3,6 @@ title: Plugin Config
 sidebar_label: Plugins
 description: Plugin Config
 slug: /plugins
-contributors:
-  - adamdbradley
-  - jthoms1
-  - mgalic
 ---
 
 # Plugins

--- a/versioned_docs/version-v2/core/cli-api.md
+++ b/versioned_docs/version-v2/core/cli-api.md
@@ -3,8 +3,6 @@ title: Stencil Core CLI API
 sidebar_label: CLI API
 description:  Stencil Core CLI API
 slug: /cli-api
-contributors:
-  - adamdbradley
 ---
 
 # Stencil Core CLI API

--- a/versioned_docs/version-v2/core/compiler-api.md
+++ b/versioned_docs/version-v2/core/compiler-api.md
@@ -3,8 +3,6 @@ title: Stencil Core Compiler API
 sidebar_label: Compiler API
 description:  Stencil Core Compiler API
 slug: /compiler-api
-contributors:
-  - adamdbradley
 ---
 
 # Stencil Core Compiler API

--- a/versioned_docs/version-v2/core/dev-server-api.md
+++ b/versioned_docs/version-v2/core/dev-server-api.md
@@ -3,9 +3,6 @@ title: Stencil Core Dev Server API
 sidebar_label: Dev Server API
 description:  Stencil Core Dev Server API
 slug: /dev-server-api
-contributors:
-  - adamdbradley
-  - dominikpieper
 ---
 
 # Stencil Core Dev Server API

--- a/versioned_docs/version-v2/framework-integration/01-overview.md
+++ b/versioned_docs/version-v2/framework-integration/01-overview.md
@@ -3,9 +3,6 @@ title: Framework Integration
 sidebar_label: Overview
 description: Framework Integration
 slug: /overview
-contributors:
-  - adamdbradley
-  - brandyscarney
 ---
 
 # Framework Integration

--- a/versioned_docs/version-v2/framework-integration/angular.md
+++ b/versioned_docs/version-v2/framework-integration/angular.md
@@ -3,15 +3,6 @@ title: Angular Integration with Stencil
 sidebar_label: Angular
 description: Learn how to wrap your components so that people can use them natively in Angular
 slug: /angular
-contributors:
-  - jthoms1
-  - adamdbradley
-  - kensodemann
-  - peterpeterparker
-  - jeanbenitez
-  - mburger81
-  - splitinfinities
-  - tanner-reits
 ---
 
 # Angular Integration

--- a/versioned_docs/version-v2/framework-integration/ember.md
+++ b/versioned_docs/version-v2/framework-integration/ember.md
@@ -3,9 +3,6 @@ title: Ember Integration with Stencil
 sidebar_label: Ember
 description: Ember Integration with Stencil
 slug: /ember
-contributors:
-  - jthoms1
-  - adamdbradley
 ---
 
 # Ember

--- a/versioned_docs/version-v2/framework-integration/javascript.md
+++ b/versioned_docs/version-v2/framework-integration/javascript.md
@@ -3,12 +3,6 @@ title: Components without a Framework
 sidebar_label: JavaScript
 description: Components without a Framework
 slug: /javascript
-contributors:
-  - mhartington
-  - jthoms1
-  - adamdbradley
-  - BDav24
-  - DaniAcu
 ---
 
 # Components without a Framework

--- a/versioned_docs/version-v2/framework-integration/react.md
+++ b/versioned_docs/version-v2/framework-integration/react.md
@@ -3,16 +3,6 @@ title: React Integration with Stencil
 sidebar_label: React
 description: Learn how to wrap your components so that people can use them natively in React
 slug: /react
-contributors:
-  - jthoms1
-  - adamdbradley
-  - kensodemann
-  - ErikSchierboom
-  - brentertz
-  - danawoodman
-  - a-giuliano
-  - rwaskiewicz
-  - tanner-reits
 ---
 
 # React Integration

--- a/versioned_docs/version-v2/framework-integration/vue.md
+++ b/versioned_docs/version-v2/framework-integration/vue.md
@@ -3,14 +3,6 @@ title: VueJS Integration with Stencil
 sidebar_label: Vue
 description: Learn how to wrap your components so that people can use them natively in Vue
 slug: /vue
-contributors:
-  - jthoms1
-  - adamdbradley
-  - kensodemann
-  - brysalazar12
-  - iskanderbroere
-  - sean-perkins
-  - tanner-reits
 ---
 
 # Vue Integration

--- a/versioned_docs/version-v2/guides/assets.md
+++ b/versioned_docs/version-v2/guides/assets.md
@@ -3,10 +3,6 @@ title: Assets
 sidebar_label: Assets
 description: Learn how to reference assets in your components
 slug: /assets
-contributors:
-  - splitinfinities
-  - simonhaenisch
-  - rwaskiewicz
 ---
 
 # Assets

--- a/versioned_docs/version-v2/guides/build-conditionals.md
+++ b/versioned_docs/version-v2/guides/build-conditionals.md
@@ -1,8 +1,6 @@
 ---
 title: Build Conditionals
 description: Build Conditionals
-contributors:
-  - jthoms1
 ---
 
 # Build Conditionals

--- a/versioned_docs/version-v2/guides/csp-nonce.md
+++ b/versioned_docs/version-v2/guides/csp-nonce.md
@@ -2,8 +2,6 @@
 title: Content Security Policy Nonces
 description: How to leverage CSP nonces in Stencil projects.
 slug: /csp-nonce
-contributors:
-  - tanner-reits
 ---
 
 # Using Content Security Policy Nonces in Stencil

--- a/versioned_docs/version-v2/guides/design-systems.md
+++ b/versioned_docs/version-v2/guides/design-systems.md
@@ -3,9 +3,6 @@ title: Design Systems
 sidebar_label: Design Systems
 description: Design Systems in Stencil
 slug: /design-systems
-contributors:
-  - dotNetkow
-  - rwaskiewicz
 ---
 
 # Design Systems

--- a/versioned_docs/version-v2/guides/forms.md
+++ b/versioned_docs/version-v2/guides/forms.md
@@ -3,8 +3,6 @@ title: Forms
 sidebar_label: Forms
 description: Forms
 slug: /forms
-contributors:
-  - jthoms1
 ---
 
 # Forms

--- a/versioned_docs/version-v2/guides/hydrate-app.md
+++ b/versioned_docs/version-v2/guides/hydrate-app.md
@@ -3,10 +3,6 @@ title: Hydrate App
 sidebar_label: Hydrate App
 description: Hydrate App
 slug: /hydrate-app
-contributors:
-  - adamdbradley
-  - dgautsch
-  - bitflower
 ---
 
 # Hydrate App

--- a/versioned_docs/version-v2/guides/module-bundling.md
+++ b/versioned_docs/version-v2/guides/module-bundling.md
@@ -3,12 +3,6 @@ title: Module Bundling
 sidebar_label: Bundling
 description: Module Bundling
 slug: /module-bundling
-contributors:
-  - jthoms1
-  - adamdbradley
-  - kensodemann
-  - manucorporat
-  - ryan3E0
 ---
 
 # Module Bundling

--- a/versioned_docs/version-v2/guides/publishing.md
+++ b/versioned_docs/version-v2/guides/publishing.md
@@ -3,8 +3,6 @@ title: Publishing A Component Library
 sidebar_label: Publishing
 description: Publishing A Component Library
 slug: /publishing
-contributors:
-  - adamdbradley
 ---
 
 # Publishing A Component Library

--- a/versioned_docs/version-v2/guides/service-workers.md
+++ b/versioned_docs/version-v2/guides/service-workers.md
@@ -3,10 +3,6 @@ title: Service Workers
 sidebar_label: Service Workers
 description: Service Workers
 slug: /service-workers
-contributors:
-  - jthoms1
-  - simonhaenisch
-  - DavidFrahm
 ---
 
 # Service Workers

--- a/versioned_docs/version-v2/guides/style-guide.md
+++ b/versioned_docs/version-v2/guides/style-guide.md
@@ -3,12 +3,6 @@ title: Stencil Style Guide
 sidebar_label: Style Guide
 description: Stencil Style Guide
 slug: /style-guide
-contributors:
-  - jthoms1
-  - natemoo-re
-  - larionov
-  - joestrouth1
-  - rwaskiewicz
 ---
 
 # Stencil Style Guide

--- a/versioned_docs/version-v2/guides/typed-components.md
+++ b/versioned_docs/version-v2/guides/typed-components.md
@@ -3,10 +3,6 @@ title: Typed Components
 sidebar_label: Typed Components
 description: Typed Components
 slug: /typed-components
-contributors:
-  - adamdbradley
-  - manucorporat
-  - rwaskiewicz
 ---
 
 # Typed Components

--- a/versioned_docs/version-v2/introduction/01-overview.md
+++ b/versioned_docs/version-v2/introduction/01-overview.md
@@ -3,10 +3,6 @@ title: Stencil - A Compiler for Web Components
 sidebar_label: Overview
 description: Stencil has a number of add-ons that you can use with the build process.
 slug: /introduction
-contributors:
-  - jthoms1
-  - splitinfinities
-  - a-giuliano
 ---
 
 # Overview

--- a/versioned_docs/version-v2/introduction/02-goals-and-objectives.md
+++ b/versioned_docs/version-v2/introduction/02-goals-and-objectives.md
@@ -3,9 +3,6 @@ title: Stencil Goals and Objectives
 sidebar_label: Goals and Objectives
 description: Stencil aims to combine the best concepts of the most popular frontend frameworks into a compile-time tool rather than run-time tool.
 slug: /goals-and-objectives
-contributors:
-  - adamdbradley
-  - sri-ni
 ---
 
 # Stencil Goals And Objectives

--- a/versioned_docs/version-v2/introduction/03-getting-started.md
+++ b/versioned_docs/version-v2/introduction/03-getting-started.md
@@ -3,9 +3,6 @@ title: Getting Started
 sidebar_label: Getting Started
 description: Getting Started
 slug: /getting-started
-contributors:
-  - jthoms1
-  - rwaskiewicz
 ---
 
 # Getting Started

--- a/versioned_docs/version-v2/introduction/upgrading-to-stencil-three.md
+++ b/versioned_docs/version-v2/introduction/upgrading-to-stencil-three.md
@@ -2,8 +2,6 @@
 title: Upgrading to Stencil v3.0.0
 description: Upgrading to Stencil v3.0.0
 url: /docs/upgrading-to-stencil-3
-contributors:
-  - rwaskiewicz
 ---
 
 # Upgrading to Stencil v3.0.0

--- a/versioned_docs/version-v2/output-targets/01-overview.md
+++ b/versioned_docs/version-v2/output-targets/01-overview.md
@@ -3,10 +3,6 @@ title: Stencil Output Targets
 sidebar_label: Overview
 description: Stencil Output Targets
 slug: /output-targets
-contributors:
-  - adamdbradley
-  - manucorporat
-  - rwaskiewicz
 ---
 
 # Output Targets

--- a/versioned_docs/version-v2/output-targets/copy-tasks.md
+++ b/versioned_docs/version-v2/output-targets/copy-tasks.md
@@ -3,10 +3,6 @@ title: Stencil Copy Tasks
 sidebar_label: Copy Tasks
 description: Stencil Copy Tasks
 slug: /copy-tasks
-contributors:
-  - adamdbradley
-  - manucorporat
-  - jeanbenitez
 ---
 
 

--- a/versioned_docs/version-v2/output-targets/custom-elements-bundle.md
+++ b/versioned_docs/version-v2/output-targets/custom-elements-bundle.md
@@ -3,9 +3,6 @@ title: (Deprecated) Bundling Custom Elements with Stencil
 sidebar_label: dist-custom-elements-bundle
 description: Bundling Custom Elements with Stencil
 slug: /custom-elements-bundle
-contributors:
-  - adamdbradley
-  - splitinfinities
 ---
 
 # Custom Elements Bundle (Deprecated)

--- a/versioned_docs/version-v2/output-targets/custom-elements.md
+++ b/versioned_docs/version-v2/output-targets/custom-elements.md
@@ -3,10 +3,6 @@ title: Custom Elements with Stencil
 sidebar_label: dist-custom-elements
 description: Custom Elements with Stencil
 slug: /custom-elements
-contributors:
-  - adamdbradley
-  - rwaskiewicz
-  - splitinfinities
 ---
 
 # Custom Elements

--- a/versioned_docs/version-v2/output-targets/dist.md
+++ b/versioned_docs/version-v2/output-targets/dist.md
@@ -3,9 +3,6 @@ title: Distributing Web Components Built with Stencil
 sidebar_label: dist
 description: Distributing Web Components Built with Stencil
 slug: /distribution
-contributors:
-  - adamdbradley
-  - jthoms1
 ---
 
 # Distribution Output Target

--- a/versioned_docs/version-v2/output-targets/docs-custom.md
+++ b/versioned_docs/version-v2/output-targets/docs-custom.md
@@ -3,10 +3,6 @@ title: Custom Docs Generation
 sidebar_label: docs-custom
 description: Custom Docs Generation
 slug: /docs-custom
-contributors:
-  - adamdbradley
-  - manucorporat
-  - arayik-yervandyan
 ---
 
 # Custom Docs Generation

--- a/versioned_docs/version-v2/output-targets/docs-json.md
+++ b/versioned_docs/version-v2/output-targets/docs-json.md
@@ -3,14 +3,6 @@ title: Docs JSON Data Output Target
 sidebar_label: docs-json
 description: Docs JSON Output Target
 slug: /docs-json
-contributors:
-  - adamdbradley
-  - snaptopixel
-  - manucorporat
-  - amwmedia
-  - mrtnmgs
-  - marcjulian
-  - seanwuapps
 ---
 
 # Docs Json Data

--- a/versioned_docs/version-v2/output-targets/docs-readme.md
+++ b/versioned_docs/version-v2/output-targets/docs-readme.md
@@ -3,13 +3,6 @@ title: Docs Readme Auto-Generation
 sidebar_label: docs-readme
 description: Docs Readme Auto-Generation
 slug: /docs-readme
-contributors:
-  - adamdbradley
-  - snaptopixel
-  - manucorporat
-  - amwmedia
-  - mrtnmgs
-  - marcjulian
 ---
 
 # Docs Readme Markdown File Auto-Generation

--- a/versioned_docs/version-v2/output-targets/docs-stats.md
+++ b/versioned_docs/version-v2/output-targets/docs-stats.md
@@ -3,9 +3,6 @@ title: Docs Stats Auto-Generation
 sidebar_label: stats
 description: Docs Stats Auto-Generation
 slug: /stats
-contributors:
-  - adamdbradley
-  - splitinfinities
 ---
 
 # Stats

--- a/versioned_docs/version-v2/output-targets/docs-vscode.md
+++ b/versioned_docs/version-v2/output-targets/docs-vscode.md
@@ -2,8 +2,6 @@
 title: VS Code Documentation
 description: VS Code Documentation
 slug: /docs-vscode
-contributors:
-  - rwaskiewicz
 ---
 
 # VS Code Documentation

--- a/versioned_docs/version-v2/output-targets/www.md
+++ b/versioned_docs/version-v2/output-targets/www.md
@@ -3,10 +3,6 @@ title: Webapp Output Target
 sidebar_label: www
 description: Webapp Output Target
 slug: /www
-contributors:
-  - jthoms1
-  - simonhaenisch
-  - DavidFrahm
 ---
 
 # Webapp Output Target: `www`

--- a/versioned_docs/version-v2/reference/browser-support.md
+++ b/versioned_docs/version-v2/reference/browser-support.md
@@ -3,11 +3,6 @@ title: Stencil Web Component Browser Support
 sidebar_label: Browser Support
 description: Out-of-the-box browser support provided by Stencil web components.
 slug: /browser-support
-contributors:
-  - adamdbradley
-  - kevinports
-  - jthoms1
-  - arjunyel
 ---
 
 # Browser Support

--- a/versioned_docs/version-v2/reference/faq.md
+++ b/versioned_docs/version-v2/reference/faq.md
@@ -3,9 +3,6 @@ title: Stencil Frequently Asked Questions
 sidebar_label: FAQ
 description: Stencil is a developer-focused toolchain for building reusable, scalable component libraries, applications and design systems.
 slug: /faq
-contributors:
-  - adamdbradley
-  - rwaskiewicz
 ---
 
 # FAQ

--- a/versioned_docs/version-v2/reference/support-policy.md
+++ b/versioned_docs/version-v2/reference/support-policy.md
@@ -3,8 +3,6 @@ title: Support Policy
 sidebar_label: Support Policy
 description: Support Policy
 slug: /support-policy
-contributors:
-- rwaskiewicz
 ---
 
 # Support Policy

--- a/versioned_docs/version-v2/reference/versioning.md
+++ b/versioned_docs/version-v2/reference/versioning.md
@@ -3,8 +3,6 @@ title: Versioning
 sidebar_label: Versioning
 description: Versioning
 slug: /versioning
-contributors:
-- rwaskiewicz
 ---
 
 # Versioning

--- a/versioned_docs/version-v2/static-site-generation/01-overview.md
+++ b/versioned_docs/version-v2/static-site-generation/01-overview.md
@@ -2,10 +2,6 @@
 title: Static Site Generation
 sidebar_label: Overview
 slug: /static-site-generation
-contributors:
-  - mlynch
-  - adamdbradley
-  - bitflower
 ---
 
 # Static Site Generation with Stencil

--- a/versioned_docs/version-v2/static-site-generation/basics.md
+++ b/versioned_docs/version-v2/static-site-generation/basics.md
@@ -3,9 +3,6 @@ title: Static Site Generation Basics in Stencil
 sidebar_label: Basics
 description: Quick introduction to configuring and using Static Site Generation in Stencil
 slug: /static-site-generation-basics
-contributors:
-  - mlynch
-  - adamdbradley
 ---
 
 # Static Site Generation Basics

--- a/versioned_docs/version-v2/static-site-generation/debugging.md
+++ b/versioned_docs/version-v2/static-site-generation/debugging.md
@@ -3,9 +3,6 @@ title: Debugging Static Site Generation in Stencil
 sidebar_label: Debugging
 description: How to debug a prerendering or Static Site Generation step in Stencil
 slug: /static-site-generation-debugging
-contributors:
-  - mlynch
-  - adamdbradley
 ---
 
 # Debugging Static Site Generation

--- a/versioned_docs/version-v2/static-site-generation/deployment.md
+++ b/versioned_docs/version-v2/static-site-generation/deployment.md
@@ -3,8 +3,6 @@ title: Deploying a Static Site
 sidebar_label: Deployment
 description: Deploying a Static Site
 slug: /static-site-generation-deployment
-contributors:
-  - mlynch
 ---
 
 # Deploying a Stencil Static Site

--- a/versioned_docs/version-v2/static-site-generation/meta.md
+++ b/versioned_docs/version-v2/static-site-generation/meta.md
@@ -3,10 +3,6 @@ title: SEO Meta Tags in SSG
 sidebar_label: Meta tags
 description: Managing meta tags for SEO and social media embedding in Stencil Static Sites
 slug: /static-site-generation-meta-tags
-contributors:
-  - mlynch
-  - adamdbradley
-  - rwaskiewicz
 ---
 
 # SEO Meta Tags and Static Site Generation

--- a/versioned_docs/version-v2/static-site-generation/prerender-config.md
+++ b/versioned_docs/version-v2/static-site-generation/prerender-config.md
@@ -3,10 +3,6 @@ title: Prerender Config
 sidebar_label: Prerender Config
 description: Prerender Config
 slug: /prerender-config
-contributors:
-  - adamdbradley
-  - ryan3E0
-  - dgautsch
 ---
 
 

--- a/versioned_docs/version-v2/static-site-generation/server-side-rendering-ssr.md
+++ b/versioned_docs/version-v2/static-site-generation/server-side-rendering-ssr.md
@@ -3,8 +3,6 @@ title: Combining Server Side Rendering and Static Site Generation
 sidebar_label: Server Side Rendering
 description: How to combine both Server Side Rendering and Static Site Generation approaches
 slug: /static-site-generation-server-side-rendering-ssr
-contributors:
-  - mlynch
 ---
 
 # Combining Server Side Rendering and Static Site Generation

--- a/versioned_docs/version-v2/telemetry.md
+++ b/versioned_docs/version-v2/telemetry.md
@@ -1,8 +1,6 @@
 ---
 title: Telemetry
 description: Stencil Telemetry usage information
-contributors:
-  - splitinfinities
 ---
 
 # Stencil CLI telemetry

--- a/versioned_docs/version-v2/testing/01-overview.md
+++ b/versioned_docs/version-v2/testing/01-overview.md
@@ -3,12 +3,6 @@ title: Testing
 sidebar_label: Overview
 description: Testing overview.
 slug: /testing-overview
-contributors:
-  - adamdbradley
-  - brandyscarney
-  - camwiegert
-  - kensodemann
-  - rwaskiewicz
 ---
 
 # Testing

--- a/versioned_docs/version-v2/testing/config.md
+++ b/versioned_docs/version-v2/testing/config.md
@@ -3,10 +3,6 @@ title: Testing Config
 sidebar_label: Config
 description: Testing Config
 slug: /testing-config
-contributors:
-  - adamdbradley
-  - mattcosta7
-  - viernullvier
 ---
 
 # Testing Config

--- a/versioned_docs/version-v2/testing/e2e-testing.md
+++ b/versioned_docs/version-v2/testing/e2e-testing.md
@@ -3,10 +3,6 @@ title: End-to-end Testing
 sidebar_label: End-to-end Testing
 description: End-to-end Testing
 slug: /end-to-end-testing
-contributors:
-  - adamdbradley
-  - mattdsteele
-  - simonhaenisch
 ---
 
 # End-to-end Testing

--- a/versioned_docs/version-v2/testing/mocking.md
+++ b/versioned_docs/version-v2/testing/mocking.md
@@ -3,8 +3,6 @@ title: Mocking
 sidebar_label: Mocking
 description: Mocking
 slug: /mocking
-contributors:
-  - simonhaenisch
 ---
 
 # Mocking

--- a/versioned_docs/version-v2/testing/screenshot-connector.md
+++ b/versioned_docs/version-v2/testing/screenshot-connector.md
@@ -3,8 +3,6 @@ title: Screenshot Connector
 sidebar_label: Screenshot Connector
 description: Screenshot Connector
 slug: /screenshot-connector
-contributors:
-  - SheepFromHeaven
 ---
 
 # Screenshot connector

--- a/versioned_docs/version-v2/testing/screenshot-visual-diff.md
+++ b/versioned_docs/version-v2/testing/screenshot-visual-diff.md
@@ -3,8 +3,6 @@ title: Screenshot Visual Diff
 sidebar_label: Visual Screenshot Diff
 description: Screenshot Visual Diff
 slug: /screenshot-visual-diff
-contributors:
-  - adamdbradley
 ---
 
 # Screenshot Visual Diff

--- a/versioned_docs/version-v2/testing/unit-testing.md
+++ b/versioned_docs/version-v2/testing/unit-testing.md
@@ -3,10 +3,6 @@ title: Unit Testing
 sidebar_label: Unit Testing
 description: Unit Testing
 slug: /unit-testing
-contributors:
-  - adamdbradley
-  - mattdsteele
-  - bassettsj
 ---
 
 # Unit Testing

--- a/versioned_docs/version-v3.0/build-variables.md
+++ b/versioned_docs/version-v3.0/build-variables.md
@@ -2,8 +2,6 @@
 title: Build Constants
 description: Stencil has a number of add-ons that you can use with the build process.
 slug: /build-variables
-contributors:
-  - jthoms1
 ---
 
 # Build Constants

--- a/versioned_docs/version-v3.0/components/api.md
+++ b/versioned_docs/version-v3.0/components/api.md
@@ -3,14 +3,6 @@ title: Component API
 sidebar_label: API
 description: Component API
 slug: /api
-contributors:
-  - manucorporat
-  - Mawulijo
-  - hashcrof
-  - ZenPylon
-  - danjohnson95
-  - rezaabedian
-  - CookieCookson
 ---
 
 # Component API

--- a/versioned_docs/version-v3.0/components/component-lifecycle.md
+++ b/versioned_docs/version-v3.0/components/component-lifecycle.md
@@ -3,8 +3,6 @@ title: Component Lifecycle Methods
 sidebar_label: Lifecycle Methods
 description: Component Lifecycle Methods
 slug: /component-lifecycle
-contributors:
-  - jthoms1
 ---
 
 # Component Lifecycle Methods

--- a/versioned_docs/version-v3.0/components/component.md
+++ b/versioned_docs/version-v3.0/components/component.md
@@ -3,9 +3,6 @@ title: Component Decorator
 sidebar_label: Component
 description: Documentation for the @Component decorator
 slug: /component
-contributors:
-- jthoms1
-- rwaskiewicz
 ---
 
 # Component Decorator

--- a/versioned_docs/version-v3.0/components/events.md
+++ b/versioned_docs/version-v3.0/components/events.md
@@ -3,12 +3,6 @@ title: Events
 sidebar_label: Events
 description: Events
 slug: /events
-contributors:
-  - jthoms1
-  - mgalic
-  - BDav24
-  - mattcosta7
-  - noherczeg
 ---
 
 # Events

--- a/versioned_docs/version-v3.0/components/functional-components.md
+++ b/versioned_docs/version-v3.0/components/functional-components.md
@@ -3,8 +3,6 @@ title: Functional Components
 sidebar_label: Functional Components
 description: Functional Components
 slug: /functional-components
-contributors:
-  - simonhaenisch
 ---
 
 # Working with Functional Components

--- a/versioned_docs/version-v3.0/components/host-element.md
+++ b/versioned_docs/version-v3.0/components/host-element.md
@@ -3,8 +3,6 @@ title: Working with host elements
 sidebar_label: Host Element
 description: Working with host elements
 slug: /host-element
-contributors:
-  - jthoms1
 ---
 
 # Working with host elements

--- a/versioned_docs/version-v3.0/components/methods.md
+++ b/versioned_docs/version-v3.0/components/methods.md
@@ -3,9 +3,6 @@ title: Methods
 sidebar_label: Methods
 description: methods
 slug: /methods
-contributors:
-  - jthoms1
-  - manucorporat
 ---
 
 # Method Decorator

--- a/versioned_docs/version-v3.0/components/properties.md
+++ b/versioned_docs/version-v3.0/components/properties.md
@@ -3,9 +3,6 @@ title: Properties
 sidebar_label: Properties
 description: Properties
 slug: /properties
-contributors:
-  - jthoms1
-  - rwaskiewicz
 ---
 
 # Properties

--- a/versioned_docs/version-v3.0/components/reactive-data.md
+++ b/versioned_docs/version-v3.0/components/reactive-data.md
@@ -3,9 +3,6 @@ title: Reactive Data, Handling arrays and objects
 sidebar_label: Reactive Data
 description: Reactive Data, Handling arrays and objects
 slug: /reactive-data
-contributors:
-  - jthoms1
-  - rwaskiewicz
 ---
 
 # Reactive Data

--- a/versioned_docs/version-v3.0/components/state.md
+++ b/versioned_docs/version-v3.0/components/state.md
@@ -3,9 +3,6 @@ title: Internal state
 sidebar_label: Internal State
 description: Use the State() for component's internal state
 slug: /state
-contributors:
-  - jthoms1
-  - rwaskiewicz
 ---
 
 # State

--- a/versioned_docs/version-v3.0/components/styling.md
+++ b/versioned_docs/version-v3.0/components/styling.md
@@ -3,10 +3,6 @@ title: Styling Components
 sidebar_label: Styling
 description: Styling Components
 slug: /styling
-contributors:
-  - jthoms1
-  - shreeshbhat
-  - a-giuliano
 ---
 
 # Styling Components

--- a/versioned_docs/version-v3.0/components/templating-and-jsx.md
+++ b/versioned_docs/version-v3.0/components/templating-and-jsx.md
@@ -3,10 +3,6 @@ title: Using JSX
 sidebar_label: Using JSX
 description: Using JSX
 slug: /templating-jsx
-contributors:
-  - jthoms1
-  - simonhaenisch
-  - arjunyel
 ---
 
 # Using JSX

--- a/versioned_docs/version-v3.0/config/01-overview.md
+++ b/versioned_docs/version-v3.0/config/01-overview.md
@@ -3,14 +3,6 @@ title: Config
 sidebar_label: Overview
 description: Config
 slug: /config
-contributors:
-  - adamdbradley
-  - jthoms1
-  - flawyte
-  - BDav24
-  - rwaskiewicz
-  - simonhaenisch
-  - splitinfinities
 ---
 
 # Stencil Config

--- a/versioned_docs/version-v3.0/config/cli.md
+++ b/versioned_docs/version-v3.0/config/cli.md
@@ -3,9 +3,6 @@ title: Stencil CLI
 sidebar_label: CLI
 description: Stencil CLI
 slug: /cli
-contributors:
-  - miguelyoobic95
-  - adamdbradley
 ---
 
 # Command Line Interface (CLI)

--- a/versioned_docs/version-v3.0/config/dev-server.md
+++ b/versioned_docs/version-v3.0/config/dev-server.md
@@ -3,11 +3,6 @@ title: Integrated Dev Server Config
 sidebar_label: Dev Server
 description: Integrated Dev Server Config
 slug: /dev-server
-contributors:
-  - adamdbradley
-  - BDav24
-  - feerglas
-  - simonhaenisch
 ---
 
 # Integrated Dev Server

--- a/versioned_docs/version-v3.0/config/extras.md
+++ b/versioned_docs/version-v3.0/config/extras.md
@@ -3,10 +3,6 @@ title: Extras Config
 sidebar_label: Extras
 description: Extras Config
 slug: /config-extras
-contributors:
-  - mattdsteele
-  - rwaskiewicz
-  - alicewriteswrongs
 ---
 
 # Extras

--- a/versioned_docs/version-v3.0/config/plugins.md
+++ b/versioned_docs/version-v3.0/config/plugins.md
@@ -3,10 +3,6 @@ title: Plugin Config
 sidebar_label: Plugins
 description: Plugin Config
 slug: /plugins
-contributors:
-  - adamdbradley
-  - jthoms1
-  - mgalic
 ---
 
 # Plugins

--- a/versioned_docs/version-v3.0/core/cli-api.md
+++ b/versioned_docs/version-v3.0/core/cli-api.md
@@ -3,8 +3,6 @@ title: Stencil Core CLI API
 sidebar_label: CLI API
 description:  Stencil Core CLI API
 slug: /cli-api
-contributors:
-  - adamdbradley
 ---
 
 # Stencil Core CLI API

--- a/versioned_docs/version-v3.0/core/compiler-api.md
+++ b/versioned_docs/version-v3.0/core/compiler-api.md
@@ -3,8 +3,6 @@ title: Stencil Core Compiler API
 sidebar_label: Compiler API
 description:  Stencil Core Compiler API
 slug: /compiler-api
-contributors:
-  - adamdbradley
 ---
 
 # Stencil Core Compiler API

--- a/versioned_docs/version-v3.0/core/dev-server-api.md
+++ b/versioned_docs/version-v3.0/core/dev-server-api.md
@@ -3,9 +3,6 @@ title: Stencil Core Dev Server API
 sidebar_label: Dev Server API
 description:  Stencil Core Dev Server API
 slug: /dev-server-api
-contributors:
-  - adamdbradley
-  - dominikpieper
 ---
 
 # Stencil Core Dev Server API

--- a/versioned_docs/version-v3.0/framework-integration/01-overview.md
+++ b/versioned_docs/version-v3.0/framework-integration/01-overview.md
@@ -3,9 +3,6 @@ title: Framework Integration
 sidebar_label: Overview
 description: Framework Integration
 slug: /overview
-contributors:
-  - adamdbradley
-  - brandyscarney
 ---
 
 # Framework Integration

--- a/versioned_docs/version-v3.0/framework-integration/angular.md
+++ b/versioned_docs/version-v3.0/framework-integration/angular.md
@@ -3,15 +3,6 @@ title: Angular Integration with Stencil
 sidebar_label: Angular
 description: Learn how to wrap your components so that people can use them natively in Angular
 slug: /angular
-contributors:
-  - jthoms1
-  - adamdbradley
-  - kensodemann
-  - peterpeterparker
-  - jeanbenitez
-  - mburger81
-  - splitinfinities
-  - tanner-reits
 ---
 
 # Angular Integration

--- a/versioned_docs/version-v3.0/framework-integration/ember.md
+++ b/versioned_docs/version-v3.0/framework-integration/ember.md
@@ -3,9 +3,6 @@ title: Ember Integration with Stencil
 sidebar_label: Ember
 description: Ember Integration with Stencil
 slug: /ember
-contributors:
-  - jthoms1
-  - adamdbradley
 ---
 
 # Ember

--- a/versioned_docs/version-v3.0/framework-integration/javascript.md
+++ b/versioned_docs/version-v3.0/framework-integration/javascript.md
@@ -3,12 +3,6 @@ title: Components without a Framework
 sidebar_label: JavaScript
 description: Components without a Framework
 slug: /javascript
-contributors:
-  - mhartington
-  - jthoms1
-  - adamdbradley
-  - BDav24
-  - DaniAcu
 ---
 
 # Components without a Framework

--- a/versioned_docs/version-v3.0/framework-integration/react.md
+++ b/versioned_docs/version-v3.0/framework-integration/react.md
@@ -3,16 +3,6 @@ title: React Integration with Stencil
 sidebar_label: React
 description: Learn how to wrap your components so that people can use them natively in React
 slug: /react
-contributors:
-  - jthoms1
-  - adamdbradley
-  - kensodemann
-  - ErikSchierboom
-  - brentertz
-  - danawoodman
-  - a-giuliano
-  - rwaskiewicz
-  - tanner-reits
 ---
 
 # React Integration

--- a/versioned_docs/version-v3.0/framework-integration/vue.md
+++ b/versioned_docs/version-v3.0/framework-integration/vue.md
@@ -3,14 +3,6 @@ title: VueJS Integration with Stencil
 sidebar_label: Vue
 description: Learn how to wrap your components so that people can use them natively in Vue
 slug: /vue
-contributors:
-  - jthoms1
-  - adamdbradley
-  - kensodemann
-  - brysalazar12
-  - iskanderbroere
-  - sean-perkins
-  - tanner-reits
 ---
 
 # Vue Integration

--- a/versioned_docs/version-v3.0/guides/assets.md
+++ b/versioned_docs/version-v3.0/guides/assets.md
@@ -3,10 +3,6 @@ title: Assets
 sidebar_label: Assets
 description: Learn how to reference assets in your components
 slug: /assets
-contributors:
-  - splitinfinities
-  - simonhaenisch
-  - rwaskiewicz
 ---
 
 # Assets

--- a/versioned_docs/version-v3.0/guides/build-conditionals.md
+++ b/versioned_docs/version-v3.0/guides/build-conditionals.md
@@ -1,8 +1,6 @@
 ---
 title: Build Conditionals
 description: Build Conditionals
-contributors:
-  - jthoms1
 ---
 
 # Build Conditionals

--- a/versioned_docs/version-v3.0/guides/csp-nonce.md
+++ b/versioned_docs/version-v3.0/guides/csp-nonce.md
@@ -2,8 +2,6 @@
 title: Content Security Policy Nonces
 description: How to leverage CSP nonces in Stencil projects.
 slug: /csp-nonce
-contributors:
-  - tanner-reits
 ---
 
 # Using Content Security Policy Nonces in Stencil

--- a/versioned_docs/version-v3.0/guides/design-systems.md
+++ b/versioned_docs/version-v3.0/guides/design-systems.md
@@ -3,9 +3,6 @@ title: Design Systems
 sidebar_label: Design Systems
 description: Design Systems in Stencil
 slug: /design-systems
-contributors:
-  - dotNetkow
-  - rwaskiewicz
 ---
 
 # Design Systems

--- a/versioned_docs/version-v3.0/guides/forms.md
+++ b/versioned_docs/version-v3.0/guides/forms.md
@@ -3,8 +3,6 @@ title: Forms
 sidebar_label: Forms
 description: Forms
 slug: /forms
-contributors:
-  - jthoms1
 ---
 
 # Forms

--- a/versioned_docs/version-v3.0/guides/hydrate-app.md
+++ b/versioned_docs/version-v3.0/guides/hydrate-app.md
@@ -3,10 +3,6 @@ title: Hydrate App
 sidebar_label: Hydrate App
 description: Hydrate App
 slug: /hydrate-app
-contributors:
-  - adamdbradley
-  - dgautsch
-  - bitflower
 ---
 
 # Hydrate App

--- a/versioned_docs/version-v3.0/guides/module-bundling.md
+++ b/versioned_docs/version-v3.0/guides/module-bundling.md
@@ -3,12 +3,6 @@ title: Module Bundling
 sidebar_label: Bundling
 description: Module Bundling
 slug: /module-bundling
-contributors:
-  - jthoms1
-  - adamdbradley
-  - kensodemann
-  - manucorporat
-  - ryan3E0
 ---
 
 # Module Bundling

--- a/versioned_docs/version-v3.0/guides/publishing.md
+++ b/versioned_docs/version-v3.0/guides/publishing.md
@@ -3,8 +3,6 @@ title: Publishing A Component Library
 sidebar_label: Publishing
 description: Publishing A Component Library
 slug: /publishing
-contributors:
-  - adamdbradley
 ---
 
 # Publishing A Component Library

--- a/versioned_docs/version-v3.0/guides/service-workers.md
+++ b/versioned_docs/version-v3.0/guides/service-workers.md
@@ -3,10 +3,6 @@ title: Service Workers
 sidebar_label: Service Workers
 description: Service Workers
 slug: /service-workers
-contributors:
-  - jthoms1
-  - simonhaenisch
-  - DavidFrahm
 ---
 
 # Service Workers

--- a/versioned_docs/version-v3.0/guides/style-guide.md
+++ b/versioned_docs/version-v3.0/guides/style-guide.md
@@ -3,12 +3,6 @@ title: Stencil Style Guide
 sidebar_label: Style Guide
 description: Stencil Style Guide
 slug: /style-guide
-contributors:
-  - jthoms1
-  - natemoo-re
-  - larionov
-  - joestrouth1
-  - rwaskiewicz
 ---
 
 # Stencil Style Guide

--- a/versioned_docs/version-v3.0/guides/typed-components.md
+++ b/versioned_docs/version-v3.0/guides/typed-components.md
@@ -3,10 +3,6 @@ title: Typed Components
 sidebar_label: Typed Components
 description: Typed Components
 slug: /typed-components
-contributors:
-  - adamdbradley
-  - manucorporat
-  - rwaskiewicz
 ---
 
 # Typed Components

--- a/versioned_docs/version-v3.0/introduction/01-overview.md
+++ b/versioned_docs/version-v3.0/introduction/01-overview.md
@@ -3,10 +3,6 @@ title: Stencil - A Compiler for Web Components
 sidebar_label: Overview
 description: Stencil has a number of add-ons that you can use with the build process.
 slug: /introduction
-contributors:
-  - jthoms1
-  - splitinfinities
-  - a-giuliano
 ---
 
 # Overview

--- a/versioned_docs/version-v3.0/introduction/02-goals-and-objectives.md
+++ b/versioned_docs/version-v3.0/introduction/02-goals-and-objectives.md
@@ -3,9 +3,6 @@ title: Stencil Goals and Objectives
 sidebar_label: Goals and Objectives
 description: Stencil aims to combine the best concepts of the most popular frontend frameworks into a compile-time tool rather than run-time tool.
 slug: /goals-and-objectives
-contributors:
-  - adamdbradley
-  - sri-ni
 ---
 
 # Stencil Goals And Objectives

--- a/versioned_docs/version-v3.0/introduction/03-getting-started.md
+++ b/versioned_docs/version-v3.0/introduction/03-getting-started.md
@@ -3,9 +3,6 @@ title: Getting Started
 sidebar_label: Getting Started
 description: Getting Started
 slug: /getting-started
-contributors:
-  - jthoms1
-  - rwaskiewicz
 ---
 
 # Getting Started

--- a/versioned_docs/version-v3.0/introduction/upgrading-to-stencil-three.md
+++ b/versioned_docs/version-v3.0/introduction/upgrading-to-stencil-three.md
@@ -2,8 +2,6 @@
 title: Upgrading to Stencil v3.0.0
 description: Upgrading to Stencil v3.0.0
 url: /docs/upgrading-to-stencil-3
-contributors:
-  - rwaskiewicz
 ---
 
 # Upgrading to Stencil v3.0.0

--- a/versioned_docs/version-v3.0/output-targets/01-overview.md
+++ b/versioned_docs/version-v3.0/output-targets/01-overview.md
@@ -3,10 +3,6 @@ title: Stencil Output Targets
 sidebar_label: Overview
 description: Stencil Output Targets
 slug: /output-targets
-contributors:
-  - adamdbradley
-  - manucorporat
-  - rwaskiewicz
 ---
 
 # Output Targets

--- a/versioned_docs/version-v3.0/output-targets/copy-tasks.md
+++ b/versioned_docs/version-v3.0/output-targets/copy-tasks.md
@@ -3,10 +3,6 @@ title: Stencil Copy Tasks
 sidebar_label: Copy Tasks
 description: Stencil Copy Tasks
 slug: /copy-tasks
-contributors:
-  - adamdbradley
-  - manucorporat
-  - jeanbenitez
 ---
 
 

--- a/versioned_docs/version-v3.0/output-targets/custom-elements.md
+++ b/versioned_docs/version-v3.0/output-targets/custom-elements.md
@@ -3,11 +3,6 @@ title: Custom Elements with Stencil
 sidebar_label: dist-custom-elements
 description: Custom Elements with Stencil
 slug: /custom-elements
-contributors:
-  - adamdbradley
-  - rwaskiewicz
-  - splitinfinities
-  - tanner-reits
 ---
 
 # Custom Elements

--- a/versioned_docs/version-v3.0/output-targets/dist.md
+++ b/versioned_docs/version-v3.0/output-targets/dist.md
@@ -3,9 +3,6 @@ title: Distributing Web Components Built with Stencil
 sidebar_label: dist
 description: Distributing Web Components Built with Stencil
 slug: /distribution
-contributors:
-  - adamdbradley
-  - jthoms1
 ---
 
 # Distribution Output Target

--- a/versioned_docs/version-v3.0/output-targets/docs-custom.md
+++ b/versioned_docs/version-v3.0/output-targets/docs-custom.md
@@ -3,10 +3,6 @@ title: Custom Docs Generation
 sidebar_label: docs-custom
 description: Custom Docs Generation
 slug: /docs-custom
-contributors:
-  - adamdbradley
-  - manucorporat
-  - arayik-yervandyan
 ---
 
 # Custom Docs Generation

--- a/versioned_docs/version-v3.0/output-targets/docs-json.md
+++ b/versioned_docs/version-v3.0/output-targets/docs-json.md
@@ -3,14 +3,6 @@ title: Docs JSON Data Output Target
 sidebar_label: docs-json
 description: Docs JSON Output Target
 slug: /docs-json
-contributors:
-  - adamdbradley
-  - snaptopixel
-  - manucorporat
-  - amwmedia
-  - mrtnmgs
-  - marcjulian
-  - seanwuapps
 ---
 
 # Docs Json Data

--- a/versioned_docs/version-v3.0/output-targets/docs-readme.md
+++ b/versioned_docs/version-v3.0/output-targets/docs-readme.md
@@ -3,13 +3,6 @@ title: Docs Readme Auto-Generation
 sidebar_label: docs-readme
 description: Docs Readme Auto-Generation
 slug: /docs-readme
-contributors:
-  - adamdbradley
-  - snaptopixel
-  - manucorporat
-  - amwmedia
-  - mrtnmgs
-  - marcjulian
 ---
 
 # Docs Readme Markdown File Auto-Generation

--- a/versioned_docs/version-v3.0/output-targets/docs-stats.md
+++ b/versioned_docs/version-v3.0/output-targets/docs-stats.md
@@ -3,9 +3,6 @@ title: Docs Stats Auto-Generation
 sidebar_label: stats
 description: Docs Stats Auto-Generation
 slug: /stats
-contributors:
-  - adamdbradley
-  - splitinfinities
 ---
 
 # Stats

--- a/versioned_docs/version-v3.0/output-targets/docs-vscode.md
+++ b/versioned_docs/version-v3.0/output-targets/docs-vscode.md
@@ -2,8 +2,6 @@
 title: VS Code Documentation
 description: VS Code Documentation
 slug: /docs-vscode
-contributors:
-  - rwaskiewicz
 ---
 
 # VS Code Documentation

--- a/versioned_docs/version-v3.0/output-targets/www.md
+++ b/versioned_docs/version-v3.0/output-targets/www.md
@@ -3,10 +3,6 @@ title: Webapp Output Target
 sidebar_label: www
 description: Webapp Output Target
 slug: /www
-contributors:
-  - jthoms1
-  - simonhaenisch
-  - DavidFrahm
 ---
 
 # Webapp Output Target: `www`

--- a/versioned_docs/version-v3.0/reference/browser-support.md
+++ b/versioned_docs/version-v3.0/reference/browser-support.md
@@ -3,11 +3,6 @@ title: Stencil Web Component Browser Support
 sidebar_label: Browser Support
 description: Out-of-the-box browser support provided by Stencil web components.
 slug: /browser-support
-contributors:
-  - adamdbradley
-  - kevinports
-  - jthoms1
-  - arjunyel
 ---
 
 # Browser Support

--- a/versioned_docs/version-v3.0/reference/faq.md
+++ b/versioned_docs/version-v3.0/reference/faq.md
@@ -3,9 +3,6 @@ title: Stencil Frequently Asked Questions
 sidebar_label: FAQ
 description: Stencil is a developer-focused toolchain for building reusable, scalable component libraries, applications and design systems.
 slug: /faq
-contributors:
-  - adamdbradley
-  - rwaskiewicz
 ---
 
 # FAQ

--- a/versioned_docs/version-v3.0/reference/support-policy.md
+++ b/versioned_docs/version-v3.0/reference/support-policy.md
@@ -3,8 +3,6 @@ title: Support Policy
 sidebar_label: Support Policy
 description: Support Policy
 slug: /support-policy
-contributors:
-- rwaskiewicz
 ---
 
 # Support Policy

--- a/versioned_docs/version-v3.0/reference/versioning.md
+++ b/versioned_docs/version-v3.0/reference/versioning.md
@@ -3,8 +3,6 @@ title: Versioning
 sidebar_label: Versioning
 description: Versioning
 slug: /versioning
-contributors:
-- rwaskiewicz
 ---
 
 # Versioning

--- a/versioned_docs/version-v3.0/static-site-generation/01-overview.md
+++ b/versioned_docs/version-v3.0/static-site-generation/01-overview.md
@@ -2,10 +2,6 @@
 title: Static Site Generation
 sidebar_label: Overview
 slug: /static-site-generation
-contributors:
-  - mlynch
-  - adamdbradley
-  - bitflower
 ---
 
 # Static Site Generation with Stencil

--- a/versioned_docs/version-v3.0/static-site-generation/basics.md
+++ b/versioned_docs/version-v3.0/static-site-generation/basics.md
@@ -3,9 +3,6 @@ title: Static Site Generation Basics in Stencil
 sidebar_label: Basics
 description: Quick introduction to configuring and using Static Site Generation in Stencil
 slug: /static-site-generation-basics
-contributors:
-  - mlynch
-  - adamdbradley
 ---
 
 # Static Site Generation Basics

--- a/versioned_docs/version-v3.0/static-site-generation/debugging.md
+++ b/versioned_docs/version-v3.0/static-site-generation/debugging.md
@@ -3,9 +3,6 @@ title: Debugging Static Site Generation in Stencil
 sidebar_label: Debugging
 description: How to debug a prerendering or Static Site Generation step in Stencil
 slug: /static-site-generation-debugging
-contributors:
-  - mlynch
-  - adamdbradley
 ---
 
 # Debugging Static Site Generation

--- a/versioned_docs/version-v3.0/static-site-generation/deployment.md
+++ b/versioned_docs/version-v3.0/static-site-generation/deployment.md
@@ -3,8 +3,6 @@ title: Deploying a Static Site
 sidebar_label: Deployment
 description: Deploying a Static Site
 slug: /static-site-generation-deployment
-contributors:
-  - mlynch
 ---
 
 # Deploying a Stencil Static Site

--- a/versioned_docs/version-v3.0/static-site-generation/meta.md
+++ b/versioned_docs/version-v3.0/static-site-generation/meta.md
@@ -3,10 +3,6 @@ title: SEO Meta Tags in SSG
 sidebar_label: Meta tags
 description: Managing meta tags for SEO and social media embedding in Stencil Static Sites
 slug: /static-site-generation-meta-tags
-contributors:
-  - mlynch
-  - adamdbradley
-  - rwaskiewicz
 ---
 
 # SEO Meta Tags and Static Site Generation

--- a/versioned_docs/version-v3.0/static-site-generation/prerender-config.md
+++ b/versioned_docs/version-v3.0/static-site-generation/prerender-config.md
@@ -3,10 +3,6 @@ title: Prerender Config
 sidebar_label: Prerender Config
 description: Prerender Config
 slug: /prerender-config
-contributors:
-  - adamdbradley
-  - ryan3E0
-  - dgautsch
 ---
 
 

--- a/versioned_docs/version-v3.0/static-site-generation/server-side-rendering-ssr.md
+++ b/versioned_docs/version-v3.0/static-site-generation/server-side-rendering-ssr.md
@@ -3,8 +3,6 @@ title: Combining Server Side Rendering and Static Site Generation
 sidebar_label: Server Side Rendering
 description: How to combine both Server Side Rendering and Static Site Generation approaches
 slug: /static-site-generation-server-side-rendering-ssr
-contributors:
-  - mlynch
 ---
 
 # Combining Server Side Rendering and Static Site Generation

--- a/versioned_docs/version-v3.0/telemetry.md
+++ b/versioned_docs/version-v3.0/telemetry.md
@@ -1,8 +1,6 @@
 ---
 title: Telemetry
 description: Stencil Telemetry usage information
-contributors:
-  - splitinfinities
 ---
 
 # Stencil CLI telemetry

--- a/versioned_docs/version-v3.0/testing/01-overview.md
+++ b/versioned_docs/version-v3.0/testing/01-overview.md
@@ -3,12 +3,6 @@ title: Testing
 sidebar_label: Overview
 description: Testing overview.
 slug: /testing-overview
-contributors:
-  - adamdbradley
-  - brandyscarney
-  - camwiegert
-  - kensodemann
-  - rwaskiewicz
 ---
 
 # Testing

--- a/versioned_docs/version-v3.0/testing/config.md
+++ b/versioned_docs/version-v3.0/testing/config.md
@@ -3,10 +3,6 @@ title: Testing Config
 sidebar_label: Config
 description: Testing Config
 slug: /testing-config
-contributors:
-  - adamdbradley
-  - mattcosta7
-  - viernullvier
 ---
 
 # Testing Config

--- a/versioned_docs/version-v3.0/testing/e2e-testing.md
+++ b/versioned_docs/version-v3.0/testing/e2e-testing.md
@@ -3,10 +3,6 @@ title: End-to-end Testing
 sidebar_label: End-to-end Testing
 description: End-to-end Testing
 slug: /end-to-end-testing
-contributors:
-  - adamdbradley
-  - mattdsteele
-  - simonhaenisch
 ---
 
 # End-to-end Testing

--- a/versioned_docs/version-v3.0/testing/mocking.md
+++ b/versioned_docs/version-v3.0/testing/mocking.md
@@ -3,8 +3,6 @@ title: Mocking
 sidebar_label: Mocking
 description: Mocking
 slug: /mocking
-contributors:
-  - simonhaenisch
 ---
 
 # Mocking

--- a/versioned_docs/version-v3.0/testing/screenshot-connector.md
+++ b/versioned_docs/version-v3.0/testing/screenshot-connector.md
@@ -3,8 +3,6 @@ title: Screenshot Connector
 sidebar_label: Screenshot Connector
 description: Screenshot Connector
 slug: /screenshot-connector
-contributors:
-  - SheepFromHeaven
 ---
 
 # Screenshot connector

--- a/versioned_docs/version-v3.0/testing/screenshot-visual-diff.md
+++ b/versioned_docs/version-v3.0/testing/screenshot-visual-diff.md
@@ -3,8 +3,6 @@ title: Screenshot Visual Diff
 sidebar_label: Visual Screenshot Diff
 description: Screenshot Visual Diff
 slug: /screenshot-visual-diff
-contributors:
-  - adamdbradley
 ---
 
 # Screenshot Visual Diff

--- a/versioned_docs/version-v3.0/testing/unit-testing.md
+++ b/versioned_docs/version-v3.0/testing/unit-testing.md
@@ -3,10 +3,6 @@ title: Unit Testing
 sidebar_label: Unit Testing
 description: Unit Testing
 slug: /unit-testing
-contributors:
-  - adamdbradley
-  - mattdsteele
-  - bassettsj
 ---
 
 # Unit Testing

--- a/versioned_docs/version-v3.1/build-variables.md
+++ b/versioned_docs/version-v3.1/build-variables.md
@@ -2,8 +2,6 @@
 title: Build Constants
 description: Stencil has a number of add-ons that you can use with the build process.
 slug: /build-variables
-contributors:
-  - jthoms1
 ---
 
 # Build Constants

--- a/versioned_docs/version-v3.1/components/api.md
+++ b/versioned_docs/version-v3.1/components/api.md
@@ -3,14 +3,6 @@ title: Component API
 sidebar_label: API
 description: Component API
 slug: /api
-contributors:
-  - manucorporat
-  - Mawulijo
-  - hashcrof
-  - ZenPylon
-  - danjohnson95
-  - rezaabedian
-  - CookieCookson
 ---
 
 # Component API

--- a/versioned_docs/version-v3.1/components/component-lifecycle.md
+++ b/versioned_docs/version-v3.1/components/component-lifecycle.md
@@ -3,8 +3,6 @@ title: Component Lifecycle Methods
 sidebar_label: Lifecycle Methods
 description: Component Lifecycle Methods
 slug: /component-lifecycle
-contributors:
-  - jthoms1
 ---
 
 # Component Lifecycle Methods

--- a/versioned_docs/version-v3.1/components/component.md
+++ b/versioned_docs/version-v3.1/components/component.md
@@ -3,9 +3,6 @@ title: Component Decorator
 sidebar_label: Component
 description: Documentation for the @Component decorator
 slug: /component
-contributors:
-- jthoms1
-- rwaskiewicz
 ---
 
 # Component Decorator

--- a/versioned_docs/version-v3.1/components/events.md
+++ b/versioned_docs/version-v3.1/components/events.md
@@ -3,12 +3,6 @@ title: Events
 sidebar_label: Events
 description: Events
 slug: /events
-contributors:
-  - jthoms1
-  - mgalic
-  - BDav24
-  - mattcosta7
-  - noherczeg
 ---
 
 # Events

--- a/versioned_docs/version-v3.1/components/functional-components.md
+++ b/versioned_docs/version-v3.1/components/functional-components.md
@@ -3,8 +3,6 @@ title: Functional Components
 sidebar_label: Functional Components
 description: Functional Components
 slug: /functional-components
-contributors:
-  - simonhaenisch
 ---
 
 # Working with Functional Components

--- a/versioned_docs/version-v3.1/components/host-element.md
+++ b/versioned_docs/version-v3.1/components/host-element.md
@@ -3,8 +3,6 @@ title: Working with host elements
 sidebar_label: Host Element
 description: Working with host elements
 slug: /host-element
-contributors:
-  - jthoms1
 ---
 
 # Working with host elements

--- a/versioned_docs/version-v3.1/components/methods.md
+++ b/versioned_docs/version-v3.1/components/methods.md
@@ -3,9 +3,6 @@ title: Methods
 sidebar_label: Methods
 description: methods
 slug: /methods
-contributors:
-  - jthoms1
-  - manucorporat
 ---
 
 # Method Decorator

--- a/versioned_docs/version-v3.1/components/properties.md
+++ b/versioned_docs/version-v3.1/components/properties.md
@@ -3,9 +3,6 @@ title: Properties
 sidebar_label: Properties
 description: Properties
 slug: /properties
-contributors:
-  - jthoms1
-  - rwaskiewicz
 ---
 
 # Properties

--- a/versioned_docs/version-v3.1/components/reactive-data.md
+++ b/versioned_docs/version-v3.1/components/reactive-data.md
@@ -3,9 +3,6 @@ title: Reactive Data, Handling arrays and objects
 sidebar_label: Reactive Data
 description: Reactive Data, Handling arrays and objects
 slug: /reactive-data
-contributors:
-  - jthoms1
-  - rwaskiewicz
 ---
 
 # Reactive Data

--- a/versioned_docs/version-v3.1/components/state.md
+++ b/versioned_docs/version-v3.1/components/state.md
@@ -3,9 +3,6 @@ title: Internal state
 sidebar_label: Internal State
 description: Use the State() for component's internal state
 slug: /state
-contributors:
-  - jthoms1
-  - rwaskiewicz
 ---
 
 # State

--- a/versioned_docs/version-v3.1/components/styling.md
+++ b/versioned_docs/version-v3.1/components/styling.md
@@ -3,10 +3,6 @@ title: Styling Components
 sidebar_label: Styling
 description: Styling Components
 slug: /styling
-contributors:
-  - jthoms1
-  - shreeshbhat
-  - a-giuliano
 ---
 
 # Styling Components

--- a/versioned_docs/version-v3.1/components/templating-and-jsx.md
+++ b/versioned_docs/version-v3.1/components/templating-and-jsx.md
@@ -3,10 +3,6 @@ title: Using JSX
 sidebar_label: Using JSX
 description: Using JSX
 slug: /templating-jsx
-contributors:
-  - jthoms1
-  - simonhaenisch
-  - arjunyel
 ---
 
 # Using JSX

--- a/versioned_docs/version-v3.1/config/01-overview.md
+++ b/versioned_docs/version-v3.1/config/01-overview.md
@@ -3,14 +3,6 @@ title: Config
 sidebar_label: Overview
 description: Config
 slug: /config
-contributors:
-  - adamdbradley
-  - jthoms1
-  - flawyte
-  - BDav24
-  - rwaskiewicz
-  - simonhaenisch
-  - splitinfinities
 ---
 
 # Stencil Config

--- a/versioned_docs/version-v3.1/config/cli.md
+++ b/versioned_docs/version-v3.1/config/cli.md
@@ -3,9 +3,6 @@ title: Stencil CLI
 sidebar_label: CLI
 description: Stencil CLI
 slug: /cli
-contributors:
-  - miguelyoobic95
-  - adamdbradley
 ---
 
 # Command Line Interface (CLI)

--- a/versioned_docs/version-v3.1/config/dev-server.md
+++ b/versioned_docs/version-v3.1/config/dev-server.md
@@ -3,11 +3,6 @@ title: Integrated Dev Server Config
 sidebar_label: Dev Server
 description: Integrated Dev Server Config
 slug: /dev-server
-contributors:
-  - adamdbradley
-  - BDav24
-  - feerglas
-  - simonhaenisch
 ---
 
 # Integrated Dev Server

--- a/versioned_docs/version-v3.1/config/extras.md
+++ b/versioned_docs/version-v3.1/config/extras.md
@@ -3,10 +3,6 @@ title: Extras Config
 sidebar_label: Extras
 description: Extras Config
 slug: /config-extras
-contributors:
-  - mattdsteele
-  - rwaskiewicz
-  - alicewriteswrongs
 ---
 
 # Extras

--- a/versioned_docs/version-v3.1/config/plugins.md
+++ b/versioned_docs/version-v3.1/config/plugins.md
@@ -3,10 +3,6 @@ title: Plugin Config
 sidebar_label: Plugins
 description: Plugin Config
 slug: /plugins
-contributors:
-  - adamdbradley
-  - jthoms1
-  - mgalic
 ---
 
 # Plugins

--- a/versioned_docs/version-v3.1/core/cli-api.md
+++ b/versioned_docs/version-v3.1/core/cli-api.md
@@ -3,8 +3,6 @@ title: Stencil Core CLI API
 sidebar_label: CLI API
 description:  Stencil Core CLI API
 slug: /cli-api
-contributors:
-  - adamdbradley
 ---
 
 # Stencil Core CLI API

--- a/versioned_docs/version-v3.1/core/compiler-api.md
+++ b/versioned_docs/version-v3.1/core/compiler-api.md
@@ -3,8 +3,6 @@ title: Stencil Core Compiler API
 sidebar_label: Compiler API
 description:  Stencil Core Compiler API
 slug: /compiler-api
-contributors:
-  - adamdbradley
 ---
 
 # Stencil Core Compiler API

--- a/versioned_docs/version-v3.1/core/dev-server-api.md
+++ b/versioned_docs/version-v3.1/core/dev-server-api.md
@@ -3,9 +3,6 @@ title: Stencil Core Dev Server API
 sidebar_label: Dev Server API
 description:  Stencil Core Dev Server API
 slug: /dev-server-api
-contributors:
-  - adamdbradley
-  - dominikpieper
 ---
 
 # Stencil Core Dev Server API

--- a/versioned_docs/version-v3.1/framework-integration/01-overview.md
+++ b/versioned_docs/version-v3.1/framework-integration/01-overview.md
@@ -3,9 +3,6 @@ title: Framework Integration
 sidebar_label: Overview
 description: Framework Integration
 slug: /overview
-contributors:
-  - adamdbradley
-  - brandyscarney
 ---
 
 # Framework Integration

--- a/versioned_docs/version-v3.1/framework-integration/angular.md
+++ b/versioned_docs/version-v3.1/framework-integration/angular.md
@@ -3,15 +3,6 @@ title: Angular Integration with Stencil
 sidebar_label: Angular
 description: Learn how to wrap your components so that people can use them natively in Angular
 slug: /angular
-contributors:
-  - jthoms1
-  - adamdbradley
-  - kensodemann
-  - peterpeterparker
-  - jeanbenitez
-  - mburger81
-  - splitinfinities
-  - tanner-reits
 ---
 
 # Angular Integration

--- a/versioned_docs/version-v3.1/framework-integration/ember.md
+++ b/versioned_docs/version-v3.1/framework-integration/ember.md
@@ -3,9 +3,6 @@ title: Ember Integration with Stencil
 sidebar_label: Ember
 description: Ember Integration with Stencil
 slug: /ember
-contributors:
-  - jthoms1
-  - adamdbradley
 ---
 
 # Ember

--- a/versioned_docs/version-v3.1/framework-integration/javascript.md
+++ b/versioned_docs/version-v3.1/framework-integration/javascript.md
@@ -3,12 +3,6 @@ title: Components without a Framework
 sidebar_label: JavaScript
 description: Components without a Framework
 slug: /javascript
-contributors:
-  - mhartington
-  - jthoms1
-  - adamdbradley
-  - BDav24
-  - DaniAcu
 ---
 
 # Components without a Framework

--- a/versioned_docs/version-v3.1/framework-integration/react.md
+++ b/versioned_docs/version-v3.1/framework-integration/react.md
@@ -3,16 +3,6 @@ title: React Integration with Stencil
 sidebar_label: React
 description: Learn how to wrap your components so that people can use them natively in React
 slug: /react
-contributors:
-  - jthoms1
-  - adamdbradley
-  - kensodemann
-  - ErikSchierboom
-  - brentertz
-  - danawoodman
-  - a-giuliano
-  - rwaskiewicz
-  - tanner-reits
 ---
 
 # React Integration

--- a/versioned_docs/version-v3.1/framework-integration/vue.md
+++ b/versioned_docs/version-v3.1/framework-integration/vue.md
@@ -3,14 +3,6 @@ title: VueJS Integration with Stencil
 sidebar_label: Vue
 description: Learn how to wrap your components so that people can use them natively in Vue
 slug: /vue
-contributors:
-  - jthoms1
-  - adamdbradley
-  - kensodemann
-  - brysalazar12
-  - iskanderbroere
-  - sean-perkins
-  - tanner-reits
 ---
 
 # Vue Integration

--- a/versioned_docs/version-v3.1/guides/assets.md
+++ b/versioned_docs/version-v3.1/guides/assets.md
@@ -3,10 +3,6 @@ title: Assets
 sidebar_label: Assets
 description: Learn how to reference assets in your components
 slug: /assets
-contributors:
-  - splitinfinities
-  - simonhaenisch
-  - rwaskiewicz
 ---
 
 # Assets

--- a/versioned_docs/version-v3.1/guides/build-conditionals.md
+++ b/versioned_docs/version-v3.1/guides/build-conditionals.md
@@ -1,8 +1,6 @@
 ---
 title: Build Conditionals
 description: Build Conditionals
-contributors:
-  - jthoms1
 ---
 
 # Build Conditionals

--- a/versioned_docs/version-v3.1/guides/csp-nonce.md
+++ b/versioned_docs/version-v3.1/guides/csp-nonce.md
@@ -2,8 +2,6 @@
 title: Content Security Policy Nonces
 description: How to leverage CSP nonces in Stencil projects.
 slug: /csp-nonce
-contributors:
-  - tanner-reits
 ---
 
 # Using Content Security Policy Nonces in Stencil

--- a/versioned_docs/version-v3.1/guides/design-systems.md
+++ b/versioned_docs/version-v3.1/guides/design-systems.md
@@ -3,9 +3,6 @@ title: Design Systems
 sidebar_label: Design Systems
 description: Design Systems in Stencil
 slug: /design-systems
-contributors:
-  - dotNetkow
-  - rwaskiewicz
 ---
 
 # Design Systems

--- a/versioned_docs/version-v3.1/guides/forms.md
+++ b/versioned_docs/version-v3.1/guides/forms.md
@@ -3,8 +3,6 @@ title: Forms
 sidebar_label: Forms
 description: Forms
 slug: /forms
-contributors:
-  - jthoms1
 ---
 
 # Forms

--- a/versioned_docs/version-v3.1/guides/hydrate-app.md
+++ b/versioned_docs/version-v3.1/guides/hydrate-app.md
@@ -3,10 +3,6 @@ title: Hydrate App
 sidebar_label: Hydrate App
 description: Hydrate App
 slug: /hydrate-app
-contributors:
-  - adamdbradley
-  - dgautsch
-  - bitflower
 ---
 
 # Hydrate App

--- a/versioned_docs/version-v3.1/guides/module-bundling.md
+++ b/versioned_docs/version-v3.1/guides/module-bundling.md
@@ -3,12 +3,6 @@ title: Module Bundling
 sidebar_label: Bundling
 description: Module Bundling
 slug: /module-bundling
-contributors:
-  - jthoms1
-  - adamdbradley
-  - kensodemann
-  - manucorporat
-  - ryan3E0
 ---
 
 # Module Bundling

--- a/versioned_docs/version-v3.1/guides/publishing.md
+++ b/versioned_docs/version-v3.1/guides/publishing.md
@@ -3,8 +3,6 @@ title: Publishing A Component Library
 sidebar_label: Publishing
 description: Publishing A Component Library
 slug: /publishing
-contributors:
-  - adamdbradley
 ---
 
 # Publishing A Component Library

--- a/versioned_docs/version-v3.1/guides/service-workers.md
+++ b/versioned_docs/version-v3.1/guides/service-workers.md
@@ -3,10 +3,6 @@ title: Service Workers
 sidebar_label: Service Workers
 description: Service Workers
 slug: /service-workers
-contributors:
-  - jthoms1
-  - simonhaenisch
-  - DavidFrahm
 ---
 
 # Service Workers

--- a/versioned_docs/version-v3.1/guides/style-guide.md
+++ b/versioned_docs/version-v3.1/guides/style-guide.md
@@ -3,12 +3,6 @@ title: Stencil Style Guide
 sidebar_label: Style Guide
 description: Stencil Style Guide
 slug: /style-guide
-contributors:
-  - jthoms1
-  - natemoo-re
-  - larionov
-  - joestrouth1
-  - rwaskiewicz
 ---
 
 # Stencil Style Guide

--- a/versioned_docs/version-v3.1/guides/typed-components.md
+++ b/versioned_docs/version-v3.1/guides/typed-components.md
@@ -3,10 +3,6 @@ title: Typed Components
 sidebar_label: Typed Components
 description: Typed Components
 slug: /typed-components
-contributors:
-  - adamdbradley
-  - manucorporat
-  - rwaskiewicz
 ---
 
 # Typed Components

--- a/versioned_docs/version-v3.1/introduction/01-overview.md
+++ b/versioned_docs/version-v3.1/introduction/01-overview.md
@@ -3,10 +3,6 @@ title: Stencil - A Compiler for Web Components
 sidebar_label: Overview
 description: Stencil has a number of add-ons that you can use with the build process.
 slug: /introduction
-contributors:
-  - jthoms1
-  - splitinfinities
-  - a-giuliano
 ---
 
 # Overview

--- a/versioned_docs/version-v3.1/introduction/02-goals-and-objectives.md
+++ b/versioned_docs/version-v3.1/introduction/02-goals-and-objectives.md
@@ -3,9 +3,6 @@ title: Stencil Goals and Objectives
 sidebar_label: Goals and Objectives
 description: Stencil aims to combine the best concepts of the most popular frontend frameworks into a compile-time tool rather than run-time tool.
 slug: /goals-and-objectives
-contributors:
-  - adamdbradley
-  - sri-ni
 ---
 
 # Stencil Goals And Objectives

--- a/versioned_docs/version-v3.1/introduction/03-getting-started.md
+++ b/versioned_docs/version-v3.1/introduction/03-getting-started.md
@@ -3,9 +3,6 @@ title: Getting Started
 sidebar_label: Getting Started
 description: Getting Started
 slug: /getting-started
-contributors:
-  - jthoms1
-  - rwaskiewicz
 ---
 
 # Getting Started

--- a/versioned_docs/version-v3.1/introduction/upgrading-to-stencil-three.md
+++ b/versioned_docs/version-v3.1/introduction/upgrading-to-stencil-three.md
@@ -2,8 +2,6 @@
 title: Upgrading to Stencil v3.0.0
 description: Upgrading to Stencil v3.0.0
 url: /docs/upgrading-to-stencil-3
-contributors:
-  - rwaskiewicz
 ---
 
 # Upgrading to Stencil v3.0.0

--- a/versioned_docs/version-v3.1/output-targets/01-overview.md
+++ b/versioned_docs/version-v3.1/output-targets/01-overview.md
@@ -3,10 +3,6 @@ title: Stencil Output Targets
 sidebar_label: Overview
 description: Stencil Output Targets
 slug: /output-targets
-contributors:
-  - adamdbradley
-  - manucorporat
-  - rwaskiewicz
 ---
 
 # Output Targets

--- a/versioned_docs/version-v3.1/output-targets/copy-tasks.md
+++ b/versioned_docs/version-v3.1/output-targets/copy-tasks.md
@@ -3,10 +3,6 @@ title: Stencil Copy Tasks
 sidebar_label: Copy Tasks
 description: Stencil Copy Tasks
 slug: /copy-tasks
-contributors:
-  - adamdbradley
-  - manucorporat
-  - jeanbenitez
 ---
 
 

--- a/versioned_docs/version-v3.1/output-targets/custom-elements.md
+++ b/versioned_docs/version-v3.1/output-targets/custom-elements.md
@@ -3,11 +3,6 @@ title: Custom Elements with Stencil
 sidebar_label: dist-custom-elements
 description: Custom Elements with Stencil
 slug: /custom-elements
-contributors:
-  - adamdbradley
-  - rwaskiewicz
-  - splitinfinities
-  - tanner-reits
 ---
 
 # Custom Elements

--- a/versioned_docs/version-v3.1/output-targets/dist.md
+++ b/versioned_docs/version-v3.1/output-targets/dist.md
@@ -3,9 +3,6 @@ title: Distributing Web Components Built with Stencil
 sidebar_label: dist
 description: Distributing Web Components Built with Stencil
 slug: /distribution
-contributors:
-  - adamdbradley
-  - jthoms1
 ---
 
 # Distribution Output Target

--- a/versioned_docs/version-v3.1/output-targets/docs-custom.md
+++ b/versioned_docs/version-v3.1/output-targets/docs-custom.md
@@ -3,10 +3,6 @@ title: Custom Docs Generation
 sidebar_label: docs-custom
 description: Custom Docs Generation
 slug: /docs-custom
-contributors:
-  - adamdbradley
-  - manucorporat
-  - arayik-yervandyan
 ---
 
 # Custom Docs Generation

--- a/versioned_docs/version-v3.1/output-targets/docs-json.md
+++ b/versioned_docs/version-v3.1/output-targets/docs-json.md
@@ -3,14 +3,6 @@ title: Docs JSON Data Output Target
 sidebar_label: docs-json
 description: Docs JSON Output Target
 slug: /docs-json
-contributors:
-  - adamdbradley
-  - snaptopixel
-  - manucorporat
-  - amwmedia
-  - mrtnmgs
-  - marcjulian
-  - seanwuapps
 ---
 
 # Docs Json Data

--- a/versioned_docs/version-v3.1/output-targets/docs-readme.md
+++ b/versioned_docs/version-v3.1/output-targets/docs-readme.md
@@ -3,13 +3,6 @@ title: Docs Readme Auto-Generation
 sidebar_label: docs-readme
 description: Docs Readme Auto-Generation
 slug: /docs-readme
-contributors:
-  - adamdbradley
-  - snaptopixel
-  - manucorporat
-  - amwmedia
-  - mrtnmgs
-  - marcjulian
 ---
 
 # Docs Readme Markdown File Auto-Generation

--- a/versioned_docs/version-v3.1/output-targets/docs-stats.md
+++ b/versioned_docs/version-v3.1/output-targets/docs-stats.md
@@ -3,9 +3,6 @@ title: Docs Stats Auto-Generation
 sidebar_label: stats
 description: Docs Stats Auto-Generation
 slug: /stats
-contributors:
-  - adamdbradley
-  - splitinfinities
 ---
 
 # Stats

--- a/versioned_docs/version-v3.1/output-targets/docs-vscode.md
+++ b/versioned_docs/version-v3.1/output-targets/docs-vscode.md
@@ -2,8 +2,6 @@
 title: VS Code Documentation
 description: VS Code Documentation
 slug: /docs-vscode
-contributors:
-  - rwaskiewicz
 ---
 
 # VS Code Documentation

--- a/versioned_docs/version-v3.1/output-targets/www.md
+++ b/versioned_docs/version-v3.1/output-targets/www.md
@@ -3,10 +3,6 @@ title: Webapp Output Target
 sidebar_label: www
 description: Webapp Output Target
 slug: /www
-contributors:
-  - jthoms1
-  - simonhaenisch
-  - DavidFrahm
 ---
 
 # Webapp Output Target: `www`

--- a/versioned_docs/version-v3.1/reference/browser-support.md
+++ b/versioned_docs/version-v3.1/reference/browser-support.md
@@ -3,11 +3,6 @@ title: Stencil Web Component Browser Support
 sidebar_label: Browser Support
 description: Out-of-the-box browser support provided by Stencil web components.
 slug: /browser-support
-contributors:
-  - adamdbradley
-  - kevinports
-  - jthoms1
-  - arjunyel
 ---
 
 # Browser Support

--- a/versioned_docs/version-v3.1/reference/faq.md
+++ b/versioned_docs/version-v3.1/reference/faq.md
@@ -3,9 +3,6 @@ title: Stencil Frequently Asked Questions
 sidebar_label: FAQ
 description: Stencil is a developer-focused toolchain for building reusable, scalable component libraries, applications and design systems.
 slug: /faq
-contributors:
-  - adamdbradley
-  - rwaskiewicz
 ---
 
 # FAQ

--- a/versioned_docs/version-v3.1/reference/support-policy.md
+++ b/versioned_docs/version-v3.1/reference/support-policy.md
@@ -3,8 +3,6 @@ title: Support Policy
 sidebar_label: Support Policy
 description: Support Policy
 slug: /support-policy
-contributors:
-- rwaskiewicz
 ---
 
 # Support Policy

--- a/versioned_docs/version-v3.1/reference/versioning.md
+++ b/versioned_docs/version-v3.1/reference/versioning.md
@@ -3,8 +3,6 @@ title: Versioning
 sidebar_label: Versioning
 description: Versioning
 slug: /versioning
-contributors:
-- rwaskiewicz
 ---
 
 # Versioning

--- a/versioned_docs/version-v3.1/static-site-generation/01-overview.md
+++ b/versioned_docs/version-v3.1/static-site-generation/01-overview.md
@@ -2,10 +2,6 @@
 title: Static Site Generation
 sidebar_label: Overview
 slug: /static-site-generation
-contributors:
-  - mlynch
-  - adamdbradley
-  - bitflower
 ---
 
 # Static Site Generation with Stencil

--- a/versioned_docs/version-v3.1/static-site-generation/basics.md
+++ b/versioned_docs/version-v3.1/static-site-generation/basics.md
@@ -3,9 +3,6 @@ title: Static Site Generation Basics in Stencil
 sidebar_label: Basics
 description: Quick introduction to configuring and using Static Site Generation in Stencil
 slug: /static-site-generation-basics
-contributors:
-  - mlynch
-  - adamdbradley
 ---
 
 # Static Site Generation Basics

--- a/versioned_docs/version-v3.1/static-site-generation/debugging.md
+++ b/versioned_docs/version-v3.1/static-site-generation/debugging.md
@@ -3,9 +3,6 @@ title: Debugging Static Site Generation in Stencil
 sidebar_label: Debugging
 description: How to debug a prerendering or Static Site Generation step in Stencil
 slug: /static-site-generation-debugging
-contributors:
-  - mlynch
-  - adamdbradley
 ---
 
 # Debugging Static Site Generation

--- a/versioned_docs/version-v3.1/static-site-generation/deployment.md
+++ b/versioned_docs/version-v3.1/static-site-generation/deployment.md
@@ -3,8 +3,6 @@ title: Deploying a Static Site
 sidebar_label: Deployment
 description: Deploying a Static Site
 slug: /static-site-generation-deployment
-contributors:
-  - mlynch
 ---
 
 # Deploying a Stencil Static Site

--- a/versioned_docs/version-v3.1/static-site-generation/meta.md
+++ b/versioned_docs/version-v3.1/static-site-generation/meta.md
@@ -3,10 +3,6 @@ title: SEO Meta Tags in SSG
 sidebar_label: Meta tags
 description: Managing meta tags for SEO and social media embedding in Stencil Static Sites
 slug: /static-site-generation-meta-tags
-contributors:
-  - mlynch
-  - adamdbradley
-  - rwaskiewicz
 ---
 
 # SEO Meta Tags and Static Site Generation

--- a/versioned_docs/version-v3.1/static-site-generation/prerender-config.md
+++ b/versioned_docs/version-v3.1/static-site-generation/prerender-config.md
@@ -3,10 +3,6 @@ title: Prerender Config
 sidebar_label: Prerender Config
 description: Prerender Config
 slug: /prerender-config
-contributors:
-  - adamdbradley
-  - ryan3E0
-  - dgautsch
 ---
 
 

--- a/versioned_docs/version-v3.1/static-site-generation/server-side-rendering-ssr.md
+++ b/versioned_docs/version-v3.1/static-site-generation/server-side-rendering-ssr.md
@@ -3,8 +3,6 @@ title: Combining Server Side Rendering and Static Site Generation
 sidebar_label: Server Side Rendering
 description: How to combine both Server Side Rendering and Static Site Generation approaches
 slug: /static-site-generation-server-side-rendering-ssr
-contributors:
-  - mlynch
 ---
 
 # Combining Server Side Rendering and Static Site Generation

--- a/versioned_docs/version-v3.1/telemetry.md
+++ b/versioned_docs/version-v3.1/telemetry.md
@@ -1,8 +1,6 @@
 ---
 title: Telemetry
 description: Stencil Telemetry usage information
-contributors:
-  - splitinfinities
 ---
 
 # Stencil CLI telemetry

--- a/versioned_docs/version-v3.1/testing/01-overview.md
+++ b/versioned_docs/version-v3.1/testing/01-overview.md
@@ -3,12 +3,6 @@ title: Testing
 sidebar_label: Overview
 description: Testing overview.
 slug: /testing-overview
-contributors:
-  - adamdbradley
-  - brandyscarney
-  - camwiegert
-  - kensodemann
-  - rwaskiewicz
 ---
 
 # Testing

--- a/versioned_docs/version-v3.1/testing/config.md
+++ b/versioned_docs/version-v3.1/testing/config.md
@@ -3,10 +3,6 @@ title: Testing Config
 sidebar_label: Config
 description: Testing Config
 slug: /testing-config
-contributors:
-  - adamdbradley
-  - mattcosta7
-  - viernullvier
 ---
 
 # Testing Config

--- a/versioned_docs/version-v3.1/testing/e2e-testing.md
+++ b/versioned_docs/version-v3.1/testing/e2e-testing.md
@@ -3,10 +3,6 @@ title: End-to-end Testing
 sidebar_label: End-to-end Testing
 description: End-to-end Testing
 slug: /end-to-end-testing
-contributors:
-  - adamdbradley
-  - mattdsteele
-  - simonhaenisch
 ---
 
 # End-to-end Testing

--- a/versioned_docs/version-v3.1/testing/mocking.md
+++ b/versioned_docs/version-v3.1/testing/mocking.md
@@ -3,8 +3,6 @@ title: Mocking
 sidebar_label: Mocking
 description: Mocking
 slug: /mocking
-contributors:
-  - simonhaenisch
 ---
 
 # Mocking

--- a/versioned_docs/version-v3.1/testing/screenshot-connector.md
+++ b/versioned_docs/version-v3.1/testing/screenshot-connector.md
@@ -3,8 +3,6 @@ title: Screenshot Connector
 sidebar_label: Screenshot Connector
 description: Screenshot Connector
 slug: /screenshot-connector
-contributors:
-  - SheepFromHeaven
 ---
 
 # Screenshot connector

--- a/versioned_docs/version-v3.1/testing/screenshot-visual-diff.md
+++ b/versioned_docs/version-v3.1/testing/screenshot-visual-diff.md
@@ -3,8 +3,6 @@ title: Screenshot Visual Diff
 sidebar_label: Visual Screenshot Diff
 description: Screenshot Visual Diff
 slug: /screenshot-visual-diff
-contributors:
-  - adamdbradley
 ---
 
 # Screenshot Visual Diff

--- a/versioned_docs/version-v3.1/testing/unit-testing.md
+++ b/versioned_docs/version-v3.1/testing/unit-testing.md
@@ -3,10 +3,6 @@ title: Unit Testing
 sidebar_label: Unit Testing
 description: Unit Testing
 slug: /unit-testing
-contributors:
-  - adamdbradley
-  - mattdsteele
-  - bassettsj
 ---
 
 # Unit Testing

--- a/versioned_docs/version-v3.2/build-variables.md
+++ b/versioned_docs/version-v3.2/build-variables.md
@@ -2,8 +2,6 @@
 title: Build Constants
 description: Stencil has a number of add-ons that you can use with the build process.
 slug: /build-variables
-contributors:
-  - jthoms1
 ---
 
 # Build Constants

--- a/versioned_docs/version-v3.2/components/api.md
+++ b/versioned_docs/version-v3.2/components/api.md
@@ -3,14 +3,6 @@ title: Component API
 sidebar_label: API
 description: Component API
 slug: /api
-contributors:
-  - manucorporat
-  - Mawulijo
-  - hashcrof
-  - ZenPylon
-  - danjohnson95
-  - rezaabedian
-  - CookieCookson
 ---
 
 # Component API

--- a/versioned_docs/version-v3.2/components/component-lifecycle.md
+++ b/versioned_docs/version-v3.2/components/component-lifecycle.md
@@ -3,8 +3,6 @@ title: Component Lifecycle Methods
 sidebar_label: Lifecycle Methods
 description: Component Lifecycle Methods
 slug: /component-lifecycle
-contributors:
-  - jthoms1
 ---
 
 # Component Lifecycle Methods

--- a/versioned_docs/version-v3.2/components/component.md
+++ b/versioned_docs/version-v3.2/components/component.md
@@ -3,9 +3,6 @@ title: Component Decorator
 sidebar_label: Component
 description: Documentation for the @Component decorator
 slug: /component
-contributors:
-- jthoms1
-- rwaskiewicz
 ---
 
 # Component Decorator

--- a/versioned_docs/version-v3.2/components/events.md
+++ b/versioned_docs/version-v3.2/components/events.md
@@ -3,12 +3,6 @@ title: Events
 sidebar_label: Events
 description: Events
 slug: /events
-contributors:
-  - jthoms1
-  - mgalic
-  - BDav24
-  - mattcosta7
-  - noherczeg
 ---
 
 # Events

--- a/versioned_docs/version-v3.2/components/functional-components.md
+++ b/versioned_docs/version-v3.2/components/functional-components.md
@@ -3,8 +3,6 @@ title: Functional Components
 sidebar_label: Functional Components
 description: Functional Components
 slug: /functional-components
-contributors:
-  - simonhaenisch
 ---
 
 # Working with Functional Components

--- a/versioned_docs/version-v3.2/components/host-element.md
+++ b/versioned_docs/version-v3.2/components/host-element.md
@@ -3,8 +3,6 @@ title: Working with host elements
 sidebar_label: Host Element
 description: Working with host elements
 slug: /host-element
-contributors:
-  - jthoms1
 ---
 
 # Working with host elements

--- a/versioned_docs/version-v3.2/components/methods.md
+++ b/versioned_docs/version-v3.2/components/methods.md
@@ -3,9 +3,6 @@ title: Methods
 sidebar_label: Methods
 description: methods
 slug: /methods
-contributors:
-  - jthoms1
-  - manucorporat
 ---
 
 # Method Decorator

--- a/versioned_docs/version-v3.2/components/properties.md
+++ b/versioned_docs/version-v3.2/components/properties.md
@@ -3,9 +3,6 @@ title: Properties
 sidebar_label: Properties
 description: Properties
 slug: /properties
-contributors:
-  - jthoms1
-  - rwaskiewicz
 ---
 
 # Properties

--- a/versioned_docs/version-v3.2/components/reactive-data.md
+++ b/versioned_docs/version-v3.2/components/reactive-data.md
@@ -3,9 +3,6 @@ title: Reactive Data, Handling arrays and objects
 sidebar_label: Reactive Data
 description: Reactive Data, Handling arrays and objects
 slug: /reactive-data
-contributors:
-  - jthoms1
-  - rwaskiewicz
 ---
 
 # Reactive Data

--- a/versioned_docs/version-v3.2/components/state.md
+++ b/versioned_docs/version-v3.2/components/state.md
@@ -3,9 +3,6 @@ title: Internal state
 sidebar_label: Internal State
 description: Use the State() for component's internal state
 slug: /state
-contributors:
-  - jthoms1
-  - rwaskiewicz
 ---
 
 # State

--- a/versioned_docs/version-v3.2/components/styling.md
+++ b/versioned_docs/version-v3.2/components/styling.md
@@ -3,10 +3,6 @@ title: Styling Components
 sidebar_label: Styling
 description: Styling Components
 slug: /styling
-contributors:
-  - jthoms1
-  - shreeshbhat
-  - a-giuliano
 ---
 
 # Styling Components

--- a/versioned_docs/version-v3.2/components/templating-and-jsx.md
+++ b/versioned_docs/version-v3.2/components/templating-and-jsx.md
@@ -3,10 +3,6 @@ title: Using JSX
 sidebar_label: Using JSX
 description: Using JSX
 slug: /templating-jsx
-contributors:
-  - jthoms1
-  - simonhaenisch
-  - arjunyel
 ---
 
 # Using JSX

--- a/versioned_docs/version-v3.2/config/01-overview.md
+++ b/versioned_docs/version-v3.2/config/01-overview.md
@@ -3,14 +3,6 @@ title: Config
 sidebar_label: Overview
 description: Config
 slug: /config
-contributors:
-  - adamdbradley
-  - jthoms1
-  - flawyte
-  - BDav24
-  - rwaskiewicz
-  - simonhaenisch
-  - splitinfinities
 ---
 
 # Stencil Config

--- a/versioned_docs/version-v3.2/config/cli.md
+++ b/versioned_docs/version-v3.2/config/cli.md
@@ -3,9 +3,6 @@ title: Stencil CLI
 sidebar_label: CLI
 description: Stencil CLI
 slug: /cli
-contributors:
-  - miguelyoobic95
-  - adamdbradley
 ---
 
 # Command Line Interface (CLI)

--- a/versioned_docs/version-v3.2/config/dev-server.md
+++ b/versioned_docs/version-v3.2/config/dev-server.md
@@ -3,11 +3,6 @@ title: Integrated Dev Server Config
 sidebar_label: Dev Server
 description: Integrated Dev Server Config
 slug: /dev-server
-contributors:
-  - adamdbradley
-  - BDav24
-  - feerglas
-  - simonhaenisch
 ---
 
 # Integrated Dev Server

--- a/versioned_docs/version-v3.2/config/extras.md
+++ b/versioned_docs/version-v3.2/config/extras.md
@@ -3,10 +3,6 @@ title: Extras Config
 sidebar_label: Extras
 description: Extras Config
 slug: /config-extras
-contributors:
-  - mattdsteele
-  - rwaskiewicz
-  - alicewriteswrongs
 ---
 
 # Extras

--- a/versioned_docs/version-v3.2/config/plugins.md
+++ b/versioned_docs/version-v3.2/config/plugins.md
@@ -3,10 +3,6 @@ title: Plugin Config
 sidebar_label: Plugins
 description: Plugin Config
 slug: /plugins
-contributors:
-  - adamdbradley
-  - jthoms1
-  - mgalic
 ---
 
 # Plugins

--- a/versioned_docs/version-v3.2/core/cli-api.md
+++ b/versioned_docs/version-v3.2/core/cli-api.md
@@ -3,8 +3,6 @@ title: Stencil Core CLI API
 sidebar_label: CLI API
 description:  Stencil Core CLI API
 slug: /cli-api
-contributors:
-  - adamdbradley
 ---
 
 # Stencil Core CLI API

--- a/versioned_docs/version-v3.2/core/compiler-api.md
+++ b/versioned_docs/version-v3.2/core/compiler-api.md
@@ -3,8 +3,6 @@ title: Stencil Core Compiler API
 sidebar_label: Compiler API
 description:  Stencil Core Compiler API
 slug: /compiler-api
-contributors:
-  - adamdbradley
 ---
 
 # Stencil Core Compiler API

--- a/versioned_docs/version-v3.2/core/dev-server-api.md
+++ b/versioned_docs/version-v3.2/core/dev-server-api.md
@@ -3,9 +3,6 @@ title: Stencil Core Dev Server API
 sidebar_label: Dev Server API
 description:  Stencil Core Dev Server API
 slug: /dev-server-api
-contributors:
-  - adamdbradley
-  - dominikpieper
 ---
 
 # Stencil Core Dev Server API

--- a/versioned_docs/version-v3.2/framework-integration/01-overview.md
+++ b/versioned_docs/version-v3.2/framework-integration/01-overview.md
@@ -3,9 +3,6 @@ title: Framework Integration
 sidebar_label: Overview
 description: Framework Integration
 slug: /overview
-contributors:
-  - adamdbradley
-  - brandyscarney
 ---
 
 # Framework Integration

--- a/versioned_docs/version-v3.2/framework-integration/angular.md
+++ b/versioned_docs/version-v3.2/framework-integration/angular.md
@@ -3,15 +3,6 @@ title: Angular Integration with Stencil
 sidebar_label: Angular
 description: Learn how to wrap your components so that people can use them natively in Angular
 slug: /angular
-contributors:
-  - jthoms1
-  - adamdbradley
-  - kensodemann
-  - peterpeterparker
-  - jeanbenitez
-  - mburger81
-  - splitinfinities
-  - tanner-reits
 ---
 
 # Angular Integration

--- a/versioned_docs/version-v3.2/framework-integration/ember.md
+++ b/versioned_docs/version-v3.2/framework-integration/ember.md
@@ -3,9 +3,6 @@ title: Ember Integration with Stencil
 sidebar_label: Ember
 description: Ember Integration with Stencil
 slug: /ember
-contributors:
-  - jthoms1
-  - adamdbradley
 ---
 
 # Ember

--- a/versioned_docs/version-v3.2/framework-integration/javascript.md
+++ b/versioned_docs/version-v3.2/framework-integration/javascript.md
@@ -3,12 +3,6 @@ title: Components without a Framework
 sidebar_label: JavaScript
 description: Components without a Framework
 slug: /javascript
-contributors:
-  - mhartington
-  - jthoms1
-  - adamdbradley
-  - BDav24
-  - DaniAcu
 ---
 
 # Components without a Framework

--- a/versioned_docs/version-v3.2/framework-integration/react.md
+++ b/versioned_docs/version-v3.2/framework-integration/react.md
@@ -3,16 +3,6 @@ title: React Integration with Stencil
 sidebar_label: React
 description: Learn how to wrap your components so that people can use them natively in React
 slug: /react
-contributors:
-  - jthoms1
-  - adamdbradley
-  - kensodemann
-  - ErikSchierboom
-  - brentertz
-  - danawoodman
-  - a-giuliano
-  - rwaskiewicz
-  - tanner-reits
 ---
 
 # React Integration

--- a/versioned_docs/version-v3.2/framework-integration/vue.md
+++ b/versioned_docs/version-v3.2/framework-integration/vue.md
@@ -3,14 +3,6 @@ title: VueJS Integration with Stencil
 sidebar_label: Vue
 description: Learn how to wrap your components so that people can use them natively in Vue
 slug: /vue
-contributors:
-  - jthoms1
-  - adamdbradley
-  - kensodemann
-  - brysalazar12
-  - iskanderbroere
-  - sean-perkins
-  - tanner-reits
 ---
 
 # Vue Integration

--- a/versioned_docs/version-v3.2/guides/assets.md
+++ b/versioned_docs/version-v3.2/guides/assets.md
@@ -3,10 +3,6 @@ title: Assets
 sidebar_label: Assets
 description: Learn how to reference assets in your components
 slug: /assets
-contributors:
-  - splitinfinities
-  - simonhaenisch
-  - rwaskiewicz
 ---
 
 # Assets

--- a/versioned_docs/version-v3.2/guides/build-conditionals.md
+++ b/versioned_docs/version-v3.2/guides/build-conditionals.md
@@ -1,8 +1,6 @@
 ---
 title: Build Conditionals
 description: Build Conditionals
-contributors:
-  - jthoms1
 ---
 
 # Build Conditionals

--- a/versioned_docs/version-v3.2/guides/csp-nonce.md
+++ b/versioned_docs/version-v3.2/guides/csp-nonce.md
@@ -2,8 +2,6 @@
 title: Content Security Policy Nonces
 description: How to leverage CSP nonces in Stencil projects.
 slug: /csp-nonce
-contributors:
-  - tanner-reits
 ---
 
 # Using Content Security Policy Nonces in Stencil

--- a/versioned_docs/version-v3.2/guides/design-systems.md
+++ b/versioned_docs/version-v3.2/guides/design-systems.md
@@ -3,9 +3,6 @@ title: Design Systems
 sidebar_label: Design Systems
 description: Design Systems in Stencil
 slug: /design-systems
-contributors:
-  - dotNetkow
-  - rwaskiewicz
 ---
 
 # Design Systems

--- a/versioned_docs/version-v3.2/guides/forms.md
+++ b/versioned_docs/version-v3.2/guides/forms.md
@@ -3,8 +3,6 @@ title: Forms
 sidebar_label: Forms
 description: Forms
 slug: /forms
-contributors:
-  - jthoms1
 ---
 
 # Forms

--- a/versioned_docs/version-v3.2/guides/hydrate-app.md
+++ b/versioned_docs/version-v3.2/guides/hydrate-app.md
@@ -3,10 +3,6 @@ title: Hydrate App
 sidebar_label: Hydrate App
 description: Hydrate App
 slug: /hydrate-app
-contributors:
-  - adamdbradley
-  - dgautsch
-  - bitflower
 ---
 
 # Hydrate App

--- a/versioned_docs/version-v3.2/guides/module-bundling.md
+++ b/versioned_docs/version-v3.2/guides/module-bundling.md
@@ -3,12 +3,6 @@ title: Module Bundling
 sidebar_label: Bundling
 description: Module Bundling
 slug: /module-bundling
-contributors:
-  - jthoms1
-  - adamdbradley
-  - kensodemann
-  - manucorporat
-  - ryan3E0
 ---
 
 # Module Bundling

--- a/versioned_docs/version-v3.2/guides/publishing.md
+++ b/versioned_docs/version-v3.2/guides/publishing.md
@@ -3,8 +3,6 @@ title: Publishing A Component Library
 sidebar_label: Publishing
 description: Publishing A Component Library
 slug: /publishing
-contributors:
-  - adamdbradley
 ---
 
 # Publishing A Component Library

--- a/versioned_docs/version-v3.2/guides/service-workers.md
+++ b/versioned_docs/version-v3.2/guides/service-workers.md
@@ -3,10 +3,6 @@ title: Service Workers
 sidebar_label: Service Workers
 description: Service Workers
 slug: /service-workers
-contributors:
-  - jthoms1
-  - simonhaenisch
-  - DavidFrahm
 ---
 
 # Service Workers

--- a/versioned_docs/version-v3.2/guides/style-guide.md
+++ b/versioned_docs/version-v3.2/guides/style-guide.md
@@ -3,12 +3,6 @@ title: Stencil Style Guide
 sidebar_label: Style Guide
 description: Stencil Style Guide
 slug: /style-guide
-contributors:
-  - jthoms1
-  - natemoo-re
-  - larionov
-  - joestrouth1
-  - rwaskiewicz
 ---
 
 # Stencil Style Guide

--- a/versioned_docs/version-v3.2/guides/typed-components.md
+++ b/versioned_docs/version-v3.2/guides/typed-components.md
@@ -3,10 +3,6 @@ title: Typed Components
 sidebar_label: Typed Components
 description: Typed Components
 slug: /typed-components
-contributors:
-  - adamdbradley
-  - manucorporat
-  - rwaskiewicz
 ---
 
 # Typed Components

--- a/versioned_docs/version-v3.2/introduction/01-overview.md
+++ b/versioned_docs/version-v3.2/introduction/01-overview.md
@@ -3,10 +3,6 @@ title: Stencil - A Compiler for Web Components
 sidebar_label: Overview
 description: Stencil has a number of add-ons that you can use with the build process.
 slug: /introduction
-contributors:
-  - jthoms1
-  - splitinfinities
-  - a-giuliano
 ---
 
 # Overview

--- a/versioned_docs/version-v3.2/introduction/02-goals-and-objectives.md
+++ b/versioned_docs/version-v3.2/introduction/02-goals-and-objectives.md
@@ -3,9 +3,6 @@ title: Stencil Goals and Objectives
 sidebar_label: Goals and Objectives
 description: Stencil aims to combine the best concepts of the most popular frontend frameworks into a compile-time tool rather than run-time tool.
 slug: /goals-and-objectives
-contributors:
-  - adamdbradley
-  - sri-ni
 ---
 
 # Stencil Goals And Objectives

--- a/versioned_docs/version-v3.2/introduction/03-getting-started.md
+++ b/versioned_docs/version-v3.2/introduction/03-getting-started.md
@@ -3,9 +3,6 @@ title: Getting Started
 sidebar_label: Getting Started
 description: Getting Started
 slug: /getting-started
-contributors:
-  - jthoms1
-  - rwaskiewicz
 ---
 
 # Getting Started

--- a/versioned_docs/version-v3.2/introduction/upgrading-to-stencil-three.md
+++ b/versioned_docs/version-v3.2/introduction/upgrading-to-stencil-three.md
@@ -2,8 +2,6 @@
 title: Upgrading to Stencil v3.0.0
 description: Upgrading to Stencil v3.0.0
 url: /docs/upgrading-to-stencil-3
-contributors:
-  - rwaskiewicz
 ---
 
 # Upgrading to Stencil v3.0.0

--- a/versioned_docs/version-v3.2/output-targets/01-overview.md
+++ b/versioned_docs/version-v3.2/output-targets/01-overview.md
@@ -3,10 +3,6 @@ title: Stencil Output Targets
 sidebar_label: Overview
 description: Stencil Output Targets
 slug: /output-targets
-contributors:
-  - adamdbradley
-  - manucorporat
-  - rwaskiewicz
 ---
 
 # Output Targets

--- a/versioned_docs/version-v3.2/output-targets/copy-tasks.md
+++ b/versioned_docs/version-v3.2/output-targets/copy-tasks.md
@@ -3,10 +3,6 @@ title: Stencil Copy Tasks
 sidebar_label: Copy Tasks
 description: Stencil Copy Tasks
 slug: /copy-tasks
-contributors:
-  - adamdbradley
-  - manucorporat
-  - jeanbenitez
 ---
 
 

--- a/versioned_docs/version-v3.2/output-targets/custom-elements.md
+++ b/versioned_docs/version-v3.2/output-targets/custom-elements.md
@@ -3,11 +3,6 @@ title: Custom Elements with Stencil
 sidebar_label: dist-custom-elements
 description: Custom Elements with Stencil
 slug: /custom-elements
-contributors:
-  - adamdbradley
-  - rwaskiewicz
-  - splitinfinities
-  - tanner-reits
 ---
 
 # Custom Elements

--- a/versioned_docs/version-v3.2/output-targets/dist.md
+++ b/versioned_docs/version-v3.2/output-targets/dist.md
@@ -3,9 +3,6 @@ title: Distributing Web Components Built with Stencil
 sidebar_label: dist
 description: Distributing Web Components Built with Stencil
 slug: /distribution
-contributors:
-  - adamdbradley
-  - jthoms1
 ---
 
 # Distribution Output Target

--- a/versioned_docs/version-v3.2/output-targets/docs-custom.md
+++ b/versioned_docs/version-v3.2/output-targets/docs-custom.md
@@ -3,10 +3,6 @@ title: Custom Docs Generation
 sidebar_label: docs-custom
 description: Custom Docs Generation
 slug: /docs-custom
-contributors:
-  - adamdbradley
-  - manucorporat
-  - arayik-yervandyan
 ---
 
 # Custom Docs Generation

--- a/versioned_docs/version-v3.2/output-targets/docs-json.md
+++ b/versioned_docs/version-v3.2/output-targets/docs-json.md
@@ -3,14 +3,6 @@ title: Docs JSON Data Output Target
 sidebar_label: docs-json
 description: Docs JSON Output Target
 slug: /docs-json
-contributors:
-  - adamdbradley
-  - snaptopixel
-  - manucorporat
-  - amwmedia
-  - mrtnmgs
-  - marcjulian
-  - seanwuapps
 ---
 
 # Docs Json Data

--- a/versioned_docs/version-v3.2/output-targets/docs-readme.md
+++ b/versioned_docs/version-v3.2/output-targets/docs-readme.md
@@ -3,13 +3,6 @@ title: Docs Readme Auto-Generation
 sidebar_label: docs-readme
 description: Docs Readme Auto-Generation
 slug: /docs-readme
-contributors:
-  - adamdbradley
-  - snaptopixel
-  - manucorporat
-  - amwmedia
-  - mrtnmgs
-  - marcjulian
 ---
 
 # Docs Readme Markdown File Auto-Generation

--- a/versioned_docs/version-v3.2/output-targets/docs-stats.md
+++ b/versioned_docs/version-v3.2/output-targets/docs-stats.md
@@ -3,9 +3,6 @@ title: Docs Stats Auto-Generation
 sidebar_label: stats
 description: Docs Stats Auto-Generation
 slug: /stats
-contributors:
-  - adamdbradley
-  - splitinfinities
 ---
 
 # Stats

--- a/versioned_docs/version-v3.2/output-targets/docs-vscode.md
+++ b/versioned_docs/version-v3.2/output-targets/docs-vscode.md
@@ -2,8 +2,6 @@
 title: VS Code Documentation
 description: VS Code Documentation
 slug: /docs-vscode
-contributors:
-  - rwaskiewicz
 ---
 
 # VS Code Documentation

--- a/versioned_docs/version-v3.2/output-targets/www.md
+++ b/versioned_docs/version-v3.2/output-targets/www.md
@@ -3,10 +3,6 @@ title: Webapp Output Target
 sidebar_label: www
 description: Webapp Output Target
 slug: /www
-contributors:
-  - jthoms1
-  - simonhaenisch
-  - DavidFrahm
 ---
 
 # Webapp Output Target: `www`

--- a/versioned_docs/version-v3.2/reference/browser-support.md
+++ b/versioned_docs/version-v3.2/reference/browser-support.md
@@ -3,11 +3,6 @@ title: Stencil Web Component Browser Support
 sidebar_label: Browser Support
 description: Out-of-the-box browser support provided by Stencil web components.
 slug: /browser-support
-contributors:
-  - adamdbradley
-  - kevinports
-  - jthoms1
-  - arjunyel
 ---
 
 # Browser Support

--- a/versioned_docs/version-v3.2/reference/faq.md
+++ b/versioned_docs/version-v3.2/reference/faq.md
@@ -3,9 +3,6 @@ title: Stencil Frequently Asked Questions
 sidebar_label: FAQ
 description: Stencil is a developer-focused toolchain for building reusable, scalable component libraries, applications and design systems.
 slug: /faq
-contributors:
-  - adamdbradley
-  - rwaskiewicz
 ---
 
 # FAQ

--- a/versioned_docs/version-v3.2/reference/support-policy.md
+++ b/versioned_docs/version-v3.2/reference/support-policy.md
@@ -3,8 +3,6 @@ title: Support Policy
 sidebar_label: Support Policy
 description: Support Policy
 slug: /support-policy
-contributors:
-- rwaskiewicz
 ---
 
 # Support Policy

--- a/versioned_docs/version-v3.2/reference/versioning.md
+++ b/versioned_docs/version-v3.2/reference/versioning.md
@@ -3,8 +3,6 @@ title: Versioning
 sidebar_label: Versioning
 description: Versioning
 slug: /versioning
-contributors:
-- rwaskiewicz
 ---
 
 # Versioning

--- a/versioned_docs/version-v3.2/static-site-generation/01-overview.md
+++ b/versioned_docs/version-v3.2/static-site-generation/01-overview.md
@@ -2,10 +2,6 @@
 title: Static Site Generation
 sidebar_label: Overview
 slug: /static-site-generation
-contributors:
-  - mlynch
-  - adamdbradley
-  - bitflower
 ---
 
 # Static Site Generation with Stencil

--- a/versioned_docs/version-v3.2/static-site-generation/basics.md
+++ b/versioned_docs/version-v3.2/static-site-generation/basics.md
@@ -3,9 +3,6 @@ title: Static Site Generation Basics in Stencil
 sidebar_label: Basics
 description: Quick introduction to configuring and using Static Site Generation in Stencil
 slug: /static-site-generation-basics
-contributors:
-  - mlynch
-  - adamdbradley
 ---
 
 # Static Site Generation Basics

--- a/versioned_docs/version-v3.2/static-site-generation/debugging.md
+++ b/versioned_docs/version-v3.2/static-site-generation/debugging.md
@@ -3,9 +3,6 @@ title: Debugging Static Site Generation in Stencil
 sidebar_label: Debugging
 description: How to debug a prerendering or Static Site Generation step in Stencil
 slug: /static-site-generation-debugging
-contributors:
-  - mlynch
-  - adamdbradley
 ---
 
 # Debugging Static Site Generation

--- a/versioned_docs/version-v3.2/static-site-generation/deployment.md
+++ b/versioned_docs/version-v3.2/static-site-generation/deployment.md
@@ -3,8 +3,6 @@ title: Deploying a Static Site
 sidebar_label: Deployment
 description: Deploying a Static Site
 slug: /static-site-generation-deployment
-contributors:
-  - mlynch
 ---
 
 # Deploying a Stencil Static Site

--- a/versioned_docs/version-v3.2/static-site-generation/meta.md
+++ b/versioned_docs/version-v3.2/static-site-generation/meta.md
@@ -3,10 +3,6 @@ title: SEO Meta Tags in SSG
 sidebar_label: Meta tags
 description: Managing meta tags for SEO and social media embedding in Stencil Static Sites
 slug: /static-site-generation-meta-tags
-contributors:
-  - mlynch
-  - adamdbradley
-  - rwaskiewicz
 ---
 
 # SEO Meta Tags and Static Site Generation

--- a/versioned_docs/version-v3.2/static-site-generation/prerender-config.md
+++ b/versioned_docs/version-v3.2/static-site-generation/prerender-config.md
@@ -3,10 +3,6 @@ title: Prerender Config
 sidebar_label: Prerender Config
 description: Prerender Config
 slug: /prerender-config
-contributors:
-  - adamdbradley
-  - ryan3E0
-  - dgautsch
 ---
 
 

--- a/versioned_docs/version-v3.2/static-site-generation/server-side-rendering-ssr.md
+++ b/versioned_docs/version-v3.2/static-site-generation/server-side-rendering-ssr.md
@@ -3,8 +3,6 @@ title: Combining Server Side Rendering and Static Site Generation
 sidebar_label: Server Side Rendering
 description: How to combine both Server Side Rendering and Static Site Generation approaches
 slug: /static-site-generation-server-side-rendering-ssr
-contributors:
-  - mlynch
 ---
 
 # Combining Server Side Rendering and Static Site Generation

--- a/versioned_docs/version-v3.2/telemetry.md
+++ b/versioned_docs/version-v3.2/telemetry.md
@@ -1,8 +1,6 @@
 ---
 title: Telemetry
 description: Stencil Telemetry usage information
-contributors:
-  - splitinfinities
 ---
 
 # Stencil CLI telemetry

--- a/versioned_docs/version-v3.2/testing/01-overview.md
+++ b/versioned_docs/version-v3.2/testing/01-overview.md
@@ -3,12 +3,6 @@ title: Testing
 sidebar_label: Overview
 description: Testing overview.
 slug: /testing-overview
-contributors:
-  - adamdbradley
-  - brandyscarney
-  - camwiegert
-  - kensodemann
-  - rwaskiewicz
 ---
 
 # Testing

--- a/versioned_docs/version-v3.2/testing/config.md
+++ b/versioned_docs/version-v3.2/testing/config.md
@@ -3,10 +3,6 @@ title: Testing Config
 sidebar_label: Config
 description: Testing Config
 slug: /testing-config
-contributors:
-  - adamdbradley
-  - mattcosta7
-  - viernullvier
 ---
 
 # Testing Config

--- a/versioned_docs/version-v3.2/testing/e2e-testing.md
+++ b/versioned_docs/version-v3.2/testing/e2e-testing.md
@@ -3,10 +3,6 @@ title: End-to-end Testing
 sidebar_label: End-to-end Testing
 description: End-to-end Testing
 slug: /end-to-end-testing
-contributors:
-  - adamdbradley
-  - mattdsteele
-  - simonhaenisch
 ---
 
 # End-to-end Testing

--- a/versioned_docs/version-v3.2/testing/mocking.md
+++ b/versioned_docs/version-v3.2/testing/mocking.md
@@ -3,8 +3,6 @@ title: Mocking
 sidebar_label: Mocking
 description: Mocking
 slug: /mocking
-contributors:
-  - simonhaenisch
 ---
 
 # Mocking

--- a/versioned_docs/version-v3.2/testing/screenshot-connector.md
+++ b/versioned_docs/version-v3.2/testing/screenshot-connector.md
@@ -3,8 +3,6 @@ title: Screenshot Connector
 sidebar_label: Screenshot Connector
 description: Screenshot Connector
 slug: /screenshot-connector
-contributors:
-  - SheepFromHeaven
 ---
 
 # Screenshot connector

--- a/versioned_docs/version-v3.2/testing/screenshot-visual-diff.md
+++ b/versioned_docs/version-v3.2/testing/screenshot-visual-diff.md
@@ -3,8 +3,6 @@ title: Screenshot Visual Diff
 sidebar_label: Visual Screenshot Diff
 description: Screenshot Visual Diff
 slug: /screenshot-visual-diff
-contributors:
-  - adamdbradley
 ---
 
 # Screenshot Visual Diff

--- a/versioned_docs/version-v3.2/testing/unit-testing.md
+++ b/versioned_docs/version-v3.2/testing/unit-testing.md
@@ -3,10 +3,6 @@ title: Unit Testing
 sidebar_label: Unit Testing
 description: Unit Testing
 slug: /unit-testing
-contributors:
-  - adamdbradley
-  - mattdsteele
-  - bassettsj
 ---
 
 # Unit Testing


### PR DESCRIPTION
this commit removes unused 'contributor' frontmatter from the site.
prior to switching to docusaurus, it was used as a part of the stencil
site build to generate 'contributor bubbles' at the bottom of the page.
we no longer do this, and if we wanted to could derive this data from
git history (at the cost of calculating it).

remove it as it's unclear for new contributors if they should update
these or not.

remove it as it also conflicts with new cspell integration work, which
flags many github user names as mis-spellings