### PR TITLE
docs(wrappers): add `enableImportInjection` to FAQ

### DIFF
--- a/docs/framework-integration/react.md
+++ b/docs/framework-integration/react.md
@@ -148,7 +148,7 @@ Update the generated `package.json` in your `react-library`, adding the followin
 -    "test": "node ./__tests__/react-library.test.js"
 +    "test": "node ./__tests__/react-library.test.js",
 +    "build": "npm run tsc",
-+    "tsc": "tsc -p ."
++    "tsc": "tsc -p . --outDir ./dist"
 -  }
 +  },
    "files": [

--- a/docs/framework-integration/react.md
+++ b/docs/framework-integration/react.md
@@ -154,7 +154,7 @@ Update the generated `package.json` in your `react-library`, adding the followin
    "files": [
 -    "lib"
 +    "dist"
-   ]
+   ],
 +  "publishConfig": {
 +    "access": "public"
 +  },
@@ -490,7 +490,7 @@ using the `dir` property for `dist-custom-elements`, you need to also specify th
 
 In addition, all the Web Components will be automatically defined as the generated component modules are bootstrapped.
 
-### TypeError: Cannot read propertied of undefined (reading 'isProxied')
+### TypeError: Cannot read properties of undefined (reading 'isProxied')
 
 If you encounter this error when running the React application consuming your proxy components, you can set the [`enableImportInjection`](../config/extras.md#enableimportinjection)
 flag on the Stencil config's `extras` object. Once set, this will require you to rebuild the Stencil component library and the React component library.

--- a/docs/framework-integration/react.md
+++ b/docs/framework-integration/react.md
@@ -490,6 +490,11 @@ using the `dir` property for `dist-custom-elements`, you need to also specify th
 
 In addition, all the Web Components will be automatically defined as the generated component modules are bootstrapped.
 
+### TypeError: Cannot read propertied of undefined (reading 'isProxied')
+
+If you encounter this error when running the React application consuming your proxy components, you can set the [`enableImportInjection`](../config/extras.md#enableimportinjection)
+flag on the Stencil config's `extras` object. Once set, this will require you to rebuild the Stencil component library and the React component library.
+
 ### What is the best format to write event names?
 
 Event names shouldn’t include special characters when initially written in Stencil. Try to lean on using camelCased event names for interoperability between frameworks.

--- a/docs/framework-integration/vue.md
+++ b/docs/framework-integration/vue.md
@@ -533,7 +533,7 @@ using the `dir` property for `dist-custom-elements`, you need to also specify th
 
 In addition, all the Web Components will be automatically defined as the generated component modules are bootstrapped.
 
-### TypeError: Cannot read propertied of undefined (reading 'isProxied')
+### TypeError: Cannot read properties of undefined (reading 'isProxied')
 
 If you encounter this error when running the Vue application consuming your proxy components, you can set the [`enableImportInjection`](../config/extras.md#enableimportinjection)
 flag on the Stencil config's `extras` object. Once set, this will require you to rebuild the Stencil component library and the Vue component library.

--- a/docs/framework-integration/vue.md
+++ b/docs/framework-integration/vue.md
@@ -138,11 +138,15 @@ Update the generated `package.json` in your `vue-library`, adding the following 
 -  "main": "lib/vue-library.js",
 +  "main": "dist/index.js",
 +  "types": "dist/index.d.ts",
+  "files": [
+-    'lib'
++    'dist'
+  ],
   "scripts": {
 -    "test": "echo \"Error: run tests from root\" && exit 1"
 +    "test": "echo \"Error: run tests from root\" && exit 1",
 +    "build": "npm run tsc",
-+    "tsc": "tsc -p ."
++    "tsc": "tsc -p . --outDir ./dist"
 -  }
 +  },
 +  "publishConfig": {

--- a/docs/framework-integration/vue.md
+++ b/docs/framework-integration/vue.md
@@ -529,6 +529,11 @@ using the `dir` property for `dist-custom-elements`, you need to also specify th
 
 In addition, all the Web Components will be automatically defined as the generated component modules are bootstrapped.
 
+### TypeError: Cannot read propertied of undefined (reading 'isProxied')
+
+If you encounter this error when running the Vue application consuming your proxy components, you can set the [`enableImportInjection`](../config/extras.md#enableimportinjection)
+flag on the Stencil config's `extras` object. Once set, this will require you to rebuild the Stencil component library and the Vue component library.
+
 ### Vue warns "Failed to resolve component: my-component"
 
 #### Lazy loaded bundle

--- a/versioned_docs/version-v2/framework-integration/react.md
+++ b/versioned_docs/version-v2/framework-integration/react.md
@@ -490,6 +490,12 @@ using the `dir` property for `dist-custom-elements`, you need to also specify th
 
 In addition, all the Web Components will be automatically defined as the generated component modules are bootstrapped.
 
+### TypeError: Cannot read propertied of undefined (reading 'isProxied')
+
+If you encounter this error when running the React application consuming your proxy components, you can set the
+[`experimentalImportInjection`](../config/extras.md#experimentalimportinjection) flag on the Stencil config's `extras` object. Once set, this will
+require you to rebuild the Stencil component library and the React component library.
+
 ### What is the best format to write event names?
 
 Event names shouldn’t include special characters when initially written in Stencil. Try to lean on using camelCased event names for interoperability between frameworks.

--- a/versioned_docs/version-v2/framework-integration/react.md
+++ b/versioned_docs/version-v2/framework-integration/react.md
@@ -148,7 +148,7 @@ Update the generated `package.json` in your `react-library`, adding the followin
 -    "test": "node ./__tests__/react-library.test.js"
 +    "test": "node ./__tests__/react-library.test.js",
 +    "build": "npm run tsc",
-+    "tsc": "tsc -p ."
++    "tsc": "tsc -p . --outDir ./dist"
 -  }
 +  },
    "files": [

--- a/versioned_docs/version-v2/framework-integration/react.md
+++ b/versioned_docs/version-v2/framework-integration/react.md
@@ -154,7 +154,7 @@ Update the generated `package.json` in your `react-library`, adding the followin
    "files": [
 -    "lib"
 +    "dist"
-   ]
+   ],
 +  "publishConfig": {
 +    "access": "public"
 +  },
@@ -490,7 +490,7 @@ using the `dir` property for `dist-custom-elements`, you need to also specify th
 
 In addition, all the Web Components will be automatically defined as the generated component modules are bootstrapped.
 
-### TypeError: Cannot read propertied of undefined (reading 'isProxied')
+### TypeError: Cannot read properties of undefined (reading 'isProxied')
 
 If you encounter this error when running the React application consuming your proxy components, you can set the
 [`experimentalImportInjection`](../config/extras.md#experimentalimportinjection) flag on the Stencil config's `extras` object. Once set, this will

--- a/versioned_docs/version-v2/framework-integration/vue.md
+++ b/versioned_docs/version-v2/framework-integration/vue.md
@@ -138,11 +138,15 @@ Update the generated `package.json` in your `vue-library`, adding the following 
 -  "main": "lib/vue-library.js",
 +  "main": "dist/index.js",
 +  "types": "dist/index.d.ts",
+  "files": [
+-    'lib'
++    'dist'
+  ],
   "scripts": {
 -    "test": "echo \"Error: run tests from root\" && exit 1"
 +    "test": "echo \"Error: run tests from root\" && exit 1",
 +    "build": "npm run tsc",
-+    "tsc": "tsc -p ."
++    "tsc": "tsc -p . --outDir ./dist"
 -  }
 +  },
 +  "publishConfig": {

--- a/versioned_docs/version-v2/framework-integration/vue.md
+++ b/versioned_docs/version-v2/framework-integration/vue.md
@@ -533,7 +533,7 @@ using the `dir` property for `dist-custom-elements`, you need to also specify th
 
 In addition, all the Web Components will be automatically defined as the generated component modules are bootstrapped.
 
-### TypeError: Cannot read propertied of undefined (reading 'isProxied')
+### TypeError: Cannot read properties of undefined (reading 'isProxied')
 
 If you encounter this error when running the Vue application consuming your proxy components, you can set the
 [`experimentalImportInjection`](../config/extras.md#experimentalimportinjection) flag on the Stencil config's `extras` object. Once set, this will

--- a/versioned_docs/version-v2/framework-integration/vue.md
+++ b/versioned_docs/version-v2/framework-integration/vue.md
@@ -529,6 +529,12 @@ using the `dir` property for `dist-custom-elements`, you need to also specify th
 
 In addition, all the Web Components will be automatically defined as the generated component modules are bootstrapped.
 
+### TypeError: Cannot read propertied of undefined (reading 'isProxied')
+
+If you encounter this error when running the Vue application consuming your proxy components, you can set the
+[`experimentalImportInjection`](../config/extras.md#experimentalimportinjection) flag on the Stencil config's `extras` object. Once set, this will
+require you to rebuild the Stencil component library and the Vue component library.
+
 ### Vue warns "Failed to resolve component: my-component"
 
 #### Lazy loaded bundle

--- a/versioned_docs/version-v3/framework-integration/react.md
+++ b/versioned_docs/version-v3/framework-integration/react.md
@@ -148,7 +148,7 @@ Update the generated `package.json` in your `react-library`, adding the followin
 -    "test": "node ./__tests__/react-library.test.js"
 +    "test": "node ./__tests__/react-library.test.js",
 +    "build": "npm run tsc",
-+    "tsc": "tsc -p ."
++    "tsc": "tsc -p . --outDir ./dist"
 -  }
 +  },
    "files": [

--- a/versioned_docs/version-v3/framework-integration/react.md
+++ b/versioned_docs/version-v3/framework-integration/react.md
@@ -154,7 +154,7 @@ Update the generated `package.json` in your `react-library`, adding the followin
    "files": [
 -    "lib"
 +    "dist"
-   ]
+   ],
 +  "publishConfig": {
 +    "access": "public"
 +  },
@@ -490,7 +490,7 @@ using the `dir` property for `dist-custom-elements`, you need to also specify th
 
 In addition, all the Web Components will be automatically defined as the generated component modules are bootstrapped.
 
-### TypeError: Cannot read propertied of undefined (reading 'isProxied')
+### TypeError: Cannot read properties of undefined (reading 'isProxied')
 
 If you encounter this error when running the React application consuming your proxy components, you can set the [`enableImportInjection`](../config/extras.md#enableimportinjection)
 flag on the Stencil config's `extras` object. Once set, this will require you to rebuild the Stencil component library and the React component library.

--- a/versioned_docs/version-v3/framework-integration/react.md
+++ b/versioned_docs/version-v3/framework-integration/react.md
@@ -490,6 +490,16 @@ using the `dir` property for `dist-custom-elements`, you need to also specify th
 
 In addition, all the Web Components will be automatically defined as the generated component modules are bootstrapped.
 
+### TypeError: Cannot read propertied of undefined (reading 'isProxied')
+
+If you encounter this error when running the React application consuming your proxy components, you can set the [`enableImportInjection`](../config/extras.md#enableimportinjection)
+flag on the Stencil config's `extras` object. Once set, this will require you to rebuild the Stencil component library and the React component library.
+
+:::note
+The `enableImportInjection` flag was introduced in Stencil v3.2.0. If you are running a previous version of Stencil, you can use the
+[`experimentalImportInjection`](../config/extras.md#experimentalimportinjection) flag.
+:::
+
 ### What is the best format to write event names?
 
 Event names shouldn’t include special characters when initially written in Stencil. Try to lean on using camelCased event names for interoperability between frameworks.

--- a/versioned_docs/version-v3/framework-integration/vue.md
+++ b/versioned_docs/version-v3/framework-integration/vue.md
@@ -533,7 +533,7 @@ using the `dir` property for `dist-custom-elements`, you need to also specify th
 
 In addition, all the Web Components will be automatically defined as the generated component modules are bootstrapped.
 
-### TypeError: Cannot read propertied of undefined (reading 'isProxied')
+### TypeError: Cannot read properties of undefined (reading 'isProxied')
 
 If you encounter this error when running the Vue application consuming your proxy components, you can set the [`enableImportInjection`](../config/extras.md#enableimportinjection)
 flag on the Stencil config's `extras` object. Once set, this will require you to rebuild the Stencil component library and the Vue component library.

--- a/versioned_docs/version-v3/framework-integration/vue.md
+++ b/versioned_docs/version-v3/framework-integration/vue.md
@@ -138,11 +138,15 @@ Update the generated `package.json` in your `vue-library`, adding the following 
 -  "main": "lib/vue-library.js",
 +  "main": "dist/index.js",
 +  "types": "dist/index.d.ts",
+  "files": [
+-    'lib'
++    'dist'
+  ],
   "scripts": {
 -    "test": "echo \"Error: run tests from root\" && exit 1"
 +    "test": "echo \"Error: run tests from root\" && exit 1",
 +    "build": "npm run tsc",
-+    "tsc": "tsc -p ."
++    "tsc": "tsc -p . --outDir ./dist"
 -  }
 +  },
 +  "publishConfig": {

--- a/versioned_docs/version-v3/framework-integration/vue.md
+++ b/versioned_docs/version-v3/framework-integration/vue.md
@@ -529,6 +529,16 @@ using the `dir` property for `dist-custom-elements`, you need to also specify th
 
 In addition, all the Web Components will be automatically defined as the generated component modules are bootstrapped.
 
+### TypeError: Cannot read propertied of undefined (reading 'isProxied')
+
+If you encounter this error when running the Vue application consuming your proxy components, you can set the [`enableImportInjection`](../config/extras.md#enableimportinjection)
+flag on the Stencil config's `extras` object. Once set, this will require you to rebuild the Stencil component library and the Vue component library.
+
+:::note
+The `enableImportInjection` flag was introduced in Stencil v3.2.0. If you are running a previous version of Stencil, you can use the
+[`experimentalImportInjection`](../config/extras.md#experimentalimportinjection) flag.
+:::
+
 ### Vue warns "Failed to resolve component: my-component"
 
 #### Lazy loaded bundle

--- a/versioned_docs/version-v4.0/framework-integration/react.md
+++ b/versioned_docs/version-v4.0/framework-integration/react.md
@@ -148,7 +148,7 @@ Update the generated `package.json` in your `react-library`, adding the followin
 -    "test": "node ./__tests__/react-library.test.js"
 +    "test": "node ./__tests__/react-library.test.js",
 +    "build": "npm run tsc",
-+    "tsc": "tsc -p ."
++    "tsc": "tsc -p . --outDir ./dist"
 -  }
 +  },
    "files": [

--- a/versioned_docs/version-v4.0/framework-integration/react.md
+++ b/versioned_docs/version-v4.0/framework-integration/react.md
@@ -154,7 +154,7 @@ Update the generated `package.json` in your `react-library`, adding the followin
    "files": [
 -    "lib"
 +    "dist"
-   ]
+   ],
 +  "publishConfig": {
 +    "access": "public"
 +  },
@@ -490,7 +490,7 @@ using the `dir` property for `dist-custom-elements`, you need to also specify th
 
 In addition, all the Web Components will be automatically defined as the generated component modules are bootstrapped.
 
-### TypeError: Cannot read propertied of undefined (reading 'isProxied')
+### TypeError: Cannot read properties of undefined (reading 'isProxied')
 
 If you encounter this error when running the React application consuming your proxy components, you can set the [`enableImportInjection`](../config/extras.md#enableimportinjection)
 flag on the Stencil config's `extras` object. Once set, this will require you to rebuild the Stencil component library and the React component library.

--- a/versioned_docs/version-v4.0/framework-integration/react.md
+++ b/versioned_docs/version-v4.0/framework-integration/react.md
@@ -490,6 +490,11 @@ using the `dir` property for `dist-custom-elements`, you need to also specify th
 
 In addition, all the Web Components will be automatically defined as the generated component modules are bootstrapped.
 
+### TypeError: Cannot read propertied of undefined (reading 'isProxied')
+
+If you encounter this error when running the React application consuming your proxy components, you can set the [`enableImportInjection`](../config/extras.md#enableimportinjection)
+flag on the Stencil config's `extras` object. Once set, this will require you to rebuild the Stencil component library and the React component library.
+
 ### What is the best format to write event names?
 
 Event names shouldn’t include special characters when initially written in Stencil. Try to lean on using camelCased event names for interoperability between frameworks.

--- a/versioned_docs/version-v4.0/framework-integration/vue.md
+++ b/versioned_docs/version-v4.0/framework-integration/vue.md
@@ -533,7 +533,7 @@ using the `dir` property for `dist-custom-elements`, you need to also specify th
 
 In addition, all the Web Components will be automatically defined as the generated component modules are bootstrapped.
 
-### TypeError: Cannot read propertied of undefined (reading 'isProxied')
+### TypeError: Cannot read properties of undefined (reading 'isProxied')
 
 If you encounter this error when running the Vue application consuming your proxy components, you can set the [`enableImportInjection`](../config/extras.md#enableimportinjection)
 flag on the Stencil config's `extras` object. Once set, this will require you to rebuild the Stencil component library and the Vue component library.

--- a/versioned_docs/version-v4.0/framework-integration/vue.md
+++ b/versioned_docs/version-v4.0/framework-integration/vue.md
@@ -138,11 +138,15 @@ Update the generated `package.json` in your `vue-library`, adding the following 
 -  "main": "lib/vue-library.js",
 +  "main": "dist/index.js",
 +  "types": "dist/index.d.ts",
+  "files": [
+-    'lib'
++    'dist'
+  ],
   "scripts": {
 -    "test": "echo \"Error: run tests from root\" && exit 1"
 +    "test": "echo \"Error: run tests from root\" && exit 1",
 +    "build": "npm run tsc",
-+    "tsc": "tsc -p ."
++    "tsc": "tsc -p . --outDir ./dist"
 -  }
 +  },
 +  "publishConfig": {

--- a/versioned_docs/version-v4.0/framework-integration/vue.md
+++ b/versioned_docs/version-v4.0/framework-integration/vue.md
@@ -529,6 +529,11 @@ using the `dir` property for `dist-custom-elements`, you need to also specify th
 
 In addition, all the Web Components will be automatically defined as the generated component modules are bootstrapped.
 
+### TypeError: Cannot read propertied of undefined (reading 'isProxied')
+
+If you encounter this error when running the Vue application consuming your proxy components, you can set the [`enableImportInjection`](../config/extras.md#enableimportinjection)
+flag on the Stencil config's `extras` object. Once set, this will require you to rebuild the Stencil component library and the Vue component library.
+
 ### Vue warns "Failed to resolve component: my-component"
 
 #### Lazy loaded bundle


### PR DESCRIPTION
Updates the documentation for the React and Vue output targets to include a FAQ entry for users encountering a "cannot read property of undefined (reading `isProxied`)".

Also updates some config diffs to make packages publishable.