### PR TITLE
docs(output-targets): enabling & configuring target validation

### DIFF
--- a/docs/config/01-overview.md
+++ b/docs/config/01-overview.md
@@ -319,3 +319,10 @@ export function util(arg) {
 import { UtilInterface } from '../path/to/utils';
 export declare function util(arg: UtilInterface): void;
 ```
+
+## validatePrimaryPackageOutputTarget
+
+*default: `false`*
+
+When `true`, validation for common `package.json` fields will occur based on setting an output target's `isPrimaryPackageOutputTarget` flag.
+For more information on package validation, please see the [output target docs](../output-targets/01-overview.md#primary-package-output-target-validation).

--- a/docs/output-targets/01-overview.md
+++ b/docs/output-targets/01-overview.md
@@ -52,3 +52,37 @@ In the example below there are two script tags, however, only one of them will b
 As of Stencil v3, legacy browser support is deprecated, and will be removed in a future major version of Stencil.
 :::
 
+## Primary Package Output Target Validation
+
+If `validatePrimaryPackageOutputTarget: true` is set in your project's [Stencil config](../config/01-overview.md#validateprimarypackageoutputtarget) Stencil will
+attempt to validate certain fields in your `package.json` that correspond with the generated distribution code. Because Stencil can output many different formats
+from a single project, it can only validate that the `package.json` has field values that align with one of the specified output targets in your project's config.
+So, Stencil allows you to designate which output target should be used for this validation and thus which will be the default distribution when bundling you
+project. 
+
+This behavior only affects a small subset of output targets so a flag exists on the following targets that are eligible for this level of validation: `dist`, `dist-types`,
+`dist-collection`, and `dist-custom-elements`. For any of these output targets, you can configure the target to be validated as follows:
+
+```ts title='stencil.config.ts'
+import { Config } from '@stencil/core';
+
+export const config: Config = {
+  ...,
+  outputTargets: [
+    {
+      type: 'dist',
+      // This flag is what tells Stencil to use this target for validation
+      isPrimaryPackageOutputTarget: true,
+      ...
+    },
+    ...
+  ],
+  // If this is not set, Stencil will not validate any targets
+  validatePrimaryPackageOutputTarget: true,
+};
+```
+
+:::note
+Stencil can only validate one of these output targets for your build. If multiple output targets are marked for validation, Stencil will use
+the first designated target in the array and ignore all others.
+:::

--- a/docs/output-targets/custom-elements.md
+++ b/docs/output-targets/custom-elements.md
@@ -115,6 +115,13 @@ _default: `false`_
 
 Setting this flag to `true` will include [global scripts](../config/01-overview.md#globalscript) in the bundle and execute them once the bundle entry point in loaded.
 
+### isPrimaryPackageOutputTarget
+
+_default: `false`_
+
+If `true`, this output target will be used to validate `package.json` fields for your project's distribution. See the overview of [primary package output target validation](./01-overview.md#primary-package-output-target-validation)
+for more information.
+
 ### minify
 
 _default: `false`_

--- a/docs/output-targets/dist.md
+++ b/docs/output-targets/dist.md
@@ -28,6 +28,12 @@ Luckily, both builds can be generated at the same time, and shipped in the same 
 
 ## Config
 
+### collectionDir
+
+The `collectionDir` config specifies the output directory within the [distribution directory](#dir) where the transpiled output of Stencil components will be written.
+
+This option defaults to `collection` when omitted from a Stencil configuration file.
+
 ### dir
 
 The `dir` config specifies the public distribution directory. This directory is commonly the `dist` directory found within [npm packages](https://docs.npmjs.com/getting-started/packages). This directory is built and rebuilt directly from the source files. Additionally, since this is a build target, all files will be deleted and rebuilt after each build, so it's best to always copy source files into this directory. It's recommended that this directory not be committed to a repository.
@@ -40,11 +46,12 @@ By default, before each build the `dir` directory will be emptied of all files. 
 
 This flag defaults to `true` when omitted from a Stencil configuration file.
 
-### collectionDir
+### isPrimaryPackageOutputTarget
 
-The `collectionDir` config specifies the output directory within the [distribution directory](#dir) where the transpiled output of Stencil components will be written.
+_default: `false`_
 
-This option defaults to `collection` when omitted from a Stencil configuration file.
+If `true`, this output target will be used to validate `package.json` fields for your project's distribution. See the overview of [primary package output target validation](./01-overview.md#primary-package-output-target-validation)
+for more information.
 
 ### transformAliasedImportPathsInCollection
 

--- a/versioned_docs/version-v3.4/config/01-overview.md
+++ b/versioned_docs/version-v3.4/config/01-overview.md
@@ -319,3 +319,10 @@ export function util(arg) {
 import { UtilInterface } from '../path/to/utils';
 export declare function util(arg: UtilInterface): void;
 ```
+
+## validatePrimaryPackageOutputTarget
+
+*default: `false`*
+
+When `true`, validation for common `package.json` fields will occur based on setting an output target's `isPrimaryPackageOutputTarget` flag.
+For more information on package validation, please see the [output target docs](../output-targets/01-overview.md#primary-package-output-target-validation).

--- a/versioned_docs/version-v3.4/output-targets/01-overview.md
+++ b/versioned_docs/version-v3.4/output-targets/01-overview.md
@@ -52,3 +52,36 @@ In the example below there are two script tags, however, only one of them will b
 As of Stencil v3, legacy browser support is deprecated, and will be removed in a future major version of Stencil.
 :::
 
+## Primary Package Output Target Validation
+
+If `validatePrimaryPackageOutputTarget: true` is set in your project's [Stencil config](../config/01-overview.md#validateprimarypackageoutputtarget) Stencil will
+attempt to validate certain fields in your `package.json` that correspond with the generated distribution code. Because Stencil can output many different formats
+from a single project, it can only validate that the `package.json` has field values that align with one of the specified output targets in your project's config.
+So, Stencil allows you to designate which output target should be used for this validation and thus which will be the default distribution when bundling you
+project. 
+
+This behavior only affects a small subset of output targets so a flag exists on the following targets that are eligible for this level of validation: `dist`, `dist-types`,
+`dist-collection`, and `dist-custom-elements`. For any of these output targets, you can configure the target to be validated as follows:
+
+```ts title='stencil.config.ts'
+import { Config } from '@stencil/core';
+export const config: Config = {
+  ...,
+  outputTargets: [
+    {
+      type: 'dist',
+      // This flag is what tells Stencil to use this target for validation
+      isPrimaryPackageOutputTarget: true,
+      ...
+    },
+    ...
+  ],
+  // If this is not set, Stencil will not validate any targets
+  validatePrimaryPackageOutputTarget: true,
+};
+```
+
+:::note
+Stencil can only validate one of these output targets for your build. If multiple output targets are marked for validation, Stencil will use
+the first designated target in the array and ignore all others.
+:::

--- a/versioned_docs/version-v3.4/output-targets/custom-elements.md
+++ b/versioned_docs/version-v3.4/output-targets/custom-elements.md
@@ -115,6 +115,13 @@ _default: `false`_
 
 Setting this flag to `true` will include [global scripts](../config/01-overview.md#globalscript) in the bundle and execute them once the bundle entry point in loaded.
 
+### isPrimaryPackageOutputTarget
+
+_default: `false`_
+
+If `true`, this output target will be used to validate `package.json` fields for your project's distribution. See the overview of [primary package output target validation](./01-overview.md#primary-package-output-target-validation)
+for more information.
+
 ### minify
 
 _default: `false`_

--- a/versioned_docs/version-v3.4/output-targets/dist.md
+++ b/versioned_docs/version-v3.4/output-targets/dist.md
@@ -28,6 +28,12 @@ Luckily, both builds can be generated at the same time, and shipped in the same 
 
 ## Config
 
+### collectionDir
+
+The `collectionDir` config specifies the output directory within the [distribution directory](#dir) where the transpiled output of Stencil components will be written.
+
+This option defaults to `collection` when omitted from a Stencil configuration file.
+
 ### dir
 
 The `dir` config specifies the public distribution directory. This directory is commonly the `dist` directory found within [npm packages](https://docs.npmjs.com/getting-started/packages). This directory is built and rebuilt directly from the source files. Additionally, since this is a build target, all files will be deleted and rebuilt after each build, so it's best to always copy source files into this directory. It's recommended that this directory not be committed to a repository.
@@ -40,11 +46,12 @@ By default, before each build the `dir` directory will be emptied of all files. 
 
 This flag defaults to `true` when omitted from a Stencil configuration file.
 
-### collectionDir
+### isPrimaryPackageOutputTarget
 
-The `collectionDir` config specifies the output directory within the [distribution directory](#dir) where the transpiled output of Stencil components will be written.
+_default: `false`_
 
-This option defaults to `collection` when omitted from a Stencil configuration file.
+If `true`, this output target will be used to validate `package.json` fields for your project's distribution. See the overview of [primary package output target validation](./01-overview.md#primary-package-output-target-validation)
+for more information.
 
 ### transformAliasedImportPathsInCollection
 


### PR DESCRIPTION
Adds documentation for the multi-target field validation. This does _not_ need to be propagated to versioned docs since this behavior will only be available starting in v3.3

**NOTE:** this is pending the open PR in the Stencil repo and any potential changes that will be made there.