### PR TITLE
docs(angular): app initializer must be a multi-provider

### DIFF
--- a/docs/framework-integration/angular.md
+++ b/docs/framework-integration/angular.md
@@ -220,9 +220,8 @@ import { defineCustomElements } from 'stencil-library/loader';
   providers: [
     {
       provide: APP_INITIALIZER,
-      useFactory: () => {
-        return defineCustomElements();
-      },
+      useFactory: () => defineCustomElements,
+      multi: true
     },
   ]
 })

--- a/versioned_docs/version-v2/framework-integration/angular.md
+++ b/versioned_docs/version-v2/framework-integration/angular.md
@@ -220,9 +220,8 @@ import { defineCustomElements } from 'stencil-library/loader';
   providers: [
     {
       provide: APP_INITIALIZER,
-      useFactory: () => {
-        return defineCustomElements();
-      },
+      useFactory: () => defineCustomElements,
+      multi: true
     },
   ]
 })

--- a/versioned_docs/version-v3.0/framework-integration/angular.md
+++ b/versioned_docs/version-v3.0/framework-integration/angular.md
@@ -220,9 +220,8 @@ import { defineCustomElements } from 'stencil-library/loader';
   providers: [
     {
       provide: APP_INITIALIZER,
-      useFactory: () => {
-        return defineCustomElements();
-      },
+      useFactory: () => defineCustomElements,
+      multi: true
     },
   ]
 })

--- a/versioned_docs/version-v3.1/framework-integration/angular.md
+++ b/versioned_docs/version-v3.1/framework-integration/angular.md
@@ -220,9 +220,8 @@ import { defineCustomElements } from 'stencil-library/loader';
   providers: [
     {
       provide: APP_INITIALIZER,
-      useFactory: () => {
-        return defineCustomElements();
-      },
+      useFactory: () => defineCustomElements,
+      multi: true
     },
   ]
 })

--- a/versioned_docs/version-v3.2/framework-integration/angular.md
+++ b/versioned_docs/version-v3.2/framework-integration/angular.md
@@ -220,9 +220,8 @@ import { defineCustomElements } from 'stencil-library/loader';
   providers: [
     {
       provide: APP_INITIALIZER,
-      useFactory: () => {
-        return defineCustomElements();
-      },
+      useFactory: () => defineCustomElements,
+      multi: true
     },
   ]
 })

--- a/versioned_docs/version-v3.3/framework-integration/angular.md
+++ b/versioned_docs/version-v3.3/framework-integration/angular.md
@@ -220,9 +220,8 @@ import { defineCustomElements } from 'stencil-library/loader';
   providers: [
     {
       provide: APP_INITIALIZER,
-      useFactory: () => {
-        return defineCustomElements();
-      },
+      useFactory: () => defineCustomElements,
+      multi: true
     },
   ]
 })

--- a/versioned_docs/version-v3.4/framework-integration/angular.md
+++ b/versioned_docs/version-v3.4/framework-integration/angular.md
@@ -220,9 +220,8 @@ import { defineCustomElements } from 'stencil-library/loader';
   providers: [
     {
       provide: APP_INITIALIZER,
-      useFactory: () => {
-        return defineCustomElements();
-      },
+      useFactory: () => defineCustomElements,
+      multi: true
     },
   ]
 })


### PR DESCRIPTION
Resolves: https://github.com/ionic-team/stencil-ds-output-targets/issues/354

The `APP_INITIALIZER` provider must be a multi-provider. This is a new run-time check in Angular: https://github.com/angular/angular/commit/bb6a3e849eca4487980c862b7a7e29c000a56f05