### PR TITLE
fix(ci): fix deploys, remove mv command

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
     "build": "docusaurus build",
-    "build.ci": "docusaurus build && mv build www && echo Hello",
+    "build.ci": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
     "build": "docusaurus build",
-    "build.ci": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
     "build": "docusaurus build",
-    "build.ci": "docusaurus build && mv build www",
+    "build.ci": "docusaurus build && mv build www && echo Hello",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",


### PR DESCRIPTION
this commit removes the 'mv www' from the build.ci command. sometime between 2023.03.15 and 2023.03.16, vercel deploys began to fail due to the `build/` directory being missing after build. the build passes locally, which gives cause to something changing on the vercel side as far as this check goes. this `mv` is believed to be a remnant of the old stencil site + transition to docusaurus, and no longer needed

# Testing
The deploy for the[ first commit](https://vercel.com/ionic/stencil-docs/Bvo5ZukbDpnRCdtCv53evzCyRvJR) errors:

```
[14:36:07.911] Running build in San Francisco, USA (West) – sfo1
[14:36:07.967] Cloning github.com/ionic-team/stencil-site (Branch: rwaskiewicz/fix-ci-www-rm-mv, Commit: a20bfb3)
[14:36:08.227] Previous build caches not available
[14:36:09.148] Cloning completed: 1.181s
[14:36:09.351] Running "vercel build"
[14:36:09.791] Vercel CLI 28.16.15
[14:36:10.424] Installing dependencies...
[14:36:15.579] npm WARN deprecated stable@0.1.8: Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility
[14:36:24.388] 
[14:36:24.388] added 1246 packages in 14s
[14:36:24.389] 
[14:36:24.389] 265 packages are looking for funding
[14:36:24.389]   run `npm fund` for details
[14:36:24.718] 
[14:36:24.718] > @stencil/stencil-site@0.0.0 build.ci
[14:36:24.718] > docusaurus build && mv build www && echo Hello
[14:36:24.718] 
[14:36:26.351] [INFO] [en] Creating an optimized production build...
[14:36:27.428] ℹ Compiling Client
[14:36:27.452] ℹ Compiling Server
[14:37:32.139] ✔ Client: Compiled successfully in 1.08m
[14:37:50.941] ✔ Server: Compiled successfully in 1.39m
[14:37:59.286] [SUCCESS] Generated static files in "build".
[14:37:59.286] [INFO] Use `npm run serve` command to test your build locally.
[14:37:59.351] Hello
[14:37:59.359] Error detecting output directory:  [Error: ENOENT: no such file or directory, scandir '/vercel/path0/build'] {
[14:37:59.359]   errno: -2,
[14:37:59.359]   code: 'ENOENT',
[14:37:59.359]   syscall: 'scandir',
[14:37:59.359]   path: '/vercel/path0/build'
[14:37:59.359] }
[14:37:59.494] Error: No Output Directory named "build" found after the Build completed. You can configure the Output Directory in your Project Settings.
[14:37:59.495] Learn More: https://vercel.link/missing-public-directory
[14:37:59.648] BUILD_FAILED: No Output Directory named "build" found after the Build completed. You can configure the Output Directory in your Project Settings.
```

With the second commit, everything deploys