### PR TITLE
docs(config): fix headful mode typo

### DIFF
--- a/versioned_docs/version-v3.4/testing/config.md
+++ b/versioned_docs/version-v3.4/testing/config.md
@@ -71,7 +71,7 @@ export interface TestingConfig extends JestConfig {
    * The following values are accepted:
    * - "new" - enables the "new" headless mode, starting with Chrome 112
    * - `true` - enables the "old" headless mode, prior to Chrome 112
-   * - `false` - enables the "headed" mode
+   * - `false` - enables the "headful" mode
    *
    * Stencil will default to `true` (the old headless mode) if no value is provided.
    *


### PR DESCRIPTION
Snuck in in #1141 - anyways, quick and easy!