### PR TITLE
docs(support): add support note for TypeScript 5.3 in Stencil v4.10 and higher

### DIFF
--- a/docs/reference/support-policy.md
+++ b/docs/reference/support-policy.md
@@ -86,6 +86,7 @@ The table below describes recent versions of Stencil and the version of TypeScri
 
 | Stencil Version | TypeScript Version |
 |:---------------:|:------------------:|
+|     v4.10.0     |       v5.3.0       |
 |     v4.4.0      |       v5.2.2       |
 |     v4.2.0      |       v5.1.6       |
 |     v3.3.0      |       v5.0.4       |

--- a/versioned_docs/version-v4.4/reference/support-policy.md
+++ b/versioned_docs/version-v4.4/reference/support-policy.md
@@ -86,6 +86,7 @@ The table below describes recent versions of Stencil and the version of TypeScri
 
 | Stencil Version | TypeScript Version |
 |:---------------:|:------------------:|
+|     v4.10.0     |       v5.3.0       |
 |     v4.4.0      |       v5.2.2       |
 |     v4.2.0      |       v5.1.6       |
 |     v3.3.0      |       v5.0.4       |

--- a/versioned_docs/version-v4.5/reference/support-policy.md
+++ b/versioned_docs/version-v4.5/reference/support-policy.md
@@ -86,6 +86,7 @@ The table below describes recent versions of Stencil and the version of TypeScri
 
 | Stencil Version | TypeScript Version |
 |:---------------:|:------------------:|
+|     v4.10.0     |       v5.3.0       |
 |     v4.4.0      |       v5.2.2       |
 |     v4.2.0      |       v5.1.6       |
 |     v3.3.0      |       v5.0.4       |

--- a/versioned_docs/version-v4.6/reference/support-policy.md
+++ b/versioned_docs/version-v4.6/reference/support-policy.md
@@ -86,6 +86,7 @@ The table below describes recent versions of Stencil and the version of TypeScri
 
 | Stencil Version | TypeScript Version |
 |:---------------:|:------------------:|
+|     v4.10.0     |       v5.3.0       |
 |     v4.4.0      |       v5.2.2       |
 |     v4.2.0      |       v5.1.6       |
 |     v3.3.0      |       v5.0.4       |

--- a/versioned_docs/version-v4.7/reference/support-policy.md
+++ b/versioned_docs/version-v4.7/reference/support-policy.md
@@ -86,6 +86,7 @@ The table below describes recent versions of Stencil and the version of TypeScri
 
 | Stencil Version | TypeScript Version |
 |:---------------:|:------------------:|
+|     v4.10.0     |       v5.3.0       |
 |     v4.4.0      |       v5.2.2       |
 |     v4.2.0      |       v5.1.6       |
 |     v3.3.0      |       v5.0.4       |

--- a/versioned_docs/version-v4.8/reference/support-policy.md
+++ b/versioned_docs/version-v4.8/reference/support-policy.md
@@ -86,6 +86,7 @@ The table below describes recent versions of Stencil and the version of TypeScri
 
 | Stencil Version | TypeScript Version |
 |:---------------:|:------------------:|
+|     v4.10.0     |       v5.3.0       |
 |     v4.4.0      |       v5.2.2       |
 |     v4.2.0      |       v5.1.6       |
 |     v3.3.0      |       v5.0.4       |

--- a/versioned_docs/version-v4.9/reference/support-policy.md
+++ b/versioned_docs/version-v4.9/reference/support-policy.md
@@ -86,6 +86,7 @@ The table below describes recent versions of Stencil and the version of TypeScri
 
 | Stencil Version | TypeScript Version |
 |:---------------:|:------------------:|
+|     v4.10.0     |       v5.3.0       |
 |     v4.4.0      |       v5.2.2       |
 |     v4.2.0      |       v5.1.6       |
 |     v3.3.0      |       v5.0.4       |


### PR DESCRIPTION
This is assuming that the [PR with the update](https://github.com/ionic-team/stencil/pull/5248) is part of a minor Stencil release. I will move this PR out of draft once this is verified and the docs update is ready.