### PR TITLE
docs(angular): mark includeSingleComponentAngularModules as experimental

### DIFF
--- a/docs/framework-integration/angular.md
+++ b/docs/framework-integration/angular.md
@@ -417,6 +417,8 @@ on using the `dist-custom-elements` output for the Angular proxies, see the [FAQ
 
 **Available Since: `@stencil/angular-output-target@v0.6.0`**
 
+**Experimental:** This flag and its behaviors are subject to change at any time.
+
 If `true`, an Angular module will be generated for each component. This option requires that `includeImportCustomElements` is set to `true`.
 
 ### valueAccessorConfigs

--- a/versioned_docs/version-v3.0/framework-integration/angular.md
+++ b/versioned_docs/version-v3.0/framework-integration/angular.md
@@ -417,6 +417,8 @@ on using the `dist-custom-elements` output for the Angular proxies, see the [FAQ
 
 **Available Since: `@stencil/angular-output-target@v0.6.0`**
 
+**Experimental:** This flag and its behaviors are subject to change at any time.
+
 If `true`, an Angular module will be generated for each component. This option requires that `includeImportCustomElements` is set to `true`.
 
 ### valueAccessorConfigs

--- a/versioned_docs/version-v3.1/framework-integration/angular.md
+++ b/versioned_docs/version-v3.1/framework-integration/angular.md
@@ -417,6 +417,8 @@ on using the `dist-custom-elements` output for the Angular proxies, see the [FAQ
 
 **Available Since: `@stencil/angular-output-target@v0.6.0`**
 
+**Experimental:** This flag and its behaviors are subject to change at any time.
+
 If `true`, an Angular module will be generated for each component. This option requires that `includeImportCustomElements` is set to `true`.
 
 ### valueAccessorConfigs

--- a/versioned_docs/version-v3.2/framework-integration/angular.md
+++ b/versioned_docs/version-v3.2/framework-integration/angular.md
@@ -417,6 +417,8 @@ on using the `dist-custom-elements` output for the Angular proxies, see the [FAQ
 
 **Available Since: `@stencil/angular-output-target@v0.6.0`**
 
+**Experimental:** This flag and its behaviors are subject to change at any time.
+
 If `true`, an Angular module will be generated for each component. This option requires that `includeImportCustomElements` is set to `true`.
 
 ### valueAccessorConfigs


### PR DESCRIPTION
this commit updates the entries for
`includeSingleComponentAngularModules` as experimental, and states that its behaviors are subject to change

![Screenshot 2023-03-28 at 10 31 45 AM](https://user-images.githubusercontent.com/1930213/228272628-ab8e40e4-393c-4004-ad90-b120f4e9e8ae.png)
