### PR TITLE
update documentation for the `docs-json` output target

### DIFF
--- a/docs/output-targets/docs-json.md
+++ b/docs/output-targets/docs-json.md
@@ -5,19 +5,25 @@ description: Docs JSON Output Target
 slug: /docs-json
 ---
 
-# Docs Json Data
+# Generating Documentation in JSON format
 
-While auto-generated readme files formatted with markdown is convenient, there may be scenarios where it'd be better to get all of the docs in the form of json data. To build the docs as json, use the `--docs-json` flag, followed by a path on where to write the json file.
+Stencil supports automatically [generating `README` files](./docs-readme.md) in
+your project which pull in [JSDoc comments](https://jsdoc.app/) and provide a
+straightforward way to document your components.
 
-```tsx
-  scripts: {
-    "docs.data": "stencil build --docs-json path/to/docs.json"
-  }
+If you need more flexibility, Stencil can also write documentation to a JSON
+file which you could use for a custom downstream documentation website.
+
+You can try this out is using the `--docs-json` CLI flag like so:
+
+```bash
+stencil build --docs-json path/to/docs.json
 ```
 
-Another option would be to add the `docs-json` output target to the `stencil.config.ts` in order to auto-generate this file with every build:
+You can also add the `docs-json` output target to your project's configuration
+file in order to auto-generate this file every time you build:
 
-```tsx
+```tsx title="stencil.config.ts"
 import { Config } from '@stencil/core';
 
 export const config: Config = {
@@ -30,80 +36,179 @@ export const config: Config = {
 };
 ```
 
-Check out the typescript declarations for the JSON output: https://github.com/ionic-team/stencil/blob/main/src/declarations/stencil-public-docs.ts
+The JSON file output by Stencil conforms to the [`JsonDocs` interface in
+Stencil's public TypeScript
+declarations](https://github.com/ionic-team/stencil/blob/main/src/declarations/stencil-public-docs.ts).
 
 
 ## CSS Variables
 
-Stencil will also document CSS variables when you specify them via jsdoc-style comments inside your css/scss files:
+Stencil can document CSS variables if you annotate them with JSDoc-style
+comments in your CSS/SCSS files. If, for instance, you had a component with a
+CSS file like the following:
 
-```css
-/**
- * @prop --background: Background of the button
- * @prop --background-activated: Background of the button when activated
- * @prop --background-focused: Background of the button when focused
- */
+```css title="src/components/my-button/my-button.css"
+:host {
+  /**
+   * @prop --background: Background of the button
+   * @prop --background-activated: Background of the button when activated
+   * @prop --background-focused: Background of the button when focused
+   */
+  --background: pink;
+  --background-activated: aqua;
+  --background-focused: fuchsia;
+}
 ```
 
+Then you'd get the following in the JSON output:
+
+```json
+"styles": [
+  {
+    "name": "--background",
+    "annotation": "prop",
+    "docs": "Background of the button"
+  },
+  {
+    "name": "--background-activated",
+    "annotation": "prop",
+    "docs": "Background of the button when activated"
+  },
+  {
+    "name": "--background-focused",
+    "annotation": "prop",
+    "docs": "Background of the button when focused"
+  }
+]
+```
+
+:::note
+This functionality works with both standard CSS and with Sass, although for the
+latter you'll need to have the
+[@stencil/sass](https://github.com/ionic-team/stencil-sass) plugin installed
+and configured.
+:::
 
 ## Slots
 
-Slots can be documented by adding `@slot` tags to the doc comments above the `@Component` decorator.
+If one of your Stencil components makes use of
+[slots](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot) for
+rendering children you can document them by using the `@slot` JSDoc tag in the
+component's comment.
 
-```tsx
+For instance, if you had a `my-button` component with a slot you might document
+it like so:
+
+```tsx title="src/components/my-button/my-button.tsx"
+import { Component, h } from '@stencil/core';
+
 /**
- * @slot slotName - slotDescription
  * @slot buttonContent - Slot for the content of the button
  */
- 
- @Component({
-  tag: '...'
-}) ...
+@Component({
+  tag: 'my-button',
+  styleUrl: 'my-button.css',
+  shadow: true,
+})
+export class MyButton {
+  render() {
+    return <button><slot name="buttonContent"></slot></button>
+  }
+}
 ```
+
+This would show up in the generated JSON file like so:
+
+```json
+"slots": {
+  "name": "buttonContent",
+  "docs": "Slot for the content of the button"
+}
+```
+
+:::caution
+Stencil does not check that the slots you document in a component's JSDoc
+comment using the `@slot` tag are actually present in the JSX returned by the
+component's `render` function.
+
+It is up to you as the component author to ensure the `@slot` tags on a
+component are kept up to date.
+:::
 
 
 ## Usage
 
-The content of `.md` files in a `usage` subdirectory of a component will be added to the `usage` property of the generated json.
+You can save usage examples for a component in the `usage/` subdirectory within
+that component's directory. The content of these files will be added to the
+`usage` property of the generated JSON. This allows you to keep examples right
+next to the code, making it easy to include them in a documentation site or
+other downstream consumer(s) of your docs.
 
-```bash
-src/
-  components/
-    my-component/
-      usage/
-        usage-example.md
-        another-example.md
-      my-component.css
-      my-component.tsx
+:::caution
+Stencil doesn't check that your usage examples are up-to-date! If you make any
+changes to your component's API you'll need to remember to update your usage
+examples manually.
+:::
+
+If, for instance, you had a usage example like this:
+
+````md title="src/components/my-button/usage/my-button-usage.md"
+# How to use `my-button`
+
+A button is often a great help in adding interactivity to an app!
+
+You could use it like this:
+
+```html
+<my-button>My Button!</my-button>
+```
+````
+
+
+You'd get the following in the JSON output under the `"usage"` key:
+
+```json
+"usage": {
+  "a-usage-example": "# How to use `my-button`\n\nA button is often a great help in adding interactivity to an app!\n\nYou could use it like this:\n\n```html\n<my-button>My Button!</my-button>\n```\n"
+}
 ```
 
 
 ## Custom JSDocs Tags
 
-In addition to reading the predefined JSDoc tags, users can provide their own custom tags which also get included in the JSON data. This makes it easier for teams to provide their own documentation and conventions to get built within the JSON data. For example, if we added a comment into our source code like this:
+In addition to reading the [standard JSDoc tags](https://jsdoc.app/), users can
+use their own custom tags which will be included in the JSON data without any
+configuration.
+
+This can be useful if your team has your own documentation conventions which you'd like to stick with.
+
+If, for example, we had a component with custom JSDoc tags like this:
 
 ```tsx
+import { Component, h } from '@stencil/core';
+
 /**
- * @myDocTag someName - some value
- * @myOtherDocTag someOtherName - some other name
+ * @customDescription This is just the best button around!
  */
- 
 @Component({
-  tag: '...'
-}) ...
+  tag: 'my-button',
+  styleUrl: 'my-button.css',
+  shadow: true,
+})
+export class MyButton {
+  render() {
+    return <button><slot name="buttonContent"></slot></button>
+  }
+}
 ```
 
 It would end up in the JSON data like this:
 
-```tsx
+```json
 "docsTags": [
   {
-    "text": "someName - some value",
-    "name": "myDocTag"
-  },
-  {
-    "text": "someOtherName - some other name",
-    "name": "myOtherDocTag"
+    "name": "customDescription",
+    "text": "This is just the best button around!"
   }
 ],
 ```

--- a/versioned_docs/version-v3.2/output-targets/docs-json.md
+++ b/versioned_docs/version-v3.2/output-targets/docs-json.md
@@ -5,19 +5,25 @@ description: Docs JSON Output Target
 slug: /docs-json
 ---
 
-# Docs Json Data
+# Generating Documentation in JSON format
 
-While auto-generated readme files formatted with markdown is convenient, there may be scenarios where it'd be better to get all of the docs in the form of json data. To build the docs as json, use the `--docs-json` flag, followed by a path on where to write the json file.
+Stencil supports automatically [generating `README` files](./docs-readme.md) in
+your project which pull in [JSDoc comments](https://jsdoc.app/) and provide a
+straightforward way to document your components.
 
-```tsx
-  scripts: {
-    "docs.data": "stencil build --docs-json path/to/docs.json"
-  }
+If you need more flexibility, Stencil can also write documentation to a JSON
+file which you could use for a custom downstream documentation website.
+
+You can try this out is using the `--docs-json` CLI flag like so:
+
+```bash
+stencil build --docs-json path/to/docs.json
 ```
 
-Another option would be to add the `docs-json` output target to the `stencil.config.ts` in order to auto-generate this file with every build:
+You can also add the `docs-json` output target to your project's configuration
+file in order to auto-generate this file every time you build:
 
-```tsx
+```tsx title="stencil.config.ts"
 import { Config } from '@stencil/core';
 
 export const config: Config = {
@@ -30,80 +36,179 @@ export const config: Config = {
 };
 ```
 
-Check out the typescript declarations for the JSON output: https://github.com/ionic-team/stencil/blob/main/src/declarations/stencil-public-docs.ts
+The JSON file output by Stencil conforms to the [`JsonDocs` interface in
+Stencil's public TypeScript
+declarations](https://github.com/ionic-team/stencil/blob/main/src/declarations/stencil-public-docs.ts).
 
 
 ## CSS Variables
 
-Stencil will also document CSS variables when you specify them via jsdoc-style comments inside your css/scss files:
+Stencil can document CSS variables if you annotate them with JSDoc-style
+comments in your CSS/SCSS files. If, for instance, you had a component with a
+CSS file like the following:
 
-```css
-/**
- * @prop --background: Background of the button
- * @prop --background-activated: Background of the button when activated
- * @prop --background-focused: Background of the button when focused
- */
+```css title="src/components/my-button/my-button.css"
+:host {
+  /**
+   * @prop --background: Background of the button
+   * @prop --background-activated: Background of the button when activated
+   * @prop --background-focused: Background of the button when focused
+   */
+  --background: pink;
+  --background-activated: aqua;
+  --background-focused: fuchsia;
+}
 ```
 
+Then you'd get the following in the JSON output:
+
+```json
+"styles": [
+  {
+    "name": "--background",
+    "annotation": "prop",
+    "docs": "Background of the button"
+  },
+  {
+    "name": "--background-activated",
+    "annotation": "prop",
+    "docs": "Background of the button when activated"
+  },
+  {
+    "name": "--background-focused",
+    "annotation": "prop",
+    "docs": "Background of the button when focused"
+  }
+]
+```
+
+:::note
+This functionality works with both standard CSS and with Sass, although for the
+latter you'll need to have the
+[@stencil/sass](https://github.com/ionic-team/stencil-sass) plugin installed
+and configured.
+:::
 
 ## Slots
 
-Slots can be documented by adding `@slot` tags to the doc comments above the `@Component` decorator.
+If one of your Stencil components makes use of
+[slots](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot) for
+rendering children you can document them by using the `@slot` JSDoc tag in the
+component's comment.
 
-```tsx
+For instance, if you had a `my-button` component with a slot you might document
+it like so:
+
+```tsx title="src/components/my-button/my-button.tsx"
+import { Component, h } from '@stencil/core';
+
 /**
- * @slot slotName - slotDescription
  * @slot buttonContent - Slot for the content of the button
  */
- 
- @Component({
-  tag: '...'
-}) ...
+@Component({
+  tag: 'my-button',
+  styleUrl: 'my-button.css',
+  shadow: true,
+})
+export class MyButton {
+  render() {
+    return <button><slot name="buttonContent"></slot></button>
+  }
+}
 ```
+
+This would show up in the generated JSON file like so:
+
+```json
+"slots": {
+  "name": "buttonContent",
+  "docs": "Slot for the content of the button"
+}
+```
+
+:::caution
+Stencil does not check that the slots you document in a component's JSDoc
+comment using the `@slot` tag are actually present in the JSX returned by the
+component's `render` function.
+
+It is up to you as the component author to ensure the `@slot` tags on a
+component are kept up to date.
+:::
 
 
 ## Usage
 
-The content of `.md` files in a `usage` subdirectory of a component will be added to the `usage` property of the generated json.
+You can save usage examples for a component in the `usage/` subdirectory within
+that component's directory. The content of these files will be added to the
+`usage` property of the generated JSON. This allows you to keep examples right
+next to the code, making it easy to include them in a documentation site or
+other downstream consumer(s) of your docs.
 
-```bash
-src/
-  components/
-    my-component/
-      usage/
-        usage-example.md
-        another-example.md
-      my-component.css
-      my-component.tsx
+:::caution
+Stencil doesn't check that your usage examples are up-to-date! If you make any
+changes to your component's API you'll need to remember to update your usage
+examples manually.
+:::
+
+If, for instance, you had a usage example like this:
+
+````md title="src/components/my-button/usage/my-button-usage.md"
+# How to use `my-button`
+
+A button is often a great help in adding interactivity to an app!
+
+You could use it like this:
+
+```html
+<my-button>My Button!</my-button>
+```
+````
+
+
+You'd get the following in the JSON output under the `"usage"` key:
+
+```json
+"usage": {
+  "a-usage-example": "# How to use `my-button`\n\nA button is often a great help in adding interactivity to an app!\n\nYou could use it like this:\n\n```html\n<my-button>My Button!</my-button>\n```\n"
+}
 ```
 
 
 ## Custom JSDocs Tags
 
-In addition to reading the predefined JSDoc tags, users can provide their own custom tags which also get included in the JSON data. This makes it easier for teams to provide their own documentation and conventions to get built within the JSON data. For example, if we added a comment into our source code like this:
+In addition to reading the [standard JSDoc tags](https://jsdoc.app/), users can
+use their own custom tags which will be included in the JSON data without any
+configuration.
+
+This can be useful if your team has your own documentation conventions which you'd like to stick with.
+
+If, for example, we had a component with custom JSDoc tags like this:
 
 ```tsx
+import { Component, h } from '@stencil/core';
+
 /**
- * @myDocTag someName - some value
- * @myOtherDocTag someOtherName - some other name
+ * @customDescription This is just the best button around!
  */
- 
 @Component({
-  tag: '...'
-}) ...
+  tag: 'my-button',
+  styleUrl: 'my-button.css',
+  shadow: true,
+})
+export class MyButton {
+  render() {
+    return <button><slot name="buttonContent"></slot></button>
+  }
+}
 ```
 
 It would end up in the JSON data like this:
 
-```tsx
+```json
 "docsTags": [
   {
-    "text": "someName - some value",
-    "name": "myDocTag"
-  },
-  {
-    "text": "someOtherName - some other name",
-    "name": "myOtherDocTag"
+    "name": "customDescription",
+    "text": "This is just the best button around!"
   }
 ],
 ```


### PR DESCRIPTION
This updates the documentation for the `docs-json` output target, making the following changes:

- most of the prose is rewritten for clarity and readability (or subjectively what I find clearer)
- code blocks have filename titles added
- example components are fleshed out to more fully show the context
- a few 'caution' notes are added to explain potentially tricky behavior
- some more example JSON output is shown throughout