### PR TITLE
docs(events): update type conflict recommendation

### DIFF
--- a/docs/components/events.md
+++ b/docs/components/events.md
@@ -83,9 +83,11 @@ export class TodoList {
 ```
 
 :::note
-In the case where the Stencil `Event` type conflicts with the native web `Event` type, it is suggested that the native web `Event` type be prefixed with `globalThis`:
-```ts title="Preventing Event Type Collisions"
-@Event() myEvent: EventEmitter<{value: string, ev: globalThis.Event}>;
+In the case where the Stencil `Event` type conflicts with the native web `Event` type, the Stencil `Event` import can be aliased like so:
+```tsx
+import { Event as StencilEvent, EventEmitter } from '@stencil/core';
+
+@StencilEvent() myEvent: EventEmitter<{value: string, ev: Event}>;
 ```
 :::
 

--- a/docs/components/events.md
+++ b/docs/components/events.md
@@ -83,11 +83,18 @@ export class TodoList {
 ```
 
 :::note
-In the case where the Stencil `Event` type conflicts with the native web `Event` type, the Stencil `Event` import can be aliased like so:
+In the case where the Stencil `Event` type conflicts with the native web `Event` type, there are two possible solutions:
+
+1. Import aliasing:
 ```tsx
 import { Event as StencilEvent, EventEmitter } from '@stencil/core';
 
 @StencilEvent() myEvent: EventEmitter<{value: string, ev: Event}>;
+```
+
+2. Namespace the native web `Event` type with `globalThis`:
+```tsx
+@Event() myEvent: EventEmitter<{value: string, ev: globalThis.Event}>;
 ```
 :::
 


### PR DESCRIPTION
Updates the verbiage around the recommendation for dealing with type conflicts in the `Event` decorator import with the addition of support for import aliasing.

Also peeked through the docs for some of our other decorators and didn't see anything needing updating there.

**Note:** This does **not** need to be propagated to other versions as this will only be available starting in v4.9