### PR TITLE
docs(functional-components): fix minor grammar issue

### DIFF
--- a/docs/components/functional-components.md
+++ b/docs/components/functional-components.md
@@ -54,7 +54,7 @@ export const Hello: FunctionalComponent<HelloProps> = ({ name }) => (
 
 ## Working with children
 
-The second argument of a functional component receives the passed children, but in order to work with them, the `FunctionalComponent` provides an utils object that exposes a `map()` method to transform the children, and `forEach()` to read them. Reading the `children` array is not recommended since the stencil compiler can rename the vNode properties in prod mode.
+The second argument of a functional component receives the passed children, but in order to work with them, `FunctionalComponent` provides a utils object that exposes a `map()` method to transform the children, and a `forEach()` method to read them. Reading the `children` array is not recommended since the stencil compiler can rename the vNode properties in prod mode.
 
 ```tsx
 export interface FunctionalUtilities {

--- a/versioned_docs/version-v4.0/components/functional-components.md
+++ b/versioned_docs/version-v4.0/components/functional-components.md
@@ -54,7 +54,7 @@ export const Hello: FunctionalComponent<HelloProps> = ({ name }) => (
 
 ## Working with children
 
-The second argument of a functional component receives the passed children, but in order to work with them, the `FunctionalComponent` provides an utils object that exposes a `map()` method to transform the children, and `forEach()` to read them. Reading the `children` array is not recommended since the stencil compiler can rename the vNode properties in prod mode.
+The second argument of a functional component receives the passed children, but in order to work with them, `FunctionalComponent` provides a utils object that exposes a `map()` method to transform the children, and a `forEach()` method to read them. Reading the `children` array is not recommended since the stencil compiler can rename the vNode properties in prod mode.
 
 ```tsx
 export interface FunctionalUtilities {


### PR DESCRIPTION
Fixes minor grammar issue and improves readability of "Working with children" section of functional components page