### PR TITLE
docs(component): fix wording for styles

### DIFF
--- a/docs/components/component.md
+++ b/docs/components/component.md
@@ -207,7 +207,7 @@ export class TodoList {
 
 **Details:**<br/>
 Relative URL to an external stylesheet containing styles to apply to your component.
-By out of the box, Stencil will only process CSS files (files ending with `.css`).
+Out of the box, Stencil will only process CSS files (files ending with `.css`).
 Support for additional CSS variants, like Sass, can be added via [a plugin](https://stenciljs.com/docs/plugins#related-plugins).
 
 **Example**:<br/>
@@ -243,9 +243,8 @@ export class TodoList {
 A list of relative URLs to external stylesheets containing styles to apply to your component.
 
 Alternatively, an object can be provided that maps a named "mode" to one or more stylesheets.
-This 
 
-By out of the box, Stencil will only process CSS files (ending with `.css`).
+Out of the box, Stencil will only process CSS files (ending with `.css`).
 Support for additional CSS variants, like Sass, can be added via [a plugin](https://stenciljs.com/docs/plugins#related-plugins).
 
 **Example**:<br/>

--- a/versioned_docs/version-v2/components/component.md
+++ b/versioned_docs/version-v2/components/component.md
@@ -219,7 +219,7 @@ export class TodoList {
 
 **Details:**<br/>
 Relative URL to an external stylesheet containing styles to apply to your component.
-By out of the box, Stencil will only process CSS files (files ending with `.css`).
+Out of the box, Stencil will only process CSS files (files ending with `.css`).
 Support for additional CSS variants, like Sass, can be added via [a plugin](https://stenciljs.com/docs/plugins#related-plugins).
 
 **Example**:<br/>
@@ -255,9 +255,8 @@ export class TodoList {
 A list of relative URLs to external stylesheets containing styles to apply to your component.
 
 Alternatively, an object can be provided that maps a named "mode" to one or more stylesheets.
-This 
 
-By out of the box, Stencil will only process CSS files (ending with `.css`).
+Out of the box, Stencil will only process CSS files (ending with `.css`).
 Support for additional CSS variants, like Sass, can be added via [a plugin](https://stenciljs.com/docs/plugins#related-plugins).
 
 **Example**:<br/>

--- a/versioned_docs/version-v3/components/component.md
+++ b/versioned_docs/version-v3/components/component.md
@@ -207,7 +207,7 @@ export class TodoList {
 
 **Details:**<br/>
 Relative URL to an external stylesheet containing styles to apply to your component.
-By out of the box, Stencil will only process CSS files (files ending with `.css`).
+Out of the box, Stencil will only process CSS files (files ending with `.css`).
 Support for additional CSS variants, like Sass, can be added via [a plugin](https://stenciljs.com/docs/plugins#related-plugins).
 
 **Example**:<br/>
@@ -243,9 +243,8 @@ export class TodoList {
 A list of relative URLs to external stylesheets containing styles to apply to your component.
 
 Alternatively, an object can be provided that maps a named "mode" to one or more stylesheets.
-This 
 
-By out of the box, Stencil will only process CSS files (ending with `.css`).
+Out of the box, Stencil will only process CSS files (ending with `.css`).
 Support for additional CSS variants, like Sass, can be added via [a plugin](https://stenciljs.com/docs/plugins#related-plugins).
 
 **Example**:<br/>

--- a/versioned_docs/version-v4.0/components/component.md
+++ b/versioned_docs/version-v4.0/components/component.md
@@ -207,7 +207,7 @@ export class TodoList {
 
 **Details:**<br/>
 Relative URL to an external stylesheet containing styles to apply to your component.
-By out of the box, Stencil will only process CSS files (files ending with `.css`).
+Out of the box, Stencil will only process CSS files (files ending with `.css`).
 Support for additional CSS variants, like Sass, can be added via [a plugin](https://stenciljs.com/docs/plugins#related-plugins).
 
 **Example**:<br/>
@@ -243,9 +243,8 @@ export class TodoList {
 A list of relative URLs to external stylesheets containing styles to apply to your component.
 
 Alternatively, an object can be provided that maps a named "mode" to one or more stylesheets.
-This 
 
-By out of the box, Stencil will only process CSS files (ending with `.css`).
+Out of the box, Stencil will only process CSS files (ending with `.css`).
 Support for additional CSS variants, like Sass, can be added via [a plugin](https://stenciljs.com/docs/plugins#related-plugins).
 
 **Example**:<br/>

--- a/versioned_docs/version-v4.1/components/component.md
+++ b/versioned_docs/version-v4.1/components/component.md
@@ -207,7 +207,7 @@ export class TodoList {
 
 **Details:**<br/>
 Relative URL to an external stylesheet containing styles to apply to your component.
-By out of the box, Stencil will only process CSS files (files ending with `.css`).
+Out of the box, Stencil will only process CSS files (files ending with `.css`).
 Support for additional CSS variants, like Sass, can be added via [a plugin](https://stenciljs.com/docs/plugins#related-plugins).
 
 **Example**:<br/>
@@ -243,9 +243,8 @@ export class TodoList {
 A list of relative URLs to external stylesheets containing styles to apply to your component.
 
 Alternatively, an object can be provided that maps a named "mode" to one or more stylesheets.
-This 
 
-By out of the box, Stencil will only process CSS files (ending with `.css`).
+Out of the box, Stencil will only process CSS files (ending with `.css`).
 Support for additional CSS variants, like Sass, can be added via [a plugin](https://stenciljs.com/docs/plugins#related-plugins).
 
 **Example**:<br/>


### PR DESCRIPTION
this commit fixes some garbled text that didn't make any real sense when read back.

partially addresses https://github.com/ionic-team/stencil-site/issues/1214

longer term, I'd like us to properly document modes as a part of the component API and link that back to these sections