### PR TITLE
chore(ci): make markdown link checker fail correctly

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Thanks for your interest in contributing to the Stencil Docs! :tada:
 1. Fork the repo.
 2. Clone your fork.
 3. Make a branch for your change.
-4. Stencil uses [volta](volta.sh) to manage its npm and Node versions.
+4. Stencil uses [volta](https://volta.sh) to manage its npm and Node versions.
    [Install it](https://docs.volta.sh/guide/getting-started) before proceeding.
    1. There's no need to install a specific version of npm or Node right now, it shall be done automatically for you in
       the next step

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
-    "check-links": "remark --use remark-validate-links ."
+    "check-links": "remark --frail --use remark-validate-links ."
   },
   "dependencies": {
     "@docusaurus/core": "^2.4.1",


### PR DESCRIPTION
I think we need the `--frail` option so it will `exit(1)` when there's a warning and thereby fail the build

The first commit makes it so the build fails, and the second fixes the issue.