### PR TITLE
chore(testing): add double dash to command

### DIFF
--- a/docs/testing/01-overview.md
+++ b/docs/testing/01-overview.md
@@ -108,7 +108,7 @@ To use the below configuration:
       "name": "E2E Test Current File",
       "cwd": "${workspaceFolder}",
       "program": "${workspaceFolder}/node_modules/.bin/stencil",
-      "args": ["test", "--e2e", "--maxWorkers=0", "${fileBasename}"],
+      "args": ["test", "--e2e", "--", "--maxWorkers=0", "${fileBasename}"],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"
     },
@@ -118,7 +118,7 @@ To use the below configuration:
       "name": "Spec Test Current File",
       "cwd": "${workspaceFolder}",
       "program": "${workspaceFolder}/node_modules/.bin/stencil",
-      "args": ["test", "--spec", "${fileBasename}"],
+      "args": ["test", "--spec", "--", "${fileBasename}"],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"
     }

--- a/versioned_docs/version-v3.2/testing/01-overview.md
+++ b/versioned_docs/version-v3.2/testing/01-overview.md
@@ -108,7 +108,7 @@ To use the below configuration:
       "name": "E2E Test Current File",
       "cwd": "${workspaceFolder}",
       "program": "${workspaceFolder}/node_modules/.bin/stencil",
-      "args": ["test", "--e2e", "--maxWorkers=0", "${fileBasename}"],
+      "args": ["test", "--e2e", "--", "--maxWorkers=0", "${fileBasename}"],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"
     },
@@ -118,7 +118,7 @@ To use the below configuration:
       "name": "Spec Test Current File",
       "cwd": "${workspaceFolder}",
       "program": "${workspaceFolder}/node_modules/.bin/stencil",
-      "args": ["test", "--spec", "${fileBasename}"],
+      "args": ["test", "--spec", "--", "${fileBasename}"],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"
     }


### PR DESCRIPTION
this commit updates the docs to add a double dash to the command used in vscode configs.

![Screenshot 2023-05-15 at 4 07 14 PM](https://github.com/ionic-team/stencil-site/assets/1930213/cb3fae99-f772-4ce6-af0d-53fa1e2fd538)
