### PR TITLE
docs(suppport): add jest 28-29 to next/ docs

### DIFF
--- a/docs/reference/support-policy.md
+++ b/docs/reference/support-policy.md
@@ -130,14 +130,14 @@ compatibility tables to describe the interoperability requirements of these piec
 
 #### Jest
 
-| Stencil Version | Jest v24 | Jest v25 | Jest v26 | Jest v27 | Jest v28+ * |
-|:---------------:|:--------:|:--------:|:--------:|:--------:|:-----------:|
-|       V4        | &#9989;  | &#9989;  | &#9989;  | &#9989;  |  &#10060;   |
-|       V3        | &#9989;  | &#9989;  | &#9989;  | &#9989;  |  &#10060;   |
-|       V2        | &#9989;  | &#9989;  | &#9989;  | &#9989;  |  &#10060;   |
-|       V1        | &#9989;  | &#9989;  | &#9989;  | &#10060; |  &#10060;   |
+| Stencil Version | Jest v24-26 | Jest v27 | Jest v28 * | Jest v29 *  |
+|:---------------:|:-----------:|:--------:|:----------:|:-----------:|
+|       V4        |   &#9989;   | &#9989;  |  &#9989;   |   &#9989;   |
+|       V3        |   &#9989;   | &#9989;  |  &#10060;  |  &#10060;   |
+|       V2        |   &#9989;   | &#9989;  |  &#10060;  |  &#10060;   |
+|       V1        |   &#9989;   | &#10060; |  &#10060;  |  &#10060;   |
 
-\* Support for Jest 28+ will be released in an upcoming version of Stencil v4.
+\* Support for Jest 28 & 29 has been included since Stencil v4.7.0.
 
 #### Puppeteer
 


### PR DESCRIPTION
add wording to next/ docs (slated for v4.7) to state we support jest 28/29 starting with v4.7.0. coalesce the support table for v24-26 to minimize the horizontal space the table was taking up