### PR TITLE
chore(support): move stencil v3 to extended support

### DIFF
--- a/docs/reference/support-policy.md
+++ b/docs/reference/support-policy.md
@@ -25,7 +25,7 @@ The current status of each Stencil version is:
 | Version |      Status      |   Released   | Maintenance Ends | Ext. Support Ends |
 |:-------:|:----------------:|:------------:|:----------------:|:-----------------:|
 |   V4    |    **Active**    | Jun 26, 2023 |       TBD        |        TBD        |
-|   V3    |    Maintenance   | Jan 25, 2023 |   Dec 26, 2023   |   Jun 26, 2024    |
+|   V3    | Extended Support | Jan 25, 2023 |   Dec 26, 2023   |   Jun 26, 2024    |
 |   V2    | Extended Support | Aug 08, 2020 |   Jul 25, 2023   |   Jan 25, 2024    |
 |   V1    |  End of Support  | Jun 03, 2019 |   Aug 08, 2020   |   Aug 08, 2020    |
 

--- a/versioned_docs/version-v3/reference/support-policy.md
+++ b/versioned_docs/version-v3/reference/support-policy.md
@@ -22,11 +22,11 @@ recommends updating to the newest version of the Stencil for the latest features
 
 The current status of each Stencil version is:
 
-| Version |     Status     |   Released   | Maintenance Ends | Ext. Support Ends |
-|:-------:|:--------------:|:------------:|:----------------:|:-----------------:|
-|   V3    |   **Active**   | Jan 25, 2023 |       TBD        |        TBD        |
-|   V2    |  Maintenance   | Aug 08, 2020 |   Jul 25, 2023   |   Jan 25, 2024    |
-|   V1    | End of Support | Jun 03, 2019 |   Aug 08, 2020   |   Aug 08, 2020    |
+| Version |      Status      |   Released   | Maintenance Ends | Ext. Support Ends |
+|:-------:|:----------------:|:------------:|:----------------:|:-----------------:|
+|   V3    | Extended Support | Jan 25, 2023 |   Dec 26, 2023   |   Jun 26, 2024    |
+|   V2    | Extended Support | Aug 08, 2020 |   Jul 25, 2023   |   Jan 25, 2024    |
+|   V1    |  End of Support  | Jun 03, 2019 |   Aug 08, 2020   |   Aug 08, 2020    |
 
 **Maintenance Period**: Only critical bug and security fixes. No major feature improvements.
 

--- a/versioned_docs/version-v4.0/reference/support-policy.md
+++ b/versioned_docs/version-v4.0/reference/support-policy.md
@@ -25,7 +25,7 @@ The current status of each Stencil version is:
 | Version |      Status      |   Released   | Maintenance Ends | Ext. Support Ends |
 |:-------:|:----------------:|:------------:|:----------------:|:-----------------:|
 |   V4    |    **Active**    | Jun 26, 2023 |       TBD        |        TBD        |
-|   V3    |    Maintenance   | Jan 25, 2023 |   Dec 26, 2023   |   Jun 26, 2024    |
+|   V3    | Extended Support | Jan 25, 2023 |   Dec 26, 2023   |   Jun 26, 2024    |
 |   V2    | Extended Support | Aug 08, 2020 |   Jul 25, 2023   |   Jan 25, 2024    |
 |   V1    |  End of Support  | Jun 03, 2019 |   Aug 08, 2020   |   Aug 08, 2020    |
 

--- a/versioned_docs/version-v4.1/reference/support-policy.md
+++ b/versioned_docs/version-v4.1/reference/support-policy.md
@@ -25,7 +25,7 @@ The current status of each Stencil version is:
 | Version |      Status      |   Released   | Maintenance Ends | Ext. Support Ends |
 |:-------:|:----------------:|:------------:|:----------------:|:-----------------:|
 |   V4    |    **Active**    | Jun 26, 2023 |       TBD        |        TBD        |
-|   V3    |    Maintenance   | Jan 25, 2023 |   Dec 26, 2023   |   Jun 26, 2024    |
+|   V3    | Extended Support | Jan 25, 2023 |   Dec 26, 2023   |   Jun 26, 2024    |
 |   V2    | Extended Support | Aug 08, 2020 |   Jul 25, 2023   |   Jan 25, 2024    |
 |   V1    |  End of Support  | Jun 03, 2019 |   Aug 08, 2020   |   Aug 08, 2020    |
 

--- a/versioned_docs/version-v4.2/reference/support-policy.md
+++ b/versioned_docs/version-v4.2/reference/support-policy.md
@@ -25,7 +25,7 @@ The current status of each Stencil version is:
 | Version |      Status      |   Released   | Maintenance Ends | Ext. Support Ends |
 |:-------:|:----------------:|:------------:|:----------------:|:-----------------:|
 |   V4    |    **Active**    | Jun 26, 2023 |       TBD        |        TBD        |
-|   V3    |    Maintenance   | Jan 25, 2023 |   Dec 26, 2023   |   Jun 26, 2024    |
+|   V3    | Extended Support | Jan 25, 2023 |   Dec 26, 2023   |   Jun 26, 2024    |
 |   V2    | Extended Support | Aug 08, 2020 |   Jul 25, 2023   |   Jan 25, 2024    |
 |   V1    |  End of Support  | Jun 03, 2019 |   Aug 08, 2020   |   Aug 08, 2020    |
 

--- a/versioned_docs/version-v4.3/reference/support-policy.md
+++ b/versioned_docs/version-v4.3/reference/support-policy.md
@@ -25,7 +25,7 @@ The current status of each Stencil version is:
 | Version |      Status      |   Released   | Maintenance Ends | Ext. Support Ends |
 |:-------:|:----------------:|:------------:|:----------------:|:-----------------:|
 |   V4    |    **Active**    | Jun 26, 2023 |       TBD        |        TBD        |
-|   V3    |    Maintenance   | Jan 25, 2023 |   Dec 26, 2023   |   Jun 26, 2024    |
+|   V3    | Extended Support | Jan 25, 2023 |   Dec 26, 2023   |   Jun 26, 2024    |
 |   V2    | Extended Support | Aug 08, 2020 |   Jul 25, 2023   |   Jan 25, 2024    |
 |   V1    |  End of Support  | Jun 03, 2019 |   Aug 08, 2020   |   Aug 08, 2020    |
 

--- a/versioned_docs/version-v4.4/reference/support-policy.md
+++ b/versioned_docs/version-v4.4/reference/support-policy.md
@@ -25,7 +25,7 @@ The current status of each Stencil version is:
 | Version |      Status      |   Released   | Maintenance Ends | Ext. Support Ends |
 |:-------:|:----------------:|:------------:|:----------------:|:-----------------:|
 |   V4    |    **Active**    | Jun 26, 2023 |       TBD        |        TBD        |
-|   V3    |    Maintenance   | Jan 25, 2023 |   Dec 26, 2023   |   Jun 26, 2024    |
+|   V3    | Extended Support | Jan 25, 2023 |   Dec 26, 2023   |   Jun 26, 2024    |
 |   V2    | Extended Support | Aug 08, 2020 |   Jul 25, 2023   |   Jan 25, 2024    |
 |   V1    |  End of Support  | Jun 03, 2019 |   Aug 08, 2020   |   Aug 08, 2020    |
 

--- a/versioned_docs/version-v4.5/reference/support-policy.md
+++ b/versioned_docs/version-v4.5/reference/support-policy.md
@@ -25,7 +25,7 @@ The current status of each Stencil version is:
 | Version |      Status      |   Released   | Maintenance Ends | Ext. Support Ends |
 |:-------:|:----------------:|:------------:|:----------------:|:-----------------:|
 |   V4    |    **Active**    | Jun 26, 2023 |       TBD        |        TBD        |
-|   V3    |    Maintenance   | Jan 25, 2023 |   Dec 26, 2023   |   Jun 26, 2024    |
+|   V3    | Extended Support | Jan 25, 2023 |   Dec 26, 2023   |   Jun 26, 2024    |
 |   V2    | Extended Support | Aug 08, 2020 |   Jul 25, 2023   |   Jan 25, 2024    |
 |   V1    |  End of Support  | Jun 03, 2019 |   Aug 08, 2020   |   Aug 08, 2020    |
 

--- a/versioned_docs/version-v4.6/reference/support-policy.md
+++ b/versioned_docs/version-v4.6/reference/support-policy.md
@@ -25,7 +25,7 @@ The current status of each Stencil version is:
 | Version |      Status      |   Released   | Maintenance Ends | Ext. Support Ends |
 |:-------:|:----------------:|:------------:|:----------------:|:-----------------:|
 |   V4    |    **Active**    | Jun 26, 2023 |       TBD        |        TBD        |
-|   V3    |    Maintenance   | Jan 25, 2023 |   Dec 26, 2023   |   Jun 26, 2024    |
+|   V3    | Extended Support | Jan 25, 2023 |   Dec 26, 2023   |   Jun 26, 2024    |
 |   V2    | Extended Support | Aug 08, 2020 |   Jul 25, 2023   |   Jan 25, 2024    |
 |   V1    |  End of Support  | Jun 03, 2019 |   Aug 08, 2020   |   Aug 08, 2020    |
 

--- a/versioned_docs/version-v4.7/reference/support-policy.md
+++ b/versioned_docs/version-v4.7/reference/support-policy.md
@@ -25,7 +25,7 @@ The current status of each Stencil version is:
 | Version |      Status      |   Released   | Maintenance Ends | Ext. Support Ends |
 |:-------:|:----------------:|:------------:|:----------------:|:-----------------:|
 |   V4    |    **Active**    | Jun 26, 2023 |       TBD        |        TBD        |
-|   V3    |    Maintenance   | Jan 25, 2023 |   Dec 26, 2023   |   Jun 26, 2024    |
+|   V3    | Extended Support | Jan 25, 2023 |   Dec 26, 2023   |   Jun 26, 2024    |
 |   V2    | Extended Support | Aug 08, 2020 |   Jul 25, 2023   |   Jan 25, 2024    |
 |   V1    |  End of Support  | Jun 03, 2019 |   Aug 08, 2020   |   Aug 08, 2020    |
 

--- a/versioned_docs/version-v4.8/reference/support-policy.md
+++ b/versioned_docs/version-v4.8/reference/support-policy.md
@@ -25,7 +25,7 @@ The current status of each Stencil version is:
 | Version |      Status      |   Released   | Maintenance Ends | Ext. Support Ends |
 |:-------:|:----------------:|:------------:|:----------------:|:-----------------:|
 |   V4    |    **Active**    | Jun 26, 2023 |       TBD        |        TBD        |
-|   V3    |    Maintenance   | Jan 25, 2023 |   Dec 26, 2023   |   Jun 26, 2024    |
+|   V3    | Extended Support | Jan 25, 2023 |   Dec 26, 2023   |   Jun 26, 2024    |
 |   V2    | Extended Support | Aug 08, 2020 |   Jul 25, 2023   |   Jan 25, 2024    |
 |   V1    |  End of Support  | Jun 03, 2019 |   Aug 08, 2020   |   Aug 08, 2020    |
 

--- a/versioned_docs/version-v4.9/reference/support-policy.md
+++ b/versioned_docs/version-v4.9/reference/support-policy.md
@@ -25,7 +25,7 @@ The current status of each Stencil version is:
 | Version |      Status      |   Released   | Maintenance Ends | Ext. Support Ends |
 |:-------:|:----------------:|:------------:|:----------------:|:-----------------:|
 |   V4    |    **Active**    | Jun 26, 2023 |       TBD        |        TBD        |
-|   V3    |    Maintenance   | Jan 25, 2023 |   Dec 26, 2023   |   Jun 26, 2024    |
+|   V3    | Extended Support | Jan 25, 2023 |   Dec 26, 2023   |   Jun 26, 2024    |
 |   V2    | Extended Support | Aug 08, 2020 |   Jul 25, 2023   |   Jan 25, 2024    |
 |   V1    |  End of Support  | Jun 03, 2019 |   Aug 08, 2020   |   Aug 08, 2020    |
 


### PR DESCRIPTION
**Note: This should not be merged before 2023.12.26**

**Note:** ~If we release v4.9 on Monday, 2023.12.18, I'll need to update this PR~ Done
 
update the support policy table to denote that stencil v3 has moved to extended support status.

