### PR TITLE
docs(bundling): remove commonjs#namedExports field

### DIFF
--- a/docs/guides/module-bundling.md
+++ b/docs/guides/module-bundling.md
@@ -81,39 +81,8 @@ Since CommonJS libraries are still common today, Stencil comes with [`rollup-plu
 
 At compiler-time, the `rollup-plugin-commonjs` plugin does a best-effort to **transform CommonJS into ESM**, but this is not always an easy task. CommonJS is dynamic by nature, while ESM is static by design.
 
-Stencil's config exposes a `commonjs` property that is passed down to the Rollup CommonJS plugin, you can use this setting to work around certain bundling issues.
+For further information, check out the [rollup-plugin-commonjs docs](https://github.com/rollup/plugins/tree/master/packages/commonjs).
 
-### NamedModules: X is not exported by X
-
-Sometimes, Rollup is unable to properly static analyze CommonJS modules, and it misses some named exports. Fortunately, there is a workaround we can use.
-
-As we already know, `stencil.config.ts` exposes a `commonjs` property, in this case, we can take advantage of [the `namedExports` property](https://github.com/rollup/rollup-plugin-commonjs#custom-named-exports).
-
-Let's say, Rollup fails, when trying to use the `hello` named export of the `commonjs-dep` module:
-
-```tsx
-// NamedModules: hello is not exported by commonjs-dep
-import { hello } from 'commonjs-dep';
-```
-
-We can use the `config.commonjs.namedExports` setting in the `stencil.config.ts` file to work around the issue:
-
-```tsx
-export const config = {
-  commonjs: {
-    namedExports: {
-       // commonjs-dep has a "hello" export
-      'commonjs-dep': ['hello']
-    }
-  }
-}
-```
-
-:::note
-We can set a map of `namedExports` for problematic dependencies, in this case, we are explicitly defining the named `hello` export in the `commonjs-dep` module.
-:::
-
-For further information, check out the [rollup-plugin-commonjs docs](https://github.com/rollup/rollup-plugin-commonjs).
 
 
 ## Custom Rollup plugins

--- a/versioned_docs/version-v4.0/guides/module-bundling.md
+++ b/versioned_docs/version-v4.0/guides/module-bundling.md
@@ -81,39 +81,7 @@ Since CommonJS libraries are still common today, Stencil comes with [`rollup-plu
 
 At compiler-time, the `rollup-plugin-commonjs` plugin does a best-effort to **transform CommonJS into ESM**, but this is not always an easy task. CommonJS is dynamic by nature, while ESM is static by design.
 
-Stencil's config exposes a `commonjs` property that is passed down to the Rollup CommonJS plugin, you can use this setting to work around certain bundling issues.
-
-### NamedModules: X is not exported by X
-
-Sometimes, Rollup is unable to properly static analyze CommonJS modules, and it misses some named exports. Fortunately, there is a workaround we can use.
-
-As we already know, `stencil.config.ts` exposes a `commonjs` property, in this case, we can take advantage of [the `namedExports` property](https://github.com/rollup/rollup-plugin-commonjs#custom-named-exports).
-
-Let's say, Rollup fails, when trying to use the `hello` named export of the `commonjs-dep` module:
-
-```tsx
-// NamedModules: hello is not exported by commonjs-dep
-import { hello } from 'commonjs-dep';
-```
-
-We can use the `config.commonjs.namedExports` setting in the `stencil.config.ts` file to work around the issue:
-
-```tsx
-export const config = {
-  commonjs: {
-    namedExports: {
-       // commonjs-dep has a "hello" export
-      'commonjs-dep': ['hello']
-    }
-  }
-}
-```
-
-:::note
-We can set a map of `namedExports` for problematic dependencies, in this case, we are explicitly defining the named `hello` export in the `commonjs-dep` module.
-:::
-
-For further information, check out the [rollup-plugin-commonjs docs](https://github.com/rollup/rollup-plugin-commonjs).
+For further information, check out the [rollup-plugin-commonjs docs](https://github.com/rollup/plugins/tree/master/packages/commonjs).
 
 
 ## Custom Rollup plugins


### PR DESCRIPTION
this commit removes the documentation around the `namedExports` field that is being deprecated in stencil v4. the field is no longer honored by the commonjs rollup plugin. we remove the documentation here to avoid any confusion surrounding its usability

STENCIL-867

https://github.com/ionic-team/stencil/pull/4532