### PR TITLE
Fix/versioned redirects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,8 @@ www
 # IDEs
 .idea/
 .vscode/
-.vercel
 
 # vercel
+.vercel
 auth.json
 config.json

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,8 @@ www
 # IDEs
 .idea/
 .vscode/
+.vercel
+
+# vercel
+auth.json
+config.json

--- a/vercel.json
+++ b/vercel.json
@@ -2,142 +2,142 @@
   "trailingSlash": false,
   "redirects": [
     {
-      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?",
       "destination": "/docs/:version/introduction",
       "statusCode": 301
     },
     {
-      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/intro",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/intro",
       "destination": "/docs/:version/introduction",
       "statusCode": 301
     },
     {
-      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/building-components",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/building-components",
       "destination": "/docs/:version/getting-started",
       "statusCode": 301
     },
     {
-      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/my-first-component",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/my-first-component",
       "destination": "/docs/:version/getting-started",
       "statusCode": 301
     },
     {
-      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/stencil-config",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/stencil-config",
       "destination": "/docs/:version/config",
       "statusCode": 301
     },
     {
-      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/testing",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/testing",
       "destination": "/docs/:version/unit-testing",
       "statusCode": 301
     },
     {
-      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/shadow-dom",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/shadow-dom",
       "destination": "/docs/:version/styling",
       "statusCode": 301
     },
     {
-      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/css-variables",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/css-variables",
       "destination": "/docs/:version/styling",
       "statusCode": 301
     },
     {
-      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/sass",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/sass",
       "destination": "/docs/:version/plugins",
       "statusCode": 301
     },
     {
-      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/add-ons",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/add-ons",
       "destination": "/docs/:version/plugins",
       "statusCode": 301
     },
     {
-      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/addons",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/addons",
       "destination": "/docs/:version/plugins",
       "statusCode": 301
     },
     {
-      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/templating",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/templating",
       "destination": "/docs/:version/templating-jsx",
       "statusCode": 301
     },
     {
-      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/router",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/router",
       "destination": "https://github.com/ionic-team/stencil-router/wiki",
       "statusCode": 301
     },
     {
-      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/stencil-router",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/stencil-router",
       "destination": "https://github.com/ionic-team/stencil-router/wiki",
       "statusCode": 301
     },
     {
-      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/routing",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/routing",
       "destination": "https://github.com/ionic-team/stencil-router/wiki",
       "statusCode": 301
     },
     {
-      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/server-side-rendering",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/server-side-rendering",
       "destination": "/docs/:version/static-site-generation-server-side-rendering-ssr",
       "statusCode": 301
     },
     {
-      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/prerendering",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/prerendering",
       "destination": "/docs/:version/static-site-generation",
       "statusCode": 301
     },
     {
-      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/build-conditionals",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/build-conditionals",
       "destination": "/docs/:version",
       "statusCode": 302
     },
     {
-      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/docs-auto-generation",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/docs-auto-generation",
       "destination": "/docs/:version/docs-readme",
       "statusCode": 301
     },
     {
-      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/what-is-design-system",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/what-is-design-system",
       "destination": "/docs/:version/design-systems",
       "statusCode": 301
     },
     {
-      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/stencil-for-design-systems",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/stencil-for-design-systems",
       "destination": "/docs/:version/design-systems",
       "statusCode": 301
     },
     {
-      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/local-assets",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/local-assets",
       "destination": "/docs/:version/assets",
       "statusCode": 301
     },
     {
-      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/deno",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/deno",
       "destination": "/docs/:version/support-policy",
       "statusCode": 301
     },
     {
-      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/stencil-state-tunnel",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/stencil-state-tunnel",
       "destination": "https://github.com/ionic-team/stencil-state-tunnel",
       "statusCode": 301
     },
     {
-      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/state-tunnel",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/state-tunnel",
       "destination": "https://github.com/ionic-team/stencil-state-tunnel",
       "statusCode": 301
     },
     {
-      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/framework-bindings",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/framework-bindings",
       "destination": "/docs/:version/overview",
       "statusCode": 301
     },
     {
-      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/redux",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/redux",
       "destination": "https://github.com/ionic-team/stencil-redux",
       "statusCode": 301
     },
     {
-      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/stencil-redux",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/stencil-redux",
       "destination": "https://github.com/ionic-team/stencil-redux",
       "statusCode": 301
     }

--- a/vercel.json
+++ b/vercel.json
@@ -2,142 +2,142 @@
   "trailingSlash": false,
   "redirects": [
     {
-      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+)?))?",
       "destination": "/docs/:version/introduction",
       "statusCode": 301
     },
     {
-      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/intro",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+)?))?/intro",
       "destination": "/docs/:version/introduction",
       "statusCode": 301
     },
     {
-      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/building-components",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+)?))?/building-components",
       "destination": "/docs/:version/getting-started",
       "statusCode": 301
     },
     {
-      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/my-first-component",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+)?))?/my-first-component",
       "destination": "/docs/:version/getting-started",
       "statusCode": 301
     },
     {
-      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/stencil-config",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+)?))?/stencil-config",
       "destination": "/docs/:version/config",
       "statusCode": 301
     },
     {
-      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/testing",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+)?))?/testing",
       "destination": "/docs/:version/unit-testing",
       "statusCode": 301
     },
     {
-      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/shadow-dom",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+)?))?/shadow-dom",
       "destination": "/docs/:version/styling",
       "statusCode": 301
     },
     {
-      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/css-variables",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+)?))?/css-variables",
       "destination": "/docs/:version/styling",
       "statusCode": 301
     },
     {
-      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/sass",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+)?))?/sass",
       "destination": "/docs/:version/plugins",
       "statusCode": 301
     },
     {
-      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/add-ons",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+)?))?/add-ons",
       "destination": "/docs/:version/plugins",
       "statusCode": 301
     },
     {
-      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/addons",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+)?))?/addons",
       "destination": "/docs/:version/plugins",
       "statusCode": 301
     },
     {
-      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/templating",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+)?))?/templating",
       "destination": "/docs/:version/templating-jsx",
       "statusCode": 301
     },
     {
-      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/router",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+)?))?/router",
       "destination": "https://github.com/ionic-team/stencil-router/wiki",
       "statusCode": 301
     },
     {
-      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/stencil-router",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+)?))?/stencil-router",
       "destination": "https://github.com/ionic-team/stencil-router/wiki",
       "statusCode": 301
     },
     {
-      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/routing",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+)?))?/routing",
       "destination": "https://github.com/ionic-team/stencil-router/wiki",
       "statusCode": 301
     },
     {
-      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/server-side-rendering",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+)?))?/server-side-rendering",
       "destination": "/docs/:version/static-site-generation-server-side-rendering-ssr",
       "statusCode": 301
     },
     {
-      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/prerendering",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+)?))?/prerendering",
       "destination": "/docs/:version/static-site-generation",
       "statusCode": 301
     },
     {
-      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/build-conditionals",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+)?))?/build-conditionals",
       "destination": "/docs/:version",
       "statusCode": 302
     },
     {
-      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/docs-auto-generation",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+)?))?/docs-auto-generation",
       "destination": "/docs/:version/docs-readme",
       "statusCode": 301
     },
     {
-      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/what-is-design-system",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+)?))?/what-is-design-system",
       "destination": "/docs/:version/design-systems",
       "statusCode": 301
     },
     {
-      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/stencil-for-design-systems",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+)?))?/stencil-for-design-systems",
       "destination": "/docs/:version/design-systems",
       "statusCode": 301
     },
     {
-      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/local-assets",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+)?))?/local-assets",
       "destination": "/docs/:version/assets",
       "statusCode": 301
     },
     {
-      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/deno",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+)?))?/deno",
       "destination": "/docs/:version/support-policy",
       "statusCode": 301
     },
     {
-      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/stencil-state-tunnel",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+)?))?/stencil-state-tunnel",
       "destination": "https://github.com/ionic-team/stencil-state-tunnel",
       "statusCode": 301
     },
     {
-      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/state-tunnel",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+)?))?/state-tunnel",
       "destination": "https://github.com/ionic-team/stencil-state-tunnel",
       "statusCode": 301
     },
     {
-      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/framework-bindings",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+)?))?/framework-bindings",
       "destination": "/docs/:version/overview",
       "statusCode": 301
     },
     {
-      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/redux",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+)?))?/redux",
       "destination": "https://github.com/ionic-team/stencil-redux",
       "statusCode": 301
     },
     {
-      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+))?)?/stencil-redux",
+      "source": "/:version(next|(?:v[\\d]+(?:\\.[\\dx]+)?))?/stencil-redux",
       "destination": "https://github.com/ionic-team/stencil-redux",
       "statusCode": 301
     }

--- a/vercel.json
+++ b/vercel.json
@@ -2,142 +2,142 @@
   "trailingSlash": false,
   "redirects": [
     {
-      "source": "/",
-      "destination": "/docs/introduction",
+      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?",
+      "destination": "/docs/:version/introduction",
       "statusCode": 301
     },
     {
-      "source": "/intro",
-      "destination": "/docs/introduction",
+      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/intro",
+      "destination": "/docs/:version/introduction",
       "statusCode": 301
     },
     {
-      "source": "/building-components",
-      "destination": "/docs/getting-started",
+      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/building-components",
+      "destination": "/docs/:version/getting-started",
       "statusCode": 301
     },
     {
-      "source": "/docs/my-first-component",
-      "destination": "/docs/getting-started",
+      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/my-first-component",
+      "destination": "/docs/:version/getting-started",
       "statusCode": 301
     },
     {
-      "source": "/stencil-config",
-      "destination": "/docs/config",
+      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/stencil-config",
+      "destination": "/docs/:version/config",
       "statusCode": 301
     },
     {
-      "source": "/testing",
-      "destination": "/docs/unit-testing",
+      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/testing",
+      "destination": "/docs/:version/unit-testing",
       "statusCode": 301
     },
     {
-      "source": "/shadow-dom",
-      "destination": "/docs/styling",
+      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/shadow-dom",
+      "destination": "/docs/:version/styling",
       "statusCode": 301
     },
     {
-      "source": "/css-variables",
-      "destination": "/docs/styling",
+      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/css-variables",
+      "destination": "/docs/:version/styling",
       "statusCode": 301
     },
     {
-      "source": "/sass",
-      "destination": "/docs/plugins",
+      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/sass",
+      "destination": "/docs/:version/plugins",
       "statusCode": 301
     },
     {
-      "source": "/add-ons",
-      "destination": "/docs/plugins",
+      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/add-ons",
+      "destination": "/docs/:version/plugins",
       "statusCode": 301
     },
     {
-      "source": "/addons",
-      "destination": "/docs/plugins",
+      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/addons",
+      "destination": "/docs/:version/plugins",
       "statusCode": 301
     },
     {
-      "source": "/templating",
-      "destination": "/docs/templating-jsx",
+      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/templating",
+      "destination": "/docs/:version/templating-jsx",
       "statusCode": 301
     },
     {
-      "source": "/router",
+      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/router",
       "destination": "https://github.com/ionic-team/stencil-router/wiki",
       "statusCode": 301
     },
     {
-      "source": "/stencil-router",
+      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/stencil-router",
       "destination": "https://github.com/ionic-team/stencil-router/wiki",
       "statusCode": 301
     },
     {
-      "source": "/routing",
+      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/routing",
       "destination": "https://github.com/ionic-team/stencil-router/wiki",
       "statusCode": 301
     },
     {
-      "source": "/server-side-rendering",
-      "destination": "/docs/static-site-generation-server-side-rendering-ssr",
+      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/server-side-rendering",
+      "destination": "/docs/:version/static-site-generation-server-side-rendering-ssr",
       "statusCode": 301
     },
     {
-      "source": "/prerendering",
-      "destination": "/docs/static-site-generation",
+      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/prerendering",
+      "destination": "/docs/:version/static-site-generation",
       "statusCode": 301
     },
     {
-      "source": "/build-conditionals",
-      "destination": "/docs",
+      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/build-conditionals",
+      "destination": "/docs/:version",
       "statusCode": 302
     },
     {
-      "source": "/docs-auto-generation",
-      "destination": "/docs/docs-readme",
+      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/docs-auto-generation",
+      "destination": "/docs/:version/docs-readme",
       "statusCode": 301
     },
     {
-      "source": "/what-is-design-system",
-      "destination": "/docs/design-systems",
+      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/what-is-design-system",
+      "destination": "/docs/:version/design-systems",
       "statusCode": 301
     },
     {
-      "source": "/stencil-for-design-systems",
-      "destination": "/docs/design-systems",
+      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/stencil-for-design-systems",
+      "destination": "/docs/:version/design-systems",
       "statusCode": 301
     },
     {
-      "source": "/local-assets",
-      "destination": "/docs/assets",
+      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/local-assets",
+      "destination": "/docs/:version/assets",
       "statusCode": 301
     },
     {
-      "source": "/deno",
-      "destination": "/docs/support-policy",
+      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/deno",
+      "destination": "/docs/:version/support-policy",
       "statusCode": 301
     },
     {
-      "source": "/stencil-state-tunnel",
+      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/stencil-state-tunnel",
       "destination": "https://github.com/ionic-team/stencil-state-tunnel",
       "statusCode": 301
     },
     {
-      "source": "/state-tunnel",
+      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/state-tunnel",
       "destination": "https://github.com/ionic-team/stencil-state-tunnel",
       "statusCode": 301
     },
     {
-      "source": "/framework-bindings",
-      "destination": "/docs/overview",
+      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/framework-bindings",
+      "destination": "/docs/:version/overview",
       "statusCode": 301
     },
     {
-      "source": "/redux",
+      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/redux",
       "destination": "https://github.com/ionic-team/stencil-redux",
       "statusCode": 301
     },
     {
-      "source": "/stencil-redux",
+      "source": "/:version(v[\\d]+(?:\\.[\\dx]+)?)?/stencil-redux",
       "destination": "https://github.com/ionic-team/stencil-redux",
       "statusCode": 301
     }

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "trailingSlash": false,
   "redirects": [
     {
       "source": "/",
@@ -6,122 +7,122 @@
       "statusCode": 301
     },
     {
-      "source": "/intro(/)?",
+      "source": "/intro",
       "destination": "/docs/introduction",
       "statusCode": 301
     },
     {
-      "source": "/building-components(/)?",
+      "source": "/building-components",
       "destination": "/docs/getting-started",
       "statusCode": 301
     },
     {
-      "source": "/docs/my-first-component(/)?",
+      "source": "/docs/my-first-component",
       "destination": "/docs/getting-started",
       "statusCode": 301
     },
     {
-      "source": "/stencil-config(/)?",
+      "source": "/stencil-config",
       "destination": "/docs/config",
       "statusCode": 301
     },
     {
-      "source": "/testing(/)?",
+      "source": "/testing",
       "destination": "/docs/unit-testing",
       "statusCode": 301
     },
     {
-      "source": "/shadow-dom(/)?",
+      "source": "/shadow-dom",
       "destination": "/docs/styling",
       "statusCode": 301
     },
     {
-      "source": "/css-variables(/)?",
+      "source": "/css-variables",
       "destination": "/docs/styling",
       "statusCode": 301
     },
     {
-      "source": "/sass(/)?",
+      "source": "/sass",
       "destination": "/docs/plugins",
       "statusCode": 301
     },
     {
-      "source": "/add-ons(/)?",
+      "source": "/add-ons",
       "destination": "/docs/plugins",
       "statusCode": 301
     },
     {
-      "source": "/addons(/)?",
+      "source": "/addons",
       "destination": "/docs/plugins",
       "statusCode": 301
     },
     {
-      "source": "/templating(/)?",
+      "source": "/templating",
       "destination": "/docs/templating-jsx",
       "statusCode": 301
     },
     {
-      "source": "/router(/)?",
+      "source": "/router",
       "destination": "https://github.com/ionic-team/stencil-router/wiki",
       "statusCode": 301
     },
     {
-      "source": "/stencil-router(/)?",
+      "source": "/stencil-router",
       "destination": "https://github.com/ionic-team/stencil-router/wiki",
       "statusCode": 301
     },
     {
-      "source": "/routing(/)?",
+      "source": "/routing",
       "destination": "https://github.com/ionic-team/stencil-router/wiki",
       "statusCode": 301
     },
     {
-      "source": "/server-side-rendering(/)?",
+      "source": "/server-side-rendering",
       "destination": "/docs/static-site-generation-server-side-rendering-ssr",
       "statusCode": 301
     },
     {
-      "source": "/prerendering(/)?",
+      "source": "/prerendering",
       "destination": "/docs/static-site-generation",
       "statusCode": 301
     },
     {
-      "source": "/build-conditionals(/)?",
+      "source": "/build-conditionals",
       "destination": "/docs",
       "statusCode": 302
     },
     {
-      "source": "/docs-auto-generation(/)?",
+      "source": "/docs-auto-generation",
       "destination": "/docs/docs-readme",
       "statusCode": 301
     },
     {
-      "source": "/what-is-design-system(/)?",
+      "source": "/what-is-design-system",
       "destination": "/docs/design-systems",
       "statusCode": 301
     },
     {
-      "source": "/stencil-for-design-systems(/)?",
+      "source": "/stencil-for-design-systems",
       "destination": "/docs/design-systems",
       "statusCode": 301
     },
     {
-      "source": "/local-assets(/)?",
+      "source": "/local-assets",
       "destination": "/docs/assets",
       "statusCode": 301
     },
     {
-      "source": "/deno(/)?",
+      "source": "/deno",
       "destination": "/docs/support-policy",
       "statusCode": 301
     },
     {
-      "source": "/stencil-state-tunnel(/)?",
+      "source": "/stencil-state-tunnel",
       "destination": "https://github.com/ionic-team/stencil-state-tunnel",
       "statusCode": 301
     },
     {
-      "source": "/state-tunnel(/)?",
+      "source": "/state-tunnel",
       "destination": "https://github.com/ionic-team/stencil-state-tunnel",
       "statusCode": 301
     },
@@ -131,12 +132,12 @@
       "statusCode": 301
     },
     {
-      "source": "/redux(/)?",
+      "source": "/redux",
       "destination": "https://github.com/ionic-team/stencil-redux",
       "statusCode": 301
     },
     {
-      "source": "/stencil-redux(/)?",
+      "source": "/stencil-redux",
       "destination": "https://github.com/ionic-team/stencil-redux",
       "statusCode": 301
     }


### PR DESCRIPTION
This PR adds functionality to the vercel.config file to include versioned docs for the current redirects. In addition, it removes pattern matching for trailing slashes and adds a config option to remove them by default.

Here is the current [pattern matching library](https://github.com/pillarjs/path-to-regexp/tree/v6.1.0) that vercel uses for its config file. Here is the [related section](https://vercel.com/docs/errors#invalid-route-source-pattern) in the vercel docs.

Unfortunately this is a blanket solution that will affect all versions (including current) of certain files, some which may not want redirects or require different destinations based on versions. I'm open to suggestions on how to mitigate this. ATM the best solution I can think of is to just handle those on a case by case basis.