### PR TITLE
[blocked] chore(docs): set up redirect from '3.x' versions to 'v3'

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -8,7 +8,7 @@
     },
     {
       "source": "/:version(v3\\.[0-4])/:path*",
-      "destination": "/docs/:path*",
+      "destination": "/docs/v3/:path*",
       "statusCode": 301
     },
     {


### PR DESCRIPTION
In #1159 we consolidated our versions for v3.0..v3.4 down to a single united 'v3' version which will be the single maintained documentation for v3 going forward (we have a policy of only maintaining point-release specific documentation for the current major version number).

That change (#1159) involved setting up a Vercel redirect to take all requests for v3.x documentation and redirecting them to the same path under `/docs/`, so that, for instance, `/docs/v3.1/support-policy` redirects to `/docs/support-policy`. This commit amends that redirect so that instead that same url will redirect to `/docs/v3/support-policy`, since the main version under `/docs/` is now v4.

### testing

You can test that a url like `/docs/v3.1/support-policy` is redirected to `/docs/v3/support-policy` although note that until a v4 version is created (and this branch is rebased over that change) that URL won't point to anything yet.

🚨🚧 **NOTE** 🚧🚨

This should not be merged until a v4 version of the docs has been created