### PR TITLE
 docs(cli): add help and version tasks

### DIFF
--- a/docs/config/cli.md
+++ b/docs/config/cli.md
@@ -82,6 +82,12 @@ src
             └── page-home.tsx
 ```
 
+## `stencil help`
+
+Aliases: `stencil --help`, `stencil -h`
+
+Prints various tasks that can be run and their associated flags to the terminal.
+
 ## `stencil test`
 
 Tests a Stencil project. The flags below are the available options for the `test` command.
@@ -94,10 +100,8 @@ Tests a Stencil project. The flags below are the available options for the `test
 | `--devtools` | Opens the dev tools panel in Chrome for end-to-end tests. Setting this flag will disable `--headless` |
 | `--headless` | Sets the headless mode to use in Chrome for end-to-end tests. `--headless` and `--headless=true` will enable the "old" headless mode in Chrome, that was used by default prior to Chrome v112. `--headless=new` will enable the new headless mode introduced in Chrome v112. See [this article](https://developer.chrome.com/articles/new-headless/) for more information on Chrome's new headless mode. |
 
+## `stencil version`
 
-## `stencil`
+Alias: `stencil -v`
 
-| Flag | Description |
-|------|-------------|
-| `--help` | Display the help output explaining the different flags. | `-h` |
-| `--version` | Prints the current Stencil version. | `-v` |
+Prints the version of Stencil to the terminal.

--- a/versioned_docs/version-v4.0/config/cli.md
+++ b/versioned_docs/version-v4.0/config/cli.md
@@ -82,6 +82,12 @@ src
             └── page-home.tsx
 ```
 
+## `stencil help`
+
+Aliases: `stencil --help`, `stencil -h`
+
+Prints various tasks that can be run and their associated flags to the terminal.
+
 ## `stencil test`
 
 Tests a Stencil project. The flags below are the available options for the `test` command.
@@ -94,10 +100,8 @@ Tests a Stencil project. The flags below are the available options for the `test
 | `--devtools` | Opens the dev tools panel in Chrome for end-to-end tests. Setting this flag will disable `--headless` |
 | `--headless` | Sets the headless mode to use in Chrome for end-to-end tests. `--headless` and `--headless=true` will enable the "old" headless mode in Chrome, that was used by default prior to Chrome v112. `--headless=new` will enable the new headless mode introduced in Chrome v112. See [this article](https://developer.chrome.com/articles/new-headless/) for more information on Chrome's new headless mode. |
 
+## `stencil version`
 
-## `stencil`
+Alias: `stencil -v`
 
-| Flag | Description |
-|------|-------------|
-| `--help` | Display the help output explaining the different flags. | `-h` |
-| `--version` | Prints the current Stencil version. | `-v` |
+Prints the version of Stencil to the terminal.

--- a/versioned_docs/version-v4.1/config/cli.md
+++ b/versioned_docs/version-v4.1/config/cli.md
@@ -82,6 +82,12 @@ src
             └── page-home.tsx
 ```
 
+## `stencil help`
+
+Aliases: `stencil --help`, `stencil -h`
+
+Prints various tasks that can be run and their associated flags to the terminal.
+
 ## `stencil test`
 
 Tests a Stencil project. The flags below are the available options for the `test` command.
@@ -94,10 +100,8 @@ Tests a Stencil project. The flags below are the available options for the `test
 | `--devtools` | Opens the dev tools panel in Chrome for end-to-end tests. Setting this flag will disable `--headless` |
 | `--headless` | Sets the headless mode to use in Chrome for end-to-end tests. `--headless` and `--headless=true` will enable the "old" headless mode in Chrome, that was used by default prior to Chrome v112. `--headless=new` will enable the new headless mode introduced in Chrome v112. See [this article](https://developer.chrome.com/articles/new-headless/) for more information on Chrome's new headless mode. |
 
+## `stencil version`
 
-## `stencil`
+Alias: `stencil -v`
 
-| Flag | Description |
-|------|-------------|
-| `--help` | Display the help output explaining the different flags. | `-h` |
-| `--version` | Prints the current Stencil version. | `-v` |
+Prints the version of Stencil to the terminal.

--- a/versioned_docs/version-v4.2/config/cli.md
+++ b/versioned_docs/version-v4.2/config/cli.md
@@ -82,6 +82,12 @@ src
             └── page-home.tsx
 ```
 
+## `stencil help`
+
+Aliases: `stencil --help`, `stencil -h`
+
+Prints various tasks that can be run and their associated flags to the terminal.
+
 ## `stencil test`
 
 Tests a Stencil project. The flags below are the available options for the `test` command.
@@ -94,10 +100,8 @@ Tests a Stencil project. The flags below are the available options for the `test
 | `--devtools` | Opens the dev tools panel in Chrome for end-to-end tests. Setting this flag will disable `--headless` |
 | `--headless` | Sets the headless mode to use in Chrome for end-to-end tests. `--headless` and `--headless=true` will enable the "old" headless mode in Chrome, that was used by default prior to Chrome v112. `--headless=new` will enable the new headless mode introduced in Chrome v112. See [this article](https://developer.chrome.com/articles/new-headless/) for more information on Chrome's new headless mode. |
 
+## `stencil version`
 
-## `stencil`
+Alias: `stencil -v`
 
-| Flag | Description |
-|------|-------------|
-| `--help` | Display the help output explaining the different flags. | `-h` |
-| `--version` | Prints the current Stencil version. | `-v` |
+Prints the version of Stencil to the terminal.

--- a/versioned_docs/version-v4.3/config/cli.md
+++ b/versioned_docs/version-v4.3/config/cli.md
@@ -82,6 +82,12 @@ src
             └── page-home.tsx
 ```
 
+## `stencil help`
+
+Aliases: `stencil --help`, `stencil -h`
+
+Prints various tasks that can be run and their associated flags to the terminal.
+
 ## `stencil test`
 
 Tests a Stencil project. The flags below are the available options for the `test` command.
@@ -94,10 +100,8 @@ Tests a Stencil project. The flags below are the available options for the `test
 | `--devtools` | Opens the dev tools panel in Chrome for end-to-end tests. Setting this flag will disable `--headless` |
 | `--headless` | Sets the headless mode to use in Chrome for end-to-end tests. `--headless` and `--headless=true` will enable the "old" headless mode in Chrome, that was used by default prior to Chrome v112. `--headless=new` will enable the new headless mode introduced in Chrome v112. See [this article](https://developer.chrome.com/articles/new-headless/) for more information on Chrome's new headless mode. |
 
+## `stencil version`
 
-## `stencil`
+Alias: `stencil -v`
 
-| Flag | Description |
-|------|-------------|
-| `--help` | Display the help output explaining the different flags. | `-h` |
-| `--version` | Prints the current Stencil version. | `-v` |
+Prints the version of Stencil to the terminal.

--- a/versioned_docs/version-v4.4/config/cli.md
+++ b/versioned_docs/version-v4.4/config/cli.md
@@ -82,6 +82,12 @@ src
             └── page-home.tsx
 ```
 
+## `stencil help`
+
+Aliases: `stencil --help`, `stencil -h`
+
+Prints various tasks that can be run and their associated flags to the terminal.
+
 ## `stencil test`
 
 Tests a Stencil project. The flags below are the available options for the `test` command.
@@ -94,10 +100,8 @@ Tests a Stencil project. The flags below are the available options for the `test
 | `--devtools` | Opens the dev tools panel in Chrome for end-to-end tests. Setting this flag will disable `--headless` |
 | `--headless` | Sets the headless mode to use in Chrome for end-to-end tests. `--headless` and `--headless=true` will enable the "old" headless mode in Chrome, that was used by default prior to Chrome v112. `--headless=new` will enable the new headless mode introduced in Chrome v112. See [this article](https://developer.chrome.com/articles/new-headless/) for more information on Chrome's new headless mode. |
 
+## `stencil version`
 
-## `stencil`
+Alias: `stencil -v`
 
-| Flag | Description |
-|------|-------------|
-| `--help` | Display the help output explaining the different flags. | `-h` |
-| `--version` | Prints the current Stencil version. | `-v` |
+Prints the version of Stencil to the terminal.

--- a/versioned_docs/version-v4.5/config/cli.md
+++ b/versioned_docs/version-v4.5/config/cli.md
@@ -82,6 +82,12 @@ src
             └── page-home.tsx
 ```
 
+## `stencil help`
+
+Aliases: `stencil --help`, `stencil -h`
+
+Prints various tasks that can be run and their associated flags to the terminal.
+
 ## `stencil test`
 
 Tests a Stencil project. The flags below are the available options for the `test` command.
@@ -94,10 +100,8 @@ Tests a Stencil project. The flags below are the available options for the `test
 | `--devtools` | Opens the dev tools panel in Chrome for end-to-end tests. Setting this flag will disable `--headless` |
 | `--headless` | Sets the headless mode to use in Chrome for end-to-end tests. `--headless` and `--headless=true` will enable the "old" headless mode in Chrome, that was used by default prior to Chrome v112. `--headless=new` will enable the new headless mode introduced in Chrome v112. See [this article](https://developer.chrome.com/articles/new-headless/) for more information on Chrome's new headless mode. |
 
+## `stencil version`
 
-## `stencil`
+Alias: `stencil -v`
 
-| Flag | Description |
-|------|-------------|
-| `--help` | Display the help output explaining the different flags. | `-h` |
-| `--version` | Prints the current Stencil version. | `-v` |
+Prints the version of Stencil to the terminal.

--- a/versioned_docs/version-v4.6/config/cli.md
+++ b/versioned_docs/version-v4.6/config/cli.md
@@ -82,6 +82,12 @@ src
             └── page-home.tsx
 ```
 
+## `stencil help`
+
+Aliases: `stencil --help`, `stencil -h`
+
+Prints various tasks that can be run and their associated flags to the terminal.
+
 ## `stencil test`
 
 Tests a Stencil project. The flags below are the available options for the `test` command.
@@ -94,10 +100,8 @@ Tests a Stencil project. The flags below are the available options for the `test
 | `--devtools` | Opens the dev tools panel in Chrome for end-to-end tests. Setting this flag will disable `--headless` |
 | `--headless` | Sets the headless mode to use in Chrome for end-to-end tests. `--headless` and `--headless=true` will enable the "old" headless mode in Chrome, that was used by default prior to Chrome v112. `--headless=new` will enable the new headless mode introduced in Chrome v112. See [this article](https://developer.chrome.com/articles/new-headless/) for more information on Chrome's new headless mode. |
 
+## `stencil version`
 
-## `stencil`
+Alias: `stencil -v`
 
-| Flag | Description |
-|------|-------------|
-| `--help` | Display the help output explaining the different flags. | `-h` |
-| `--version` | Prints the current Stencil version. | `-v` |
+Prints the version of Stencil to the terminal.

--- a/versioned_docs/version-v4.7/config/cli.md
+++ b/versioned_docs/version-v4.7/config/cli.md
@@ -82,6 +82,12 @@ src
             └── page-home.tsx
 ```
 
+## `stencil help`
+
+Aliases: `stencil --help`, `stencil -h`
+
+Prints various tasks that can be run and their associated flags to the terminal.
+
 ## `stencil test`
 
 Tests a Stencil project. The flags below are the available options for the `test` command.
@@ -94,10 +100,8 @@ Tests a Stencil project. The flags below are the available options for the `test
 | `--devtools` | Opens the dev tools panel in Chrome for end-to-end tests. Setting this flag will disable `--headless` |
 | `--headless` | Sets the headless mode to use in Chrome for end-to-end tests. `--headless` and `--headless=true` will enable the "old" headless mode in Chrome, that was used by default prior to Chrome v112. `--headless=new` will enable the new headless mode introduced in Chrome v112. See [this article](https://developer.chrome.com/articles/new-headless/) for more information on Chrome's new headless mode. |
 
+## `stencil version`
 
-## `stencil`
+Alias: `stencil -v`
 
-| Flag | Description |
-|------|-------------|
-| `--help` | Display the help output explaining the different flags. | `-h` |
-| `--version` | Prints the current Stencil version. | `-v` |
+Prints the version of Stencil to the terminal.


### PR DESCRIPTION
add explicit sections for the help and version tasks, rather than
grouping them under the vague header 'stencil'

Depends on: https://github.com/ionic-team/stencil-site/pull/1265 landing first

I'll propagate this back to all v4 entries once approved and the parent PR lands