### PR TITLE
docs(vue): update example vue library structure

### DIFF
--- a/docs/framework-integration/vue.md
+++ b/docs/framework-integration/vue.md
@@ -27,8 +27,8 @@ An example project set-up may look similar to:
 top-most-directory/
 └── packages/
     ├── vue-library/
-    │   └── src/
-    │       ├── lib/
+    │   └── lib/
+    │       ├── plugin.ts
     │       └── index.ts
     └── stencil-library/
         ├── stencil.config.js

--- a/versioned_docs/version-v2/framework-integration/vue.md
+++ b/versioned_docs/version-v2/framework-integration/vue.md
@@ -27,8 +27,8 @@ An example project set-up may look similar to:
 top-most-directory/
 └── packages/
     ├── vue-library/
-    │   └── src/
-    │       ├── lib/
+    │   └── lib/
+    │       ├── plugin.ts
     │       └── index.ts
     └── stencil-library/
         ├── stencil.config.js

--- a/versioned_docs/version-v3/framework-integration/vue.md
+++ b/versioned_docs/version-v3/framework-integration/vue.md
@@ -27,8 +27,8 @@ An example project set-up may look similar to:
 top-most-directory/
 └── packages/
     ├── vue-library/
-    │   └── src/
-    │       ├── lib/
+    │   └── lib/
+    │       ├── plugin.ts
     │       └── index.ts
     └── stencil-library/
         ├── stencil.config.js

--- a/versioned_docs/version-v4.0/framework-integration/vue.md
+++ b/versioned_docs/version-v4.0/framework-integration/vue.md
@@ -27,8 +27,8 @@ An example project set-up may look similar to:
 top-most-directory/
 └── packages/
     ├── vue-library/
-    │   └── src/
-    │       ├── lib/
+    │   └── lib/
+    │       ├── plugin.ts
     │       └── index.ts
     └── stencil-library/
         ├── stencil.config.js


### PR DESCRIPTION
The documentation is confusing when you scroll further down and you dont actually have a /src/ folder anywhere, only /lib/ and the index.ts and plugin.ts file under it.