### PR TITLE
docs(angular): fixup app initializer 

### DIFF
--- a/versioned_docs/version-v3.4/framework-integration/angular.md
+++ b/versioned_docs/version-v3.4/framework-integration/angular.md
@@ -220,9 +220,8 @@ import { defineCustomElements } from 'stencil-library/loader';
   providers: [
     {
       provide: APP_INITIALIZER,
-      useFactory: () => {
-        return defineCustomElements();
-      },
+      useFactory: () => defineCustomElements,
+      multi: true
     },
   ]
 })


### PR DESCRIPTION
this commit fixes an issue where the documentation in #1148 for the 3.4 docs was accidentally overwritten in #1141 (58235d447cd1c0bec502b47af9c9c5cf78a299cd). this was generated by checking out the head of `main` (58235d447cd1c0bec502b47af9c9c5cf78a299cd) and `git cherry-pick c288f3e979e09607b9e27c5a587712a53347ccc3`. Looking at the diff from #1141, that appears to be the only thing that was overwritten