### PR TITLE
docs(extras): link slot fix issues for versions

### DIFF
--- a/docs/config/extras.md
+++ b/docs/config/extras.md
@@ -96,6 +96,13 @@ with the intent of making these the default behavior in Stencil v5. When set to
 `true` fixes for the following issues will be applied:
 
 - [Elements rendered outside of slot when shadow not enabled (#2641)](https://github.com/ionic-team/stencil/issues/2641) (since v4.2.0)
+- [A slot gets the attribute hidden when it shouldn't (#4523)](https://github.com/ionic-team/stencil/issues/4523) (since v4.7.0)
+- [Nested slots mis-ordered when not using Shadow DOM (#2997)](https://github.com/ionic-team/stencil/issues/2997) (since v4.7.0)
+- [Inconsistent behavior: slot-fb breaks styling of default slot content in component with 'shadow: false' (#2937)](https://github.com/ionic-team/stencil/issues/2937) (since v4.7.2)
+- [Slot content went missing within dynamic component (#4284)](https://github.com/ionic-team/stencil/issues/4284) (since v4.8.2)
+- [Slot element loses its parent reference and disappears when its parent is rendered conditionally (#3913)](https://github.com/ionic-team/stencil/issues/3913) (since v4.8.2)
+- [Failed to execute 'removeChild' on 'Node' (#3278)](https://github.com/ionic-team/stencil/issues/3278) (since v4.9.0)
+- [React fails to manage children in Stencil <slot /> (#2259)](https://github.com/ionic-team/stencil/issues/2259) (since v4.9.0)
 
 :::note
 New fixes enabled by this experimental flag are not subject to Stencil's

--- a/docs/config/extras.md
+++ b/docs/config/extras.md
@@ -95,14 +95,14 @@ Slot-related fixes to the runtime will be added over the course of Stencil v4,
 with the intent of making these the default behavior in Stencil v5. When set to
 `true` fixes for the following issues will be applied:
 
-- [Elements rendered outside of slot when shadow not enabled (#2641)](https://github.com/ionic-team/stencil/issues/2641) (since v4.2.0)
-- [A slot gets the attribute hidden when it shouldn't (#4523)](https://github.com/ionic-team/stencil/issues/4523) (since v4.7.0)
-- [Nested slots mis-ordered when not using Shadow DOM (#2997)](https://github.com/ionic-team/stencil/issues/2997) (since v4.7.0)
-- [Inconsistent behavior: slot-fb breaks styling of default slot content in component with 'shadow: false' (#2937)](https://github.com/ionic-team/stencil/issues/2937) (since v4.7.2)
-- [Slot content went missing within dynamic component (#4284)](https://github.com/ionic-team/stencil/issues/4284) (since v4.8.2)
-- [Slot element loses its parent reference and disappears when its parent is rendered conditionally (#3913)](https://github.com/ionic-team/stencil/issues/3913) (since v4.8.2)
-- [Failed to execute 'removeChild' on 'Node' (#3278)](https://github.com/ionic-team/stencil/issues/3278) (since v4.9.0)
-- [React fails to manage children in Stencil <slot /> (#2259)](https://github.com/ionic-team/stencil/issues/2259) (since v4.9.0)
+- Elements rendered outside of slot when shadow not enabled [(#2641)](https://github.com/ionic-team/stencil/issues/2641) (since v4.2.0)
+- A slot gets the attribute hidden when it shouldn't [(#4523)](https://github.com/ionic-team/stencil/issues/4523) (since v4.7.0)
+- Nested slots mis-ordered when not using Shadow DOM [(#2997)](https://github.com/ionic-team/stencil/issues/2997) (since v4.7.0)
+- Inconsistent behavior: slot-fb breaks styling of default slot content in component with 'shadow: false' [(#2937)](https://github.com/ionic-team/stencil/issues/2937) (since v4.7.2)
+- Slot content went missing within dynamic component [(#4284)](https://github.com/ionic-team/stencil/issues/4284) (since v4.8.2)
+- Slot element loses its parent reference and disappears when its parent is rendered conditionally [(#3913)](https://github.com/ionic-team/stencil/issues/3913) (since v4.8.2)
+- Failed to execute 'removeChild' on 'Node' [(#3278)](https://github.com/ionic-team/stencil/issues/3278) (since v4.9.0)
+- React fails to manage children in Stencil slot [(#2259)](https://github.com/ionic-team/stencil/issues/2259) (since v4.9.0)
 
 :::note
 New fixes enabled by this experimental flag are not subject to Stencil's

--- a/versioned_docs/version-v4.10/config/extras.md
+++ b/versioned_docs/version-v4.10/config/extras.md
@@ -96,6 +96,13 @@ with the intent of making these the default behavior in Stencil v5. When set to
 `true` fixes for the following issues will be applied:
 
 - [Elements rendered outside of slot when shadow not enabled (#2641)](https://github.com/ionic-team/stencil/issues/2641) (since v4.2.0)
+- [A slot gets the attribute hidden when it shouldn't (#4523)](https://github.com/ionic-team/stencil/issues/4523) (since v4.7.0)
+- [Nested slots mis-ordered when not using Shadow DOM (#2997)](https://github.com/ionic-team/stencil/issues/2997) (since v4.7.0)
+- [Inconsistent behavior: slot-fb breaks styling of default slot content in component with 'shadow: false' (#2937)](https://github.com/ionic-team/stencil/issues/2937) (since v4.7.2)
+- [Slot content went missing within dynamic component (#4284)](https://github.com/ionic-team/stencil/issues/4284) (since v4.8.2)
+- [Slot element loses its parent reference and disappears when its parent is rendered conditionally (#3913)](https://github.com/ionic-team/stencil/issues/3913) (since v4.8.2)
+- [Failed to execute 'removeChild' on 'Node' (#3278)](https://github.com/ionic-team/stencil/issues/3278) (since v4.9.0)
+- [React fails to manage children in Stencil <slot /> (#2259)](https://github.com/ionic-team/stencil/issues/2259) (since v4.9.0)
 
 :::note
 New fixes enabled by this experimental flag are not subject to Stencil's

--- a/versioned_docs/version-v4.10/config/extras.md
+++ b/versioned_docs/version-v4.10/config/extras.md
@@ -95,14 +95,14 @@ Slot-related fixes to the runtime will be added over the course of Stencil v4,
 with the intent of making these the default behavior in Stencil v5. When set to
 `true` fixes for the following issues will be applied:
 
-- [Elements rendered outside of slot when shadow not enabled (#2641)](https://github.com/ionic-team/stencil/issues/2641) (since v4.2.0)
-- [A slot gets the attribute hidden when it shouldn't (#4523)](https://github.com/ionic-team/stencil/issues/4523) (since v4.7.0)
-- [Nested slots mis-ordered when not using Shadow DOM (#2997)](https://github.com/ionic-team/stencil/issues/2997) (since v4.7.0)
-- [Inconsistent behavior: slot-fb breaks styling of default slot content in component with 'shadow: false' (#2937)](https://github.com/ionic-team/stencil/issues/2937) (since v4.7.2)
-- [Slot content went missing within dynamic component (#4284)](https://github.com/ionic-team/stencil/issues/4284) (since v4.8.2)
-- [Slot element loses its parent reference and disappears when its parent is rendered conditionally (#3913)](https://github.com/ionic-team/stencil/issues/3913) (since v4.8.2)
-- [Failed to execute 'removeChild' on 'Node' (#3278)](https://github.com/ionic-team/stencil/issues/3278) (since v4.9.0)
-- [React fails to manage children in Stencil <slot /> (#2259)](https://github.com/ionic-team/stencil/issues/2259) (since v4.9.0)
+- Elements rendered outside of slot when shadow not enabled [(#2641)](https://github.com/ionic-team/stencil/issues/2641) (since v4.2.0)
+- A slot gets the attribute hidden when it shouldn't [(#4523)](https://github.com/ionic-team/stencil/issues/4523) (since v4.7.0)
+- Nested slots mis-ordered when not using Shadow DOM [(#2997)](https://github.com/ionic-team/stencil/issues/2997) (since v4.7.0)
+- Inconsistent behavior: slot-fb breaks styling of default slot content in component with 'shadow: false' [(#2937)](https://github.com/ionic-team/stencil/issues/2937) (since v4.7.2)
+- Slot content went missing within dynamic component [(#4284)](https://github.com/ionic-team/stencil/issues/4284) (since v4.8.2)
+- Slot element loses its parent reference and disappears when its parent is rendered conditionally [(#3913)](https://github.com/ionic-team/stencil/issues/3913) (since v4.8.2)
+- Failed to execute 'removeChild' on 'Node' [(#3278)](https://github.com/ionic-team/stencil/issues/3278) (since v4.9.0)
+- React fails to manage children in Stencil slot [(#2259)](https://github.com/ionic-team/stencil/issues/2259) (since v4.9.0)
 
 :::note
 New fixes enabled by this experimental flag are not subject to Stencil's

--- a/versioned_docs/version-v4.2/config/extras.md
+++ b/versioned_docs/version-v4.2/config/extras.md
@@ -103,7 +103,7 @@ Slot-related fixes to the runtime will be added over the course of Stencil v4,
 with the intent of making these the default behavior in Stencil v5. When set to
 `true` fixes for the following issues will be applied:
 
-- [Elements rendered outside of slot when shadow not enabled (#2641)](https://github.com/ionic-team/stencil/issues/2641) (since v4.2.0)
+- Elements rendered outside of slot when shadow not enabled [(#2641)](https://github.com/ionic-team/stencil/issues/2641) (since v4.2.0)
 
 :::note
 New fixes enabled by this experimental flag are not subject to Stencil's

--- a/versioned_docs/version-v4.3/config/extras.md
+++ b/versioned_docs/version-v4.3/config/extras.md
@@ -103,7 +103,7 @@ Slot-related fixes to the runtime will be added over the course of Stencil v4,
 with the intent of making these the default behavior in Stencil v5. When set to
 `true` fixes for the following issues will be applied:
 
-- [Elements rendered outside of slot when shadow not enabled (#2641)](https://github.com/ionic-team/stencil/issues/2641) (since v4.2.0)
+- Elements rendered outside of slot when shadow not enabled [(#2641)](https://github.com/ionic-team/stencil/issues/2641) (since v4.2.0)
 
 :::note
 New fixes enabled by this experimental flag are not subject to Stencil's

--- a/versioned_docs/version-v4.4/config/extras.md
+++ b/versioned_docs/version-v4.4/config/extras.md
@@ -103,7 +103,7 @@ Slot-related fixes to the runtime will be added over the course of Stencil v4,
 with the intent of making these the default behavior in Stencil v5. When set to
 `true` fixes for the following issues will be applied:
 
-- [Elements rendered outside of slot when shadow not enabled (#2641)](https://github.com/ionic-team/stencil/issues/2641) (since v4.2.0)
+- Elements rendered outside of slot when shadow not enabled [(#2641)](https://github.com/ionic-team/stencil/issues/2641) (since v4.2.0)
 
 :::note
 New fixes enabled by this experimental flag are not subject to Stencil's

--- a/versioned_docs/version-v4.5/config/extras.md
+++ b/versioned_docs/version-v4.5/config/extras.md
@@ -103,7 +103,7 @@ Slot-related fixes to the runtime will be added over the course of Stencil v4,
 with the intent of making these the default behavior in Stencil v5. When set to
 `true` fixes for the following issues will be applied:
 
-- [Elements rendered outside of slot when shadow not enabled (#2641)](https://github.com/ionic-team/stencil/issues/2641) (since v4.2.0)
+- Elements rendered outside of slot when shadow not enabled [(#2641)](https://github.com/ionic-team/stencil/issues/2641) (since v4.2.0)
 
 :::note
 New fixes enabled by this experimental flag are not subject to Stencil's

--- a/versioned_docs/version-v4.6/config/extras.md
+++ b/versioned_docs/version-v4.6/config/extras.md
@@ -103,7 +103,7 @@ Slot-related fixes to the runtime will be added over the course of Stencil v4,
 with the intent of making these the default behavior in Stencil v5. When set to
 `true` fixes for the following issues will be applied:
 
-- [Elements rendered outside of slot when shadow not enabled (#2641)](https://github.com/ionic-team/stencil/issues/2641) (since v4.2.0)
+- Elements rendered outside of slot when shadow not enabled [(#2641)](https://github.com/ionic-team/stencil/issues/2641) (since v4.2.0)
 
 :::note
 New fixes enabled by this experimental flag are not subject to Stencil's

--- a/versioned_docs/version-v4.7/config/extras.md
+++ b/versioned_docs/version-v4.7/config/extras.md
@@ -103,10 +103,10 @@ Slot-related fixes to the runtime will be added over the course of Stencil v4,
 with the intent of making these the default behavior in Stencil v5. When set to
 `true` fixes for the following issues will be applied:
 
-- [Elements rendered outside of slot when shadow not enabled (#2641)](https://github.com/ionic-team/stencil/issues/2641) (since v4.2.0)
-- [A slot gets the attribute hidden when it shouldn't (#4523)](https://github.com/ionic-team/stencil/issues/4523) (since v4.7.0)
-- [Nested slots mis-ordered when not using Shadow DOM (#2997)](https://github.com/ionic-team/stencil/issues/2997) (since v4.7.0)
-- [Inconsistent behavior: slot-fb breaks styling of default slot content in component with 'shadow: false' (#2937)](https://github.com/ionic-team/stencil/issues/2937) (since v4.7.2)
+- Elements rendered outside of slot when shadow not enabled [(#2641)](https://github.com/ionic-team/stencil/issues/2641) (since v4.2.0)
+- A slot gets the attribute hidden when it shouldn't [(#4523)](https://github.com/ionic-team/stencil/issues/4523) (since v4.7.0)
+- Nested slots mis-ordered when not using Shadow DOM [(#2997)](https://github.com/ionic-team/stencil/issues/2997) (since v4.7.0)
+- Inconsistent behavior: slot-fb breaks styling of default slot content in component with 'shadow: false' [(#2937)](https://github.com/ionic-team/stencil/issues/2937) (since v4.7.2)
 
 :::note
 New fixes enabled by this experimental flag are not subject to Stencil's

--- a/versioned_docs/version-v4.7/config/extras.md
+++ b/versioned_docs/version-v4.7/config/extras.md
@@ -104,6 +104,9 @@ with the intent of making these the default behavior in Stencil v5. When set to
 `true` fixes for the following issues will be applied:
 
 - [Elements rendered outside of slot when shadow not enabled (#2641)](https://github.com/ionic-team/stencil/issues/2641) (since v4.2.0)
+- [A slot gets the attribute hidden when it shouldn't (#4523)](https://github.com/ionic-team/stencil/issues/4523) (since v4.7.0)
+- [Nested slots mis-ordered when not using Shadow DOM (#2997)](https://github.com/ionic-team/stencil/issues/2997) (since v4.7.0)
+- [Inconsistent behavior: slot-fb breaks styling of default slot content in component with 'shadow: false' (#2937)](https://github.com/ionic-team/stencil/issues/2937) (since v4.7.2)
 
 :::note
 New fixes enabled by this experimental flag are not subject to Stencil's

--- a/versioned_docs/version-v4.8/config/extras.md
+++ b/versioned_docs/version-v4.8/config/extras.md
@@ -104,6 +104,11 @@ with the intent of making these the default behavior in Stencil v5. When set to
 `true` fixes for the following issues will be applied:
 
 - [Elements rendered outside of slot when shadow not enabled (#2641)](https://github.com/ionic-team/stencil/issues/2641) (since v4.2.0)
+- [A slot gets the attribute hidden when it shouldn't (#4523)](https://github.com/ionic-team/stencil/issues/4523) (since v4.7.0)
+- [Nested slots mis-ordered when not using Shadow DOM (#2997)](https://github.com/ionic-team/stencil/issues/2997) (since v4.7.0)
+- [Inconsistent behavior: slot-fb breaks styling of default slot content in component with 'shadow: false' (#2937)](https://github.com/ionic-team/stencil/issues/2937) (since v4.7.2)
+- [Slot content went missing within dynamic component (#4284)](https://github.com/ionic-team/stencil/issues/4284) (since v4.8.2)
+- [Slot element loses its parent reference and disappears when its parent is rendered conditionally (#3913)](https://github.com/ionic-team/stencil/issues/3913) (since v4.8.2)
 
 :::note
 New fixes enabled by this experimental flag are not subject to Stencil's

--- a/versioned_docs/version-v4.8/config/extras.md
+++ b/versioned_docs/version-v4.8/config/extras.md
@@ -103,12 +103,12 @@ Slot-related fixes to the runtime will be added over the course of Stencil v4,
 with the intent of making these the default behavior in Stencil v5. When set to
 `true` fixes for the following issues will be applied:
 
-- [Elements rendered outside of slot when shadow not enabled (#2641)](https://github.com/ionic-team/stencil/issues/2641) (since v4.2.0)
-- [A slot gets the attribute hidden when it shouldn't (#4523)](https://github.com/ionic-team/stencil/issues/4523) (since v4.7.0)
-- [Nested slots mis-ordered when not using Shadow DOM (#2997)](https://github.com/ionic-team/stencil/issues/2997) (since v4.7.0)
-- [Inconsistent behavior: slot-fb breaks styling of default slot content in component with 'shadow: false' (#2937)](https://github.com/ionic-team/stencil/issues/2937) (since v4.7.2)
-- [Slot content went missing within dynamic component (#4284)](https://github.com/ionic-team/stencil/issues/4284) (since v4.8.2)
-- [Slot element loses its parent reference and disappears when its parent is rendered conditionally (#3913)](https://github.com/ionic-team/stencil/issues/3913) (since v4.8.2)
+- Elements rendered outside of slot when shadow not enabled [(#2641)](https://github.com/ionic-team/stencil/issues/2641) (since v4.2.0)
+- A slot gets the attribute hidden when it shouldn't [(#4523)](https://github.com/ionic-team/stencil/issues/4523) (since v4.7.0)
+- Nested slots mis-ordered when not using Shadow DOM [(#2997)](https://github.com/ionic-team/stencil/issues/2997) (since v4.7.0)
+- Inconsistent behavior: slot-fb breaks styling of default slot content in component with 'shadow: false' [(#2937)](https://github.com/ionic-team/stencil/issues/2937) (since v4.7.2)
+- Slot content went missing within dynamic component [(#4284)](https://github.com/ionic-team/stencil/issues/4284) (since v4.8.2)
+- Slot element loses its parent reference and disappears when its parent is rendered conditionally [(#3913)](https://github.com/ionic-team/stencil/issues/3913) (since v4.8.2)
 
 :::note
 New fixes enabled by this experimental flag are not subject to Stencil's

--- a/versioned_docs/version-v4.9/config/extras.md
+++ b/versioned_docs/version-v4.9/config/extras.md
@@ -104,6 +104,13 @@ with the intent of making these the default behavior in Stencil v5. When set to
 `true` fixes for the following issues will be applied:
 
 - [Elements rendered outside of slot when shadow not enabled (#2641)](https://github.com/ionic-team/stencil/issues/2641) (since v4.2.0)
+- [A slot gets the attribute hidden when it shouldn't (#4523)](https://github.com/ionic-team/stencil/issues/4523) (since v4.7.0)
+- [Nested slots mis-ordered when not using Shadow DOM (#2997)](https://github.com/ionic-team/stencil/issues/2997) (since v4.7.0)
+- [Inconsistent behavior: slot-fb breaks styling of default slot content in component with 'shadow: false' (#2937)](https://github.com/ionic-team/stencil/issues/2937) (since v4.7.2)
+- [Slot content went missing within dynamic component (#4284)](https://github.com/ionic-team/stencil/issues/4284) (since v4.8.2)
+- [Slot element loses its parent reference and disappears when its parent is rendered conditionally (#3913)](https://github.com/ionic-team/stencil/issues/3913) (since v4.8.2)
+- [Failed to execute 'removeChild' on 'Node' (#3278)](https://github.com/ionic-team/stencil/issues/3278) (since v4.9.0)
+- [React fails to manage children in Stencil <slot /> (#2259)](https://github.com/ionic-team/stencil/issues/2259) (since v4.9.0)
 
 :::note
 New fixes enabled by this experimental flag are not subject to Stencil's

--- a/versioned_docs/version-v4.9/config/extras.md
+++ b/versioned_docs/version-v4.9/config/extras.md
@@ -103,14 +103,14 @@ Slot-related fixes to the runtime will be added over the course of Stencil v4,
 with the intent of making these the default behavior in Stencil v5. When set to
 `true` fixes for the following issues will be applied:
 
-- [Elements rendered outside of slot when shadow not enabled (#2641)](https://github.com/ionic-team/stencil/issues/2641) (since v4.2.0)
-- [A slot gets the attribute hidden when it shouldn't (#4523)](https://github.com/ionic-team/stencil/issues/4523) (since v4.7.0)
-- [Nested slots mis-ordered when not using Shadow DOM (#2997)](https://github.com/ionic-team/stencil/issues/2997) (since v4.7.0)
-- [Inconsistent behavior: slot-fb breaks styling of default slot content in component with 'shadow: false' (#2937)](https://github.com/ionic-team/stencil/issues/2937) (since v4.7.2)
-- [Slot content went missing within dynamic component (#4284)](https://github.com/ionic-team/stencil/issues/4284) (since v4.8.2)
-- [Slot element loses its parent reference and disappears when its parent is rendered conditionally (#3913)](https://github.com/ionic-team/stencil/issues/3913) (since v4.8.2)
-- [Failed to execute 'removeChild' on 'Node' (#3278)](https://github.com/ionic-team/stencil/issues/3278) (since v4.9.0)
-- [React fails to manage children in Stencil <slot /> (#2259)](https://github.com/ionic-team/stencil/issues/2259) (since v4.9.0)
+- Elements rendered outside of slot when shadow not enabled [(#2641)](https://github.com/ionic-team/stencil/issues/2641) (since v4.2.0)
+- A slot gets the attribute hidden when it shouldn't [(#4523)](https://github.com/ionic-team/stencil/issues/4523) (since v4.7.0)
+- Nested slots mis-ordered when not using Shadow DOM [(#2997)](https://github.com/ionic-team/stencil/issues/2997) (since v4.7.0)
+- Inconsistent behavior: slot-fb breaks styling of default slot content in component with 'shadow: false' [(#2937)](https://github.com/ionic-team/stencil/issues/2937) (since v4.7.2)
+- Slot content went missing within dynamic component [(#4284)](https://github.com/ionic-team/stencil/issues/4284) (since v4.8.2)
+- Slot element loses its parent reference and disappears when its parent is rendered conditionally [(#3913)](https://github.com/ionic-team/stencil/issues/3913) (since v4.8.2)
+- Failed to execute 'removeChild' on 'Node' [(#3278)](https://github.com/ionic-team/stencil/issues/3278) (since v4.9.0)
+- React fails to manage children in Stencil slot [(#2259)](https://github.com/ionic-team/stencil/issues/2259) (since v4.9.0)
 
 :::note
 New fixes enabled by this experimental flag are not subject to Stencil's


### PR DESCRIPTION
Adds links to issues resolved by the `experimentalSlotFixes` flag in the corresponding versions