### PR TITLE
[Ember] Update example for Ionic-specific APIs

### DIFF
--- a/docs/framework-integration/ember.md
+++ b/docs/framework-integration/ember.md
@@ -39,7 +39,7 @@ import { tracked } from '@glimmer/tracking';
 
 export default class Demo extends Component {
   <template>
-    <ion-toggle value="{{this.isOn}}" {{on "click" this.toggle}}></ion-toggle>
+    <ion-toggle checked="{{this.isOn}}" {{on "ionChange" this.toggle}}></ion-toggle>
   </template>
 
   @tracked isOn = true;

--- a/versioned_docs/version-v4.0/framework-integration/ember.md
+++ b/versioned_docs/version-v4.0/framework-integration/ember.md
@@ -39,7 +39,7 @@ import { tracked } from '@glimmer/tracking';
 
 export default class Demo extends Component {
   <template>
-    <ion-toggle value="{{this.isOn}}" {{on "click" this.toggle}}></ion-toggle>
+    <ion-toggle checked="{{this.isOn}}" {{on "ionChange" this.toggle}}></ion-toggle>
   </template>
 
   @tracked isOn = true;


### PR DESCRIPTION
Demo proving that `checked` and `ionChange` or the APIs for turning `ion-toggle` in to a _controlled_ component: [here (live demo)](https://limber.glimdown.com/edit?c=MQAgqgzglgdg5iAygFwKYwMZQDYliAUQFsAjVAJwChKB9AQRhpAEMYIB3CkZAe24AsoEEAG0IyZhgDWPAG4UAZth7sQARwCuqcVB4wAuiLUBGfSAXkeREAAMAAgBkeABx42AdNSOmAXCH7IyM4QPgD0oeKSMvLkSiruGFahmtrIumyhAOwAbDkALAAMAMwArKGopBQAtCVVxlXsUMj8VRVk5FUY2FBV4uhY2FWsACZVzVDko87M5MgAnp1WrjDoyBBVMDzIDTzkUrBw1JQAPACEVVUglPjjwqjDTbsA5MIAREQzUsMqMCBEPMNUK8ADRXTggDCsEDdeStAAeqAwGjQEIBqBAJDmLGGD3gIFeMKB3D4zXRcAAVsJEoCFP1UJQLgA%2Bag2VkU4SE65EVyzEAAbxAehAAF9zJZrE87G0KKF-g8FFAKE8ANxcnnIEAAYSWelWYqsIElcG6RCIMsS3N1MGQKrVuw1AuQ5Ci9xF%2BoldmNUFNMqdUQOtsoXWYEGEABEKnxUHC0DBhsJtZaVtb%2BZQQCBjmhudhmGhmen00IAPIwPx8vm3dzFmDC4VpgvHEjkfMN9JjHhwY3ojD8RFSe4AXle5cr1drr35fKFr3Smv4rDgRMrvE72FQtcZx1CbZXXZb6cbzcP%2B4zJGRvF%2B5aFTy6UGkTwEQncu7XG%2BjaHIMGYuB7C9QW7PQI9BbLcs2cHM82odM7D9aRXWrEAB24cgtFVesX3RJCAAoAEpEMZR8ICrCAS0QkBTlHEiYFVdNKDrTMKnA3NUBAiAMHIKBnA1CByAwIcAiCEJwgwYYYHcSlARhch3BWZBQhgZwiFCOx0jvUJEnIVBQgecRtz0O9xIgV5NwidjOOQZl62OCN-hAUJmVAxiIJYyhWRsIA&format=glimdown)