### PR TITLE
docs(ts): add TypeScript 5.2.2 <-> Stencil 4.4.0 note

### DIFF
--- a/docs/reference/support-policy.md
+++ b/docs/reference/support-policy.md
@@ -86,6 +86,7 @@ The table below describes recent versions of Stencil and the version of TypeScri
 
 | Stencil Version | TypeScript Version |
 |:---------------:|:------------------:|
+|     v4.4.0      |       v5.2.2       |
 |     v4.2.0      |       v5.1.6       |
 |     v3.3.0      |       v5.0.4       |
 |     v3.0.0      |       v4.9.4       |


### PR DESCRIPTION
This adds an entry to the table where we note the versions of Stencil where we upgrade TypeScript to include information about the forthcoming upgrade to TypeScript 5.2.2 in Stencil 4.4.0.

Relevant to https://github.com/ionic-team/stencil/pull/4852