### PR TITLE
docs(angular): update section for configuring to use custom elements

### DIFF
--- a/docs/framework-integration/angular.md
+++ b/docs/framework-integration/angular.md
@@ -462,8 +462,7 @@ export const config: Config = {
 
 No! By default, this output target will look to use the `dist` output, but the output from `dist-custom-elements` can be used alternatively.
 
-To do so, simply set the `includeImportCustomElements` option in the output target's config and ensure the
-[custom elements output target](../output-targets/custom-elements.md) is added to the Stencil config's output target array:
+To do so, change the type `outputType` argument to either `scam` or `standalone`. For more information on both these options, see the [API section](#outputtype).
 
 ```ts
 // stencil.config.ts
@@ -479,7 +478,7 @@ export const config: Config = {
       componentCorePackage: 'component-library',
       directivesProxyFile: '{path to your proxy file}',
       // This is what tells the target to use the custom elements output
-      includeImportCustomElements: true
+      outputType: 'standalone' // or 'scam'
     })
   ]
 }


### PR DESCRIPTION
This just updates the FAQ for configuring the output target to use the `dist-custom-elements` output. This was a small oversight when the API changed in the 0.8.2 release.