### PR TITLE
docs: fix typo for attribute 'my-service' in properties.md.

### DIFF
--- a/docs/components/properties.md
+++ b/docs/components/properties.md
@@ -746,7 +746,7 @@ By using this option, we are being explicit about which properties have an assoc
 when using the component in HTML.
 
 ```html
-<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" http-service="{}"></my-cmp>
+<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></my-cmp>
 ```
 
 ### Prop Mutability (`mutable`)

--- a/versioned_docs/version-v3.2/components/properties.md
+++ b/versioned_docs/version-v3.2/components/properties.md
@@ -746,7 +746,7 @@ By using this option, we are being explicit about which properties have an assoc
 when using the component in HTML.
 
 ```html
-<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" http-service="{}"></my-cmp>
+<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></my-cmp>
 ```
 
 ### Prop Mutability (`mutable`)


### PR DESCRIPTION
Changed attribute from 'http-service' to 'my-service' in sample code for HTML. 

As the attribute name was specified as "my-service" in the Prop decorator. Copied below:

```
export class ToDoListItem {
   ...
   @Prop({ attribute: 'my-service' }) httpService: MyHttpService;
}
```