### PR TITLE
docs(docs): update sidebar

### DIFF
--- a/docs/documentation-generation/docs-custom.md
+++ b/docs/documentation-generation/docs-custom.md
@@ -1,7 +1,7 @@
 ---
 title: Custom Docs Generation
-sidebar_label: docs-custom
-description: Custom Docs Generation
+sidebar_label: Custom Docs (docs-custom)
+description: Custom Docs
 slug: /docs-custom
 ---
 

--- a/docs/documentation-generation/docs-json.md
+++ b/docs/documentation-generation/docs-json.md
@@ -1,7 +1,7 @@
 ---
 title: Docs JSON Data Output Target
-sidebar_label: docs-json
-description: Docs JSON Output Target
+sidebar_label: JSON Docs (docs-json)
+description: JSON Docs
 slug: /docs-json
 ---
 

--- a/docs/documentation-generation/docs-readme.md
+++ b/docs/documentation-generation/docs-readme.md
@@ -1,7 +1,7 @@
 ---
 title: Docs Readme Auto-Generation
-sidebar_label: docs-readme
-description: Docs Readme Auto-Generation
+sidebar_label: README Docs (docs-readme)
+description: README Docs
 slug: /docs-readme
 ---
 

--- a/docs/documentation-generation/docs-stats.md
+++ b/docs/documentation-generation/docs-stats.md
@@ -1,7 +1,7 @@
 ---
 title: Docs Stats Auto-Generation
-sidebar_label: stats
-description: Docs Stats Auto-Generation
+sidebar_label: Stats (stats)
+description: Stats Generation
 slug: /stats
 ---
 

--- a/docs/documentation-generation/docs-vscode.md
+++ b/docs/documentation-generation/docs-vscode.md
@@ -1,5 +1,6 @@
 ---
 title: VS Code Documentation
+sidebar_label: VS Code (docs-vscode)
 description: VS Code Documentation
 slug: /docs-vscode
 ---

--- a/versioned_docs/version-v3.2/documentation-generation/docs-custom.md
+++ b/versioned_docs/version-v3.2/documentation-generation/docs-custom.md
@@ -1,7 +1,7 @@
 ---
 title: Custom Docs Generation
-sidebar_label: docs-custom
-description: Custom Docs Generation
+sidebar_label: Custom Docs (docs-custom)
+description: Custom Docs
 slug: /docs-custom
 ---
 

--- a/versioned_docs/version-v3.2/documentation-generation/docs-json.md
+++ b/versioned_docs/version-v3.2/documentation-generation/docs-json.md
@@ -1,7 +1,7 @@
 ---
 title: Docs JSON Data Output Target
-sidebar_label: docs-json
-description: Docs JSON Output Target
+sidebar_label: JSON Docs (docs-json)
+description: JSON Docs
 slug: /docs-json
 ---
 

--- a/versioned_docs/version-v3.2/documentation-generation/docs-readme.md
+++ b/versioned_docs/version-v3.2/documentation-generation/docs-readme.md
@@ -1,7 +1,7 @@
 ---
 title: Docs Readme Auto-Generation
-sidebar_label: docs-readme
-description: Docs Readme Auto-Generation
+sidebar_label: README Docs (docs-readme)
+description: README Docs
 slug: /docs-readme
 ---
 

--- a/versioned_docs/version-v3.2/documentation-generation/docs-stats.md
+++ b/versioned_docs/version-v3.2/documentation-generation/docs-stats.md
@@ -1,7 +1,7 @@
 ---
 title: Docs Stats Auto-Generation
-sidebar_label: stats
-description: Docs Stats Auto-Generation
+sidebar_label: Stats (stats)
+description: Stats Generation
 slug: /stats
 ---
 

--- a/versioned_docs/version-v3.2/documentation-generation/docs-vscode.md
+++ b/versioned_docs/version-v3.2/documentation-generation/docs-vscode.md
@@ -1,5 +1,6 @@
 ---
 title: VS Code Documentation
+sidebar_label: VS Code (docs-vscode)
 description: VS Code Documentation
 slug: /docs-vscode
 ---


### PR DESCRIPTION
this commit updates the sidebar titles for the docs-* output targets, as
well as updating additional metadata for docusaurus for consistency
![Screenshot 2023-04-28 at 4 12 18 PM](https://user-images.githubusercontent.com/1930213/235244621-4ffb4411-a58e-4f49-9769-99469b4d66a2.png)

**EDIT**: @tanner-reits has given an initial sign off, I'll propagate this to v3.2 now, and if we need to change anything I'll just change it in both place

