### PR TITLE
removes shadowDomShim from extras docs

### DIFF
--- a/docs/config/extras.md
+++ b/docs/config/extras.md
@@ -29,7 +29,6 @@ Example `extras` config when **supporting** legacy browsers:
 export const config: Config = {
   buildEs5: 'prod',
   extras: {
-    __deprecated__shadowDomShim: true,
     scriptDataOpts: true,
     appendChildSlotFix: false,
     cloneNodeFix: false,
@@ -112,18 +111,6 @@ An experimental flag that when set to `true`, aligns the behavior of invoking th
 ### scriptDataOpts
 
 It is possible to assign data to the actual `<script>` element's `data-opts` property, which then gets passed to Stencil's initial bootstrap. This feature is only required for very special cases and rarely needed. When set to `false` it will not read this data. Defaults to `false`.
-
-### `__deprecated__shadowDomShim`
-
-If enabled `true`, the runtime will check if the shadow dom shim is required.
-However, if it's determined that shadow dom is already natively supported by
-the browser then it does not request the shim. Setting to `false` will avoid
-all shadow dom tests. If the app does not need to support IE11 or Edge 18 and
-below, it's recommended to set `shadowDomShim` to `false`. Defaults to `false`.
-
-As of Stencil v3.0.0, support for IE 11, Edge <= 18, and Safari 10 has begun to
-reach end-of-life. While this flag and its supporting functionality is
-currently available, it will be removed in a future version of Stencil.
 
 ### slotChildNodesFix
 


### PR DESCRIPTION
Removes the `__deprecated__shadowDomShim` from the `extras` docs. This was removed from #1129 since the option had not yet been removed from the Stencil compiler/runtime