### PR TITLE
docs(event): add note about colliding event types

### DIFF
--- a/docs/components/events.md
+++ b/docs/components/events.md
@@ -82,6 +82,13 @@ export class TodoList {
 }
 ```
 
+:::note
+In the case where the Stencil `Event` type conflicts with the native web `Event` type, it is suggested that the native web `Event` type be prefixed with `globalThis`:
+```ts title="Preventing Event Type Collisions"
+@Event() myEvent: EventEmitter<{value: string, ev: globalThis.Event}>;
+```
+:::
+
 ## Listen Decorator
 
 The `Listen()` decorator is for listening to DOM events, including the ones dispatched from `@Events`. The event listeners are automatically added and removed when the component gets added or removed from the DOM.

--- a/versioned_docs/version-v2/components/events.md
+++ b/versioned_docs/version-v2/components/events.md
@@ -82,6 +82,13 @@ export class TodoList {
 }
 ```
 
+:::note
+In the case where the Stencil `Event` type conflicts with the native web `Event` type, it is suggested that the native web `Event` type be prefixed with `globalThis`:
+```ts title="Preventing Event Type Collisions"
+@Event() myEvent: EventEmitter<{value: string, ev: globalThis.Event}>;
+```
+:::
+
 ## Listen Decorator
 
 The `Listen()` decorator is for listening to DOM events, including the ones dispatched from `@Events`. The event listeners are automatically added and removed when the component gets added or removed from the DOM.

--- a/versioned_docs/version-v3/components/events.md
+++ b/versioned_docs/version-v3/components/events.md
@@ -82,6 +82,13 @@ export class TodoList {
 }
 ```
 
+:::note
+In the case where the Stencil `Event` type conflicts with the native web `Event` type, it is suggested that the native web `Event` type be prefixed with `globalThis`:
+```ts title="Preventing Event Type Collisions"
+@Event() myEvent: EventEmitter<{value: string, ev: globalThis.Event}>;
+```
+:::
+
 ## Listen Decorator
 
 The `Listen()` decorator is for listening to DOM events, including the ones dispatched from `@Events`. The event listeners are automatically added and removed when the component gets added or removed from the DOM.

--- a/versioned_docs/version-v4.0/components/events.md
+++ b/versioned_docs/version-v4.0/components/events.md
@@ -82,6 +82,13 @@ export class TodoList {
 }
 ```
 
+:::note
+In the case where the Stencil `Event` type conflicts with the native web `Event` type, it is suggested that the native web `Event` type be prefixed with `globalThis`:
+```ts title="Preventing Event Type Collisions"
+@Event() myEvent: EventEmitter<{value: string, ev: globalThis.Event}>;
+```
+:::
+
 ## Listen Decorator
 
 The `Listen()` decorator is for listening to DOM events, including the ones dispatched from `@Events`. The event listeners are automatically added and removed when the component gets added or removed from the DOM.


### PR DESCRIPTION
this commit adds a workaround/note about collisions between the native web `Event` type and stencil's decorator.

based on: https://discord.com/channels/520266681499779082/1131898715217612911/1131898715217612911

![Screenshot 2023-07-21 at 3 35 36 PM](https://github.com/ionic-team/stencil-site/assets/1930213/cc1d9007-67fc-494d-b934-1bae5bedd25a)



Note: I'll backport this all the way to v2 once approved