### PR TITLE
docs: update Ionic Angular links

### DIFF
--- a/docs/framework-integration/angular.md
+++ b/docs/framework-integration/angular.md
@@ -384,7 +384,7 @@ Ionic Framework can integrate better with Angular's Router.
 **Type: `string`**
 
 Used to provide a list of type Proxies to the Angular Component Library.
-See [Ionic Framework](https://github.com/ionic-team/ionic-framework/blob/main/angular/src/directives/proxies-list.ts) for a sample.
+See [Ionic Framework](https://github.com/ionic-team/ionic-framework/blob/main/packages/angular/src/directives/proxies-list.ts) for a sample.
 
 ### directivesProxyFile
 

--- a/docs/framework-integration/angular.md
+++ b/docs/framework-integration/angular.md
@@ -207,7 +207,7 @@ export * from './lib/stencil-generated/components';
 ### Registering Custom Elements
 
 The default behavior for this output target does not handle automatically defining/registering the custom elements. One strategy (and the approach
-the [Ionic Framework](https://github.com/ionic-team/ionic-framework/blob/main/angular/src/app-initialize.ts#L21-L34) takes) is to use the loader to define all custom elements during app initialization:
+the [Ionic Framework](https://github.com/ionic-team/ionic-framework/blob/main/packages/angular/src/app-initialize.ts#L21-L34) takes) is to use the loader to define all custom elements during app initialization:
 
 ```ts
 // component-library.module.ts

--- a/versioned_docs/version-v2/framework-integration/angular.md
+++ b/versioned_docs/version-v2/framework-integration/angular.md
@@ -207,7 +207,7 @@ export * from './lib/stencil-generated/components';
 ### Registering Custom Elements
 
 The default behavior for this output target does not handle automatically defining/registering the custom elements. One strategy (and the approach
-the [Ionic Framework](https://github.com/ionic-team/ionic-framework/blob/main/angular/src/app-initialize.ts#L21-L34) takes) is to use the loader to define all custom elements during app initialization:
+the [Ionic Framework](https://github.com/ionic-team/ionic-framework/blob/main/packages/angular/src/app-initialize.ts#L21-L34) takes) is to use the loader to define all custom elements during app initialization:
 
 ```ts
 // component-library.module.ts
@@ -384,7 +384,7 @@ Ionic Framework can integrate better with Angular's Router.
 **Type: `string`**
 
 Used to provide a list of type Proxies to the Angular Component Library.
-See [Ionic Framework](https://github.com/ionic-team/ionic-framework/blob/main/angular/src/directives/proxies-list.ts) for a sample.
+See [Ionic Framework](https://github.com/ionic-team/ionic-framework/blob/main/packages/angular/src/directives/proxies-list.ts) for a sample.
 
 ### directivesProxyFile
 

--- a/versioned_docs/version-v3/framework-integration/angular.md
+++ b/versioned_docs/version-v3/framework-integration/angular.md
@@ -207,7 +207,7 @@ export * from './lib/stencil-generated/components';
 ### Registering Custom Elements
 
 The default behavior for this output target does not handle automatically defining/registering the custom elements. One strategy (and the approach
-the [Ionic Framework](https://github.com/ionic-team/ionic-framework/blob/main/angular/src/app-initialize.ts#L21-L34) takes) is to use the loader to define all custom elements during app initialization:
+the [Ionic Framework](https://github.com/ionic-team/ionic-framework/blob/main/packages/angular/src/app-initialize.ts#L21-L34) takes) is to use the loader to define all custom elements during app initialization:
 
 ```ts
 // component-library.module.ts
@@ -384,7 +384,7 @@ Ionic Framework can integrate better with Angular's Router.
 **Type: `string`**
 
 Used to provide a list of type Proxies to the Angular Component Library.
-See [Ionic Framework](https://github.com/ionic-team/ionic-framework/blob/main/angular/src/directives/proxies-list.ts) for a sample.
+See [Ionic Framework](https://github.com/ionic-team/ionic-framework/blob/main/packages/angular/src/directives/proxies-list.ts) for a sample.
 
 ### directivesProxyFile
 

--- a/versioned_docs/version-v4.0/framework-integration/angular.md
+++ b/versioned_docs/version-v4.0/framework-integration/angular.md
@@ -207,7 +207,7 @@ export * from './lib/stencil-generated/components';
 ### Registering Custom Elements
 
 The default behavior for this output target does not handle automatically defining/registering the custom elements. One strategy (and the approach
-the [Ionic Framework](https://github.com/ionic-team/ionic-framework/blob/main/angular/src/app-initialize.ts#L21-L34) takes) is to use the loader to define all custom elements during app initialization:
+the [Ionic Framework](https://github.com/ionic-team/ionic-framework/blob/main/packages/angular/src/app-initialize.ts#L21-L34) takes) is to use the loader to define all custom elements during app initialization:
 
 ```ts
 // component-library.module.ts
@@ -384,7 +384,7 @@ Ionic Framework can integrate better with Angular's Router.
 **Type: `string`**
 
 Used to provide a list of type Proxies to the Angular Component Library.
-See [Ionic Framework](https://github.com/ionic-team/ionic-framework/blob/main/angular/src/directives/proxies-list.ts) for a sample.
+See [Ionic Framework](https://github.com/ionic-team/ionic-framework/blob/main/packages/angular/src/directives/proxies-list.ts) for a sample.
 
 ### directivesProxyFile
 


### PR DESCRIPTION
The Framework team plans to move the `angular` directory to `packages/angular` in https://github.com/ionic-team/ionic-framework/pull/27719. This PR updates the links on the Stencil Site to point to the new location. Let me know if you'd rather I use permalinks.

Blocked on merging until https://github.com/ionic-team/ionic-framework/pull/27719 is merged.