### PR TITLE
add componentOnReady to API docs

### DIFF
--- a/docs/components/api.md
+++ b/docs/components/api.md
@@ -38,6 +38,34 @@ Once all the metadata has been collected, all the decorators are removed from th
 - [componentDidUpdate()](./component-lifecycle.md#componentdidupdate)
 - **[render()](./templating-and-jsx.md)**
 
+## componentOnReady()
+
+This isn't a true "lifecycle" method that would be declared on the component class definition, but instead is a utility method that
+can be used by an implementation consuming your Stencil component to detect when a component has finished its first render cycle.
+
+This method resolves after `componentDidRender()` on the _first_ render cycle.
+
+:::note
+`componentOnReady()` only resolves once per component instance. If you need to hook into subsequent render cycle, use
+`componentDidRender()` or `componentDidUpdate()`.
+:::
+
+Executing code after `componentOnReady()` resolves could look something like this:
+
+```ts
+// Get a reference to the element
+const el = documents.querySelector('my-component');
+
+el.componentOnReady().then(() => {
+  // Place any code in here you want to execute when the component is ready
+  console.log('my-component is ready');
+});
+```
+
+The availability of `componentOnReady()` depends on the component's compiled output type. This method is only available for lazy-loaded
+distribution types and, as such, is not available for [`dist-custom-elements`](../output-targets/custom-elements.md) output. If you want to
+simulate the behavior of `componentOnReady()` for non-lazy builds, you can implement a helper method to wrap the functionality similar to what
+the Ionic Framework does [here](https://github.com/ionic-team/ionic-framework/blob/main/core/src/utils/helpers.ts#L60-L79).
 
 ## The appload event
 

--- a/docs/components/api.md
+++ b/docs/components/api.md
@@ -43,10 +43,10 @@ Once all the metadata has been collected, all the decorators are removed from th
 This isn't a true "lifecycle" method that would be declared on the component class definition, but instead is a utility method that
 can be used by an implementation consuming your Stencil component to detect when a component has finished its first render cycle.
 
-This method resolves after `componentDidRender()` on the _first_ render cycle.
+This method returns a promise which resolves after `componentDidRender()` on the _first_ render cycle.
 
 :::note
-`componentOnReady()` only resolves once per component instance. If you need to hook into subsequent render cycle, use
+`componentOnReady()` only resolves once per component lifetime. If you need to hook into subsequent render cycle, use
 `componentDidRender()` or `componentDidUpdate()`.
 :::
 
@@ -63,9 +63,9 @@ el.componentOnReady().then(() => {
 ```
 
 The availability of `componentOnReady()` depends on the component's compiled output type. This method is only available for lazy-loaded
-distribution types and, as such, is not available for [`dist-custom-elements`](../output-targets/custom-elements.md) output. If you want to
-simulate the behavior of `componentOnReady()` for non-lazy builds, you can implement a helper method to wrap the functionality similar to what
-the Ionic Framework does [here](https://github.com/ionic-team/ionic-framework/blob/main/core/src/utils/helpers.ts#L60-L79).
+distribution types ([`dist`](../output-targets/dist.md) and [`www`](../output-targets/www.md)) and, as such, is not available for
+[`dist-custom-elements`](../output-targets/custom-elements.md) output. If you want to simulate the behavior of `componentOnReady()` for non-lazy builds,
+you can implement a helper method to wrap the functionality similar to what the Ionic Framework does [here](https://github.com/ionic-team/ionic-framework/blob/main/core/src/utils/helpers.ts#L60-L79).
 
 ## The appload event
 

--- a/versioned_docs/version-v2/components/api.md
+++ b/versioned_docs/version-v2/components/api.md
@@ -38,6 +38,34 @@ Once all the metadata has been collected, all the decorators are removed from th
 - [componentDidUpdate()](./component-lifecycle.md#componentdidupdate)
 - **[render()](./templating-and-jsx.md)**
 
+## componentOnReady()
+
+This isn't a true "lifecycle" method that would be declared on the component class definition, but instead is a utility method that
+can be used by an implementation consuming your Stencil component to detect when a component has finished its first render cycle.
+
+This method returns a promise which resolves after `componentDidRender()` on the _first_ render cycle.
+
+:::note
+`componentOnReady()` only resolves once per component lifetime. If you need to hook into subsequent render cycle, use
+`componentDidRender()` or `componentDidUpdate()`.
+:::
+
+Executing code after `componentOnReady()` resolves could look something like this:
+
+```ts
+// Get a reference to the element
+const el = documents.querySelector('my-component');
+
+el.componentOnReady().then(() => {
+  // Place any code in here you want to execute when the component is ready
+  console.log('my-component is ready');
+});
+```
+
+The availability of `componentOnReady()` depends on the component's compiled output type. This method is only available for lazy-loaded
+distribution types ([`dist`](../output-targets/dist.md) and [`www`](../output-targets/www.md)) and, as such, is not available for
+[`dist-custom-elements`](../output-targets/custom-elements.md) output. If you want to simulate the behavior of `componentOnReady()` for non-lazy builds,
+you can implement a helper method to wrap the functionality similar to what the Ionic Framework does [here](https://github.com/ionic-team/ionic-framework/blob/main/core/src/utils/helpers.ts#L60-L79).
 
 ## The appload event
 

--- a/versioned_docs/version-v3.0/components/api.md
+++ b/versioned_docs/version-v3.0/components/api.md
@@ -38,6 +38,34 @@ Once all the metadata has been collected, all the decorators are removed from th
 - [componentDidUpdate()](./component-lifecycle.md#componentdidupdate)
 - **[render()](./templating-and-jsx.md)**
 
+## componentOnReady()
+
+This isn't a true "lifecycle" method that would be declared on the component class definition, but instead is a utility method that
+can be used by an implementation consuming your Stencil component to detect when a component has finished its first render cycle.
+
+This method returns a promise which resolves after `componentDidRender()` on the _first_ render cycle.
+
+:::note
+`componentOnReady()` only resolves once per component lifetime. If you need to hook into subsequent render cycle, use
+`componentDidRender()` or `componentDidUpdate()`.
+:::
+
+Executing code after `componentOnReady()` resolves could look something like this:
+
+```ts
+// Get a reference to the element
+const el = documents.querySelector('my-component');
+
+el.componentOnReady().then(() => {
+  // Place any code in here you want to execute when the component is ready
+  console.log('my-component is ready');
+});
+```
+
+The availability of `componentOnReady()` depends on the component's compiled output type. This method is only available for lazy-loaded
+distribution types ([`dist`](../output-targets/dist.md) and [`www`](../output-targets/www.md)) and, as such, is not available for
+[`dist-custom-elements`](../output-targets/custom-elements.md) output. If you want to simulate the behavior of `componentOnReady()` for non-lazy builds,
+you can implement a helper method to wrap the functionality similar to what the Ionic Framework does [here](https://github.com/ionic-team/ionic-framework/blob/main/core/src/utils/helpers.ts#L60-L79).
 
 ## The appload event
 

--- a/versioned_docs/version-v3.1/components/api.md
+++ b/versioned_docs/version-v3.1/components/api.md
@@ -38,6 +38,34 @@ Once all the metadata has been collected, all the decorators are removed from th
 - [componentDidUpdate()](./component-lifecycle.md#componentdidupdate)
 - **[render()](./templating-and-jsx.md)**
 
+## componentOnReady()
+
+This isn't a true "lifecycle" method that would be declared on the component class definition, but instead is a utility method that
+can be used by an implementation consuming your Stencil component to detect when a component has finished its first render cycle.
+
+This method returns a promise which resolves after `componentDidRender()` on the _first_ render cycle.
+
+:::note
+`componentOnReady()` only resolves once per component lifetime. If you need to hook into subsequent render cycle, use
+`componentDidRender()` or `componentDidUpdate()`.
+:::
+
+Executing code after `componentOnReady()` resolves could look something like this:
+
+```ts
+// Get a reference to the element
+const el = documents.querySelector('my-component');
+
+el.componentOnReady().then(() => {
+  // Place any code in here you want to execute when the component is ready
+  console.log('my-component is ready');
+});
+```
+
+The availability of `componentOnReady()` depends on the component's compiled output type. This method is only available for lazy-loaded
+distribution types ([`dist`](../output-targets/dist.md) and [`www`](../output-targets/www.md)) and, as such, is not available for
+[`dist-custom-elements`](../output-targets/custom-elements.md) output. If you want to simulate the behavior of `componentOnReady()` for non-lazy builds,
+you can implement a helper method to wrap the functionality similar to what the Ionic Framework does [here](https://github.com/ionic-team/ionic-framework/blob/main/core/src/utils/helpers.ts#L60-L79).
 
 ## The appload event
 

--- a/versioned_docs/version-v3.2/components/api.md
+++ b/versioned_docs/version-v3.2/components/api.md
@@ -38,6 +38,34 @@ Once all the metadata has been collected, all the decorators are removed from th
 - [componentDidUpdate()](./component-lifecycle.md#componentdidupdate)
 - **[render()](./templating-and-jsx.md)**
 
+## componentOnReady()
+
+This isn't a true "lifecycle" method that would be declared on the component class definition, but instead is a utility method that
+can be used by an implementation consuming your Stencil component to detect when a component has finished its first render cycle.
+
+This method returns a promise which resolves after `componentDidRender()` on the _first_ render cycle.
+
+:::note
+`componentOnReady()` only resolves once per component lifetime. If you need to hook into subsequent render cycle, use
+`componentDidRender()` or `componentDidUpdate()`.
+:::
+
+Executing code after `componentOnReady()` resolves could look something like this:
+
+```ts
+// Get a reference to the element
+const el = documents.querySelector('my-component');
+
+el.componentOnReady().then(() => {
+  // Place any code in here you want to execute when the component is ready
+  console.log('my-component is ready');
+});
+```
+
+The availability of `componentOnReady()` depends on the component's compiled output type. This method is only available for lazy-loaded
+distribution types ([`dist`](../output-targets/dist.md) and [`www`](../output-targets/www.md)) and, as such, is not available for
+[`dist-custom-elements`](../output-targets/custom-elements.md) output. If you want to simulate the behavior of `componentOnReady()` for non-lazy builds,
+you can implement a helper method to wrap the functionality similar to what the Ionic Framework does [here](https://github.com/ionic-team/ionic-framework/blob/main/core/src/utils/helpers.ts#L60-L79).
 
 ## The appload event
 


### PR DESCRIPTION
Adds documentation for `componentOnReady()` to the component API section of the docs. 