### PR TITLE
docs(testing): update browserHeadless description

### DIFF
--- a/docs/testing/config.md
+++ b/docs/testing/config.md
@@ -61,7 +61,24 @@ export interface TestingConfig extends JestConfig {
   browserExecutablePath?: string;
 
   /**
-   * Whether to run browser e2e tests in headless mode. Defaults to true.
+   * Whether to run browser e2e tests in headless mode. 
+   * 
+   * `headless` is an argument passed through to Puppeteer (which is passed to Chrome) for
+   * end-to-end testing. Prior to Chrome v112, `headless` was treated like a boolean flag.
+   * Starting with Chrome v112, 'new' is an accepted option to support Chrome's new
+   * headless mode.
+   * 
+   * The following values are accepted:
+   * - "new" - enables the "new" headless mode, starting with Chrome 112
+   * - `true` - enables the "old" headless mode, prior to Chrome 112
+   * - `false` - enables the "headful" mode
+   * 
+   * Stencil will default to `true` (the old headless mode) if no value is provided.
+   * 
+   * In the future, Chrome will enable the new headless mode by default, even when `true`
+   * is provided.
+   *
+   * {@see https://developer.chrome.com/articles/new-headless/}
    */
   browserHeadless?: boolean;
 


### PR DESCRIPTION
this commit updates the description of `browserHeadless` to account for the changes made in https://github.com/ionic-team/stencil/pull/4356

![Screenshot 2023-05-04 at 4 13 54 PM](https://user-images.githubusercontent.com/1930213/236319256-ca8b4074-49a2-4a40-a696-0aa3baa14d9c.png)

Note: These changes only exist in `next`, as this change will occur in Stencil 3.3