### PR TITLE
fill out table for docs-custom

### DIFF
--- a/docs/output-targets/docs-custom.md
+++ b/docs/output-targets/docs-custom.md
@@ -55,21 +55,21 @@ The generated docs JSON data will in the type of `JsonDocs` which consists of ma
 | `fileName`    | File name |
 | `filePath`    | File path |
 | `readmePath`    | Readme file path |
-| `usagesDir`    | Usages directory path  |
+| `usagesDir`    | Stencil looks in a directory named `usages/` in the same directory as your component to find usage examples. This holds the full path to that directory. |
 | `encapsulation`    | Component `encapsulation` type. Possible values are `shadow`, `scoped`, `none`  |
 | `tag`    | Component tag described in `.tsx` file  |
 | `readme`    | Component readme file first line content  |
 | `docs`    | Description written in top of `@Component` e.g. /**  Documentation Example */. If no JSDoc is present, default to any manually written text in the component's markdown file. Empty otherwise. |
 | `docsTags`    | Annotations (In the way of JSDoc ) written in `.tsx` file will be collected here   |
 | `overview`    | Description written in top of `@Component` e.g. /**  Documentation Example */ |
-| `usage`    |    |
+| `usage`    | Array of [usage examples](./docs-json.md#usage), written in Markdown files in the `usages/` directory adjacent to your component. |
 | `props`    | Array of component properties information   |
 | `methods`    | Array of component methods information   |
-| `events`    |    |
-| `listeners`    |    |
-| `styles`    |    |
-| `slots`    |    |
-| `parts`    |    |
+| `events`    | Array of objects with metadata about component events.   |
+| `listeners`    | Array of objects with metadata about component listeners.   |
+| `styles`    | Array of objects documenting annotated [CSS variables](./docs-json.md#css-variables) used in the current component's CSS. |
+| `slots`    | Array of objects documenting [slots](./docs-json.md#slots) which are tagged with `@slot` in the current component's JSDoc comment. |
+| `parts`    |  Array of objects derived from `@part` tags in the current component's JSDoc comment. |
 | `dependents`    |  Array of components where current component is used  |
 | `dependencies`    |  Array of components which is used in current component  |
 | `dependencyGraph`    | Describes a tree of components coupling |

--- a/docs/output-targets/docs-custom.md
+++ b/docs/output-targets/docs-custom.md
@@ -62,11 +62,11 @@ The generated docs JSON data will in the type of `JsonDocs` which consists of ma
 | `docs`    | Description written in top of `@Component` e.g. /**  Documentation Example */. If no JSDoc is present, default to any manually written text in the component's markdown file. Empty otherwise. |
 | `docsTags`    | Annotations (In the way of JSDoc ) written in `.tsx` file will be collected here   |
 | `overview`    | Description written in top of `@Component` e.g. /**  Documentation Example */ |
-| `usage`    | Array of [usage examples](./docs-json.md#usage), written in Markdown files in the `usages/` directory adjacent to your component. |
-| `props`    | Array of component properties information   |
-| `methods`    | Array of component methods information   |
-| `events`    | Array of objects with metadata about component events.   |
-| `listeners`    | Array of objects with metadata about component listeners.   |
+| `usage`    | Array of [usage examples](./docs-json.md#usage), written in Markdown files in the `usages/` directory adjacent to the current component. |
+| `props`    | Array of metadata objects for each usage of the [`@Prop` decorator](../components/properties.md#the-prop-decorator-prop) on the current component. |
+| `methods`    | Array of metadata objects for each usage of the [`@Method` decorator](../components/methods.md) on the current component.  | 
+| `events`    | Array of metadata objects for each usage of the [`@Event` decorator](../components/events.md#event-decorator) on the current component. |
+| `listeners`    | Array of metadata objects for each usage of the [`@Listen` decorator](../components/events.md#listen-decorator) on the current component. |
 | `styles`    | Array of objects documenting annotated [CSS variables](./docs-json.md#css-variables) used in the current component's CSS. |
 | `slots`    | Array of objects documenting [slots](./docs-json.md#slots) which are tagged with `@slot` in the current component's JSDoc comment. |
 | `parts`    |  Array of objects derived from `@part` tags in the current component's JSDoc comment. |

--- a/versioned_docs/version-v3.2/output-targets/docs-custom.md
+++ b/versioned_docs/version-v3.2/output-targets/docs-custom.md
@@ -55,21 +55,21 @@ The generated docs JSON data will in the type of `JsonDocs` which consists of ma
 | `fileName`    | File name |
 | `filePath`    | File path |
 | `readmePath`    | Readme file path |
-| `usagesDir`    | Usages directory path  |
+| `usagesDir`    | Stencil looks in a directory named `usages/` in the same directory as your component to find usage examples. This holds the full path to that directory. |
 | `encapsulation`    | Component `encapsulation` type. Possible values are `shadow`, `scoped`, `none`  |
 | `tag`    | Component tag described in `.tsx` file  |
 | `readme`    | Component readme file first line content  |
 | `docs`    | Description written in top of `@Component` e.g. /**  Documentation Example */. If no JSDoc is present, default to any manually written text in the component's markdown file. Empty otherwise. |
 | `docsTags`    | Annotations (In the way of JSDoc ) written in `.tsx` file will be collected here   |
 | `overview`    | Description written in top of `@Component` e.g. /**  Documentation Example */ |
-| `usage`    |    |
-| `props`    | Array of component properties information   |
-| `methods`    | Array of component methods information   |
-| `events`    |    |
-| `listeners`    |    |
-| `styles`    |    |
-| `slots`    |    |
-| `parts`    |    |
+| `usage`    | Array of [usage examples](./docs-json.md#usage), written in Markdown files in the `usages/` directory adjacent to the current component. |
+| `props`    | Array of metadata objects for each usage of the [`@Prop` decorator](../components/properties.md#the-prop-decorator-prop) on the current component. |
+| `methods`    | Array of metadata objects for each usage of the [`@Method` decorator](../components/methods.md) on the current component.  | 
+| `events`    | Array of metadata objects for each usage of the [`@Event` decorator](../components/events.md#event-decorator) on the current component. |
+| `listeners`    | Array of metadata objects for each usage of the [`@Listen` decorator](../components/events.md#listen-decorator) on the current component. |
+| `styles`    | Array of objects documenting annotated [CSS variables](./docs-json.md#css-variables) used in the current component's CSS. |
+| `slots`    | Array of objects documenting [slots](./docs-json.md#slots) which are tagged with `@slot` in the current component's JSDoc comment. |
+| `parts`    |  Array of objects derived from `@part` tags in the current component's JSDoc comment. |
 | `dependents`    |  Array of components where current component is used  |
 | `dependencies`    |  Array of components which is used in current component  |
 | `dependencyGraph`    | Describes a tree of components coupling |


### PR DESCRIPTION
This fills out the table describing the shape of the `JsonDocsComponent` type on the page for custom docs. I added links over to the updated JSON documentation page where appropriate.