### PR TITLE
chore(node): use node 20 for development

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -11,9 +11,10 @@ jobs:
     steps:
     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
 
-    - name: setup node
+    - name: Use Node from Volta
       uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
       with:
+        node-version-file: 'package.json'
         cache: 'npm'
 
     - name: install dependencies

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "prettier": "@ionic/prettier-config",
   "volta": {
-    "node": "18.14.2",
-    "npm": "9.5.0"
+    "node": "20.2.0",
+    "npm": "9.6.6"
   }
 }


### PR DESCRIPTION
this pr bumps the version of node used in the project to v20. it also updates the setup node step in ci to ensure that the version of node used is pulled from the `volta` key in `package.json`