### PR TITLE
docs(config): update updating guide for transformAliasedImportPaths

### DIFF
--- a/docs/config/01-overview.md
+++ b/docs/config/01-overview.md
@@ -293,7 +293,7 @@ Please see the [testing config docs](../testing/config.md).
 
 ## transformAliasedImportPaths
 
-*default: `false`*
+*default: `true`*
 
 This sets whether or not Stencil should transform [path aliases](
 https://www.typescriptlang.org/docs/handbook/module-resolution.html#path-mapping) set
@@ -330,8 +330,7 @@ export function util(arg: UtilInterface) {
 }
 ```
 
-if the `transformAliasedImportPaths` option is set to `true` Stencil will
-produce the following output:
+Stencil will produce the following output:
 
 ```js title="dist/my-module.js"
 import { utilFunc } from '../path/to/utils';

--- a/docs/introduction/upgrading-to-stencil-four.md
+++ b/docs/introduction/upgrading-to-stencil-four.md
@@ -24,8 +24,84 @@ For breaking changes introduced in previous major versions of the library, see:
 
 For projects that are on Stencil v3, install the latest version of Stencil v4: `npm install @stencil/core@v4-next`
 
+
 ## Updating Your Code
 
+### New Configuration Defaults
+Starting with Stencil v4.0.0, the default configuration values have changed for a few configuration options.
+The following sections lay out the configuration options that have changed, their new default values, and ways to opt-out of the new behavior (if applicable).
+
+#### `transformAliasedImportPaths`
+
+TypeScript projects have the ability to specify a path aliases via the [`paths` configuration in their `tsconfig.json`](https://www.typescriptlang.org/docs/handbook/module-resolution.html#path-mapping) like so:
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@utils": ["src/utils/index.ts"]
+    }
+  }
+}
+```
+In the example above, `"@utils"` would be mapped to the string `"src/utils/index.ts"` when TypeScript performs type resolution.
+The TypeScript compiler does not however, transform these paths from their keys to their values as a part of its output.
+Instead, it relies on a bundler/loader to do the transformation.
+
+The ability to transform path aliases was introduced in [Stencil v3.1.0](https://github.com/ionic-team/stencil/releases/tag/v3.1.0) as an opt-in feature.
+Previously, users had to explicitly enable this functionality in their `stencil.config.ts` file with `transformAliasedImportPaths`:
+```ts title="stencil.config.ts - enabling 'transformAliasedImportPaths' in Stencil v3.1.0"
+import { Config } from '@stencil/core';
+
+export const config: Config = {
+  transformAliasedImportPaths: true,
+  // ...
+};
+```
+
+Starting with Stencil v4.0.0, this feature is enabled by default.
+Projects that had previously enabled this functionality that are migrating from Stencil v3.1.0+ may safely remove the flag from their Stencil configuration file(s).
+
+For users that run into issues with this new default, we encourage you to file a [new issue on the Stencil GitHub repo](https://github.com/ionic-team/stencil/issues/new?assignees=&labels=&projects=&template=bug_report.yml&title=bug%3A+).
+As a workaround, this flag can be set to `false` to disable the default functionality.
+```ts title="stencil.config.ts - disabling 'transformAliasedImportPaths' in Stencil v4.0.0"
+import { Config } from '@stencil/core';
+
+export const config: Config = {
+  transformAliasedImportPaths: false,
+  // ...
+};
+```
+
+For more information on this flag, please see the [configuration documentation](../config/01-overview.md#transformaliasedimportpaths)
+
+#### `transformAliasedImportPathsInCollection`
+
+Introduced in [Stencil v2.18.0](https://github.com/ionic-team/stencil/releases/tag/v2.18.0), `transformAliasedImportPathsInCollection` is a configuration flag on the [`dist` output target](../output-targets/dist.md#transformaliasedimportpathsincollection).
+`transformAliasedImportPathsInCollection` transforms import paths, similar to [`transformAliasedImportPaths`](#transformaliasedimportpathsincollection).
+This flag however, only enables the functionality of `transformAliasedImportPaths` for collection output targets.
+
+Starting with Stencil v4.0.0, this flag is enabled by default.
+Projects that had previously enabled this functionality that are migrating from Stencil v2.18.0+ may safely remove the flag from their Stencil configuration file(s).
+
+For users that run into issues with this new default, we encourage you to file a [new issue on the Stencil GitHub repo](https://github.com/ionic-team/stencil/issues/new?assignees=&labels=&projects=&template=bug_report.yml&title=bug%3A+).
+As a workaround, this flag can be set to `false` to disable the default functionality.
+```ts title="stencil.config.ts - disabling 'transformAliasedImportPathsInCollection' in Stencil v4.0.0"
+import { Config } from '@stencil/core';
+
+export const config: Config = {
+  outputTargets: [
+    {
+      type: 'dist',
+      transformAliasedImportPathsInCollection: false,
+    },
+    // ...
+  ]
+  // ...
+};
+```
+
+For more information on this flag, please see the [`dist` output target's documentation](../output-targets/dist.md#transformaliasedimportpathsincollection).
 ### In Browser Compilation Support Removed
 
 Prior to Stencil v4.0.0, components could be compiled from TSX to JS in the browser.

--- a/docs/output-targets/dist.md
+++ b/docs/output-targets/dist.md
@@ -55,6 +55,8 @@ for more information.
 
 ### transformAliasedImportPathsInCollection
 
+*default: `true`*
+
 This option will allow [path aliases](https://www.typescriptlang.org/docs/handbook/module-resolution.html#path-mapping) defined in a project's `tsconfig.json` to be transformed into relative paths in the code output under the [collectionDir](#collectiondir) subdirectory for this output target. This does not affect imports for external packages.
 
 An example of path transformation could look something like:
@@ -67,10 +69,8 @@ import * as utils from '@utils';
 import * as utils from '../path/to/utils';
 ```
 
-This flag defaults to `false` when omitted from a Stencil configuration file.
-
 :::tip
-If using the `dist-collection` output target directly, the same result can be achieved using the `transformAliasedImportPaths` flag on the target's config.
+If using the `dist-collection` output target directly, the same result can be achieved using the [`transformAliasedImportPaths`](../config/01-overview.md#transformaliasedimportpaths) flag on the target's config.
 :::
 
 ## Publishing

--- a/docs/output-targets/dist.md
+++ b/docs/output-targets/dist.md
@@ -70,7 +70,7 @@ import * as utils from '../path/to/utils';
 ```
 
 :::tip
-If using the `dist-collection` output target directly, the same result can be achieved using the [`transformAliasedImportPaths`](../config/01-overview.md#transformaliasedimportpaths) flag on the target's config.
+If using the `dist-collection` output target directly, the same result can be achieved using the [`transformAliasedImportPaths`](../output-targets/dist.md#transformaliasedimportpathsincollection) flag on the target's config.
 :::
 
 ## Publishing


### PR DESCRIPTION
this commit updates the upgrade guide for stencil v4 to include new default values for `transformAliasedImportPaths` and `transformAliasedImportPathsInCollection`.

STENCIL-829

Core PR: https://github.com/ionic-team/stencil/pull/4418