### PR TITLE
chore(github): add actions to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,7 @@ updates:
       # See: https://github.com/facebook/docusaurus/issues/4029
       - dependency-name: '@mdx-js/react'
         versions: ['>=2']
+  - package-ecosystem: 'github-actions' # See documentation for possible values
+    directory: '/.github/workflows/'
+    schedule:
+      interval: 'daily'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,6 @@ updates:
       - dependency-name: '@mdx-js/react'
         versions: ['>=2']
   - package-ecosystem: 'github-actions' # See documentation for possible values
-    directory: '/.github/workflows/'
+    directory: '/'
     schedule:
       interval: 'daily'


### PR DESCRIPTION
this commit adds github actions to dependabot's manifest, ensuring that those dependencies are updated in a timely manner.

