### PR TITLE
docs(angular-output-target): includeSingleComponentAngularModules option

### DIFF
--- a/docs/framework-integration/angular.md
+++ b/docs/framework-integration/angular.md
@@ -415,6 +415,8 @@ on using the `dist-custom-elements` output for the Angular proxies, see the [FAQ
 
 **Type: `boolean`**
 
+**Available Since: `@stencil/angular-output-target@v0.6.0`**
+
 If `true`, an Angular module will be generated for each component. This option requires that `includeImportCustomElements` is set to `true`.
 
 ### valueAccessorConfigs

--- a/docs/framework-integration/angular.md
+++ b/docs/framework-integration/angular.md
@@ -122,6 +122,7 @@ workspace `package.json` file:
 # from `/packages/angular-workspace`
 npm uninstall jasmine-core @types/jasmine
 ```
+
 :::
 
 ### Adding the Angular Output Target
@@ -406,6 +407,16 @@ first file you should import in your Angular project.
 
 If `true`, Angular components will import and define elements from the `dist-custom-elements` build, rather than `dist`. For more information
 on using the `dist-custom-elements` output for the Angular proxies, see the [FAQ answer below](#do-i-have-to-use-the-dist-output-target).
+
+### includeSingleComponentAngularModules
+
+**Optional**
+
+**Default: `false`**
+
+**Type: `boolean`**
+
+If `true`, an Angular module will be generated for each component. This option requires that `includeImportCustomElements` is set to `true`.
 
 ### valueAccessorConfigs
 

--- a/docs/framework-integration/angular.md
+++ b/docs/framework-integration/angular.md
@@ -122,7 +122,6 @@ workspace `package.json` file:
 # from `/packages/angular-workspace`
 npm uninstall jasmine-core @types/jasmine
 ```
-
 :::
 
 ### Adding the Angular Output Target

--- a/versioned_docs/version-v3.0/framework-integration/angular.md
+++ b/versioned_docs/version-v3.0/framework-integration/angular.md
@@ -415,6 +415,8 @@ on using the `dist-custom-elements` output for the Angular proxies, see the [FAQ
 
 **Type: `boolean`**
 
+**Available Since: `@stencil/angular-output-target@v0.6.0`**
+
 If `true`, an Angular module will be generated for each component. This option requires that `includeImportCustomElements` is set to `true`.
 
 ### valueAccessorConfigs

--- a/versioned_docs/version-v3.0/framework-integration/angular.md
+++ b/versioned_docs/version-v3.0/framework-integration/angular.md
@@ -407,6 +407,16 @@ first file you should import in your Angular project.
 If `true`, Angular components will import and define elements from the `dist-custom-elements` build, rather than `dist`. For more information
 on using the `dist-custom-elements` output for the Angular proxies, see the [FAQ answer below](#do-i-have-to-use-the-dist-output-target).
 
+### includeSingleComponentAngularModules
+
+**Optional**
+
+**Default: `false`**
+
+**Type: `boolean`**
+
+If `true`, an Angular module will be generated for each component. This option requires that `includeImportCustomElements` is set to `true`.
+
 ### valueAccessorConfigs
 
 **Optional**

--- a/versioned_docs/version-v3.1/framework-integration/angular.md
+++ b/versioned_docs/version-v3.1/framework-integration/angular.md
@@ -415,6 +415,8 @@ on using the `dist-custom-elements` output for the Angular proxies, see the [FAQ
 
 **Type: `boolean`**
 
+**Available Since: `@stencil/angular-output-target@v0.6.0`**
+
 If `true`, an Angular module will be generated for each component. This option requires that `includeImportCustomElements` is set to `true`.
 
 ### valueAccessorConfigs

--- a/versioned_docs/version-v3.1/framework-integration/angular.md
+++ b/versioned_docs/version-v3.1/framework-integration/angular.md
@@ -407,6 +407,16 @@ first file you should import in your Angular project.
 If `true`, Angular components will import and define elements from the `dist-custom-elements` build, rather than `dist`. For more information
 on using the `dist-custom-elements` output for the Angular proxies, see the [FAQ answer below](#do-i-have-to-use-the-dist-output-target).
 
+### includeSingleComponentAngularModules
+
+**Optional**
+
+**Default: `false`**
+
+**Type: `boolean`**
+
+If `true`, an Angular module will be generated for each component. This option requires that `includeImportCustomElements` is set to `true`.
+
 ### valueAccessorConfigs
 
 **Optional**

--- a/versioned_docs/version-v3.2/framework-integration/angular.md
+++ b/versioned_docs/version-v3.2/framework-integration/angular.md
@@ -415,6 +415,8 @@ on using the `dist-custom-elements` output for the Angular proxies, see the [FAQ
 
 **Type: `boolean`**
 
+**Available Since: `@stencil/angular-output-target@v0.6.0`**
+
 If `true`, an Angular module will be generated for each component. This option requires that `includeImportCustomElements` is set to `true`.
 
 ### valueAccessorConfigs

--- a/versioned_docs/version-v3.2/framework-integration/angular.md
+++ b/versioned_docs/version-v3.2/framework-integration/angular.md
@@ -407,6 +407,16 @@ first file you should import in your Angular project.
 If `true`, Angular components will import and define elements from the `dist-custom-elements` build, rather than `dist`. For more information
 on using the `dist-custom-elements` output for the Angular proxies, see the [FAQ answer below](#do-i-have-to-use-the-dist-output-target).
 
+### includeSingleComponentAngularModules
+
+**Optional**
+
+**Default: `false`**
+
+**Type: `boolean`**
+
+If `true`, an Angular module will be generated for each component. This option requires that `includeImportCustomElements` is set to `true`.
+
 ### valueAccessorConfigs
 
 **Optional**


### PR DESCRIPTION
Adds documentation for the `includeSingleComponentAngularModules` option of `@stencil/angular-output-target`.