### PR TITLE
docs(docs-readme): fill out docs-readme output target

### DIFF
--- a/docs/config/cli.md
+++ b/docs/config/cli.md
@@ -14,26 +14,26 @@ Stencil's CLI is included in the compiler, and can be invoked with the `stencil`
 
 Builds a Stencil project. The flags below are the available options for the `build` command.
 
-| Flag | Description                                                                                                                                                                                                                                        | Alias |
-|------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------|
-| `--ci` | Run a build using recommended settings for a Continuous Integration (CI) environment. Defaults the number of workers to 4, allows for extra time if taking screenshots via the tests and modifies the console logs.                                | |
-| `--config` | Path to the `stencil.config.ts` file. This flag is not needed in most cases since Stencil will find the config. Additionally, a Stencil config is not required.                                                                                    | `-c` |
-| `--debug` | Adds additional runtime code to help debug, and sets the log level for more verbose output.                                                                                                                                                        | |
-| `--dev` | Runs a development build.                                                                                                                                                                                                                          | |
-| `--docs` | Generate docs based on the component types, properties, methods, events, JSDocs, CSS Custom Properties, etc.                                                                                                                                       | |
+| Flag | Description | Alias |
+|------|-------------|-------|
+| `--ci` | Run a build using recommended settings for a Continuous Integration (CI) environment. Defaults the number of workers to 4, allows for extra time if taking screenshots via the tests and modifies the console logs. | |
+| `--config` | Path to the `stencil.config.ts` file. This flag is not needed in most cases since Stencil will find the config. Additionally, a Stencil config is not required. | `-c` |
+| `--debug` | Adds additional runtime code to help debug, and sets the log level for more verbose output. | |
+| `--dev` | Runs a development build. | |
+| `--docs` | Generate all docs based on the component types, properties, methods, events, JSDocs, CSS Custom Properties, etc. | |
 | `--es5` | Creates an ES5 compatible build. By default ES5 builds are not created during development in order to improve build times. However, ES5 builds are always created during production builds. Use this flag to create ES5 builds during development. | |
-| `--log` | Write logs for the `stencil build` into `stencil-build.log`. The log file is written in the same location as the config.                                                                                                                           | |
-| `--prerender` | Prerender the application using the `www` output target after the build has completed.                                                                                                                                                             | |
-| `--prod` | Runs a production build which will optimize each file, improve bundling, remove unused code, minify, etc. A production build is the default, this flag is only used to override the `--dev` flag.                                                  | |
-| `--max-workers` | Max number of workers the compiler should use. Defaults to use the same number of CPUs the Operating System has available.                                                                                                                         | |
-| `--next` | Opt-in to test the "next" Stencil compiler features.                                                                                                                                                                                               | |
-| `--no-cache` | Disables using the cache.                                                                                                                                                                                                                          | |
-| `--no-open` | By default the `--serve` command will open a browser window. Using the `--no-open` command will not automatically open a browser window.                                                                                                           | |
-| `--port` | Port for the [Integrated Dev Server](./dev-server.md). Defaults to `3333`.                                                                                                                                                                         | `-p` |
-| `--serve` | Starts the [Integrated Dev Server](./dev-server.md).                                                                                                                                                                                               | |
-| `--stats` | Write stats about the project to `stencil-stats.json`. The stats file is written in the same location as the config.                                                                                                                               | |
-| `--verbose` | Logs additional information about each step of the build.                                                                                                                                                                                          | |
-| `--watch` | Watches files during development and triggers a rebuild when files are updated.                                                                                                                                                                    | |
+| `--log` | Write logs for the `stencil build` into `stencil-build.log`. The log file is written in the same location as the config. | |
+| `--prerender` | Prerender the application using the `www` output target after the build has completed. | |
+| `--prod` | Runs a production build which will optimize each file, improve bundling, remove unused code, minify, etc. A production build is the default, this flag is only used to override the `--dev` flag. | |
+| `--max-workers` | Max number of workers the compiler should use. Defaults to use the same number of CPUs the Operating System has available. | |
+| `--next` | Opt-in to test the "next" Stencil compiler features. | |
+| `--no-cache` | Disables using the cache. | |
+| `--no-open` | By default the `--serve` command will open a browser window. Using the `--no-open` command will not automatically open a browser window. | |
+| `--port` | Port for the [Integrated Dev Server](./dev-server.md). Defaults to `3333`. | `-p` |
+| `--serve` | Starts the [Integrated Dev Server](./dev-server.md). | |
+| `--stats` | Write stats about the project to `stencil-stats.json`. The stats file is written in the same location as the config. | |
+| `--verbose` | Logs additional information about each step of the build. | |
+| `--watch` | Watches files during development and triggers a rebuild when files are updated. | |
 
 ## `stencil docs`
 

--- a/docs/config/cli.md
+++ b/docs/config/cli.md
@@ -14,26 +14,26 @@ Stencil's CLI is included in the compiler, and can be invoked with the `stencil`
 
 Builds a Stencil project. The flags below are the available options for the `build` command.
 
-| Flag | Description | Alias |
-|------|-------------|-------|
-| `--ci` | Run a build using recommended settings for a Continuous Integration (CI) environment. Defaults the number of workers to 4, allows for extra time if taking screenshots via the tests and modifies the console logs. | |
-| `--config` | Path to the `stencil.config.ts` file. This flag is not needed in most cases since Stencil will find the config. Additionally, a Stencil config is not required. | `-c` |
-| `--debug` | Adds additional runtime code to help debug, and sets the log level for more verbose output. | |
-| `--dev` | Runs a development build. | |
-| `--docs-readme` | Generate `readme.md` docs based on the component types, properties, methods, events, JSDocs, CSS Custom Properties, etc. | |
+| Flag | Description                                                                                                                                                                                                                                        | Alias |
+|------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------|
+| `--ci` | Run a build using recommended settings for a Continuous Integration (CI) environment. Defaults the number of workers to 4, allows for extra time if taking screenshots via the tests and modifies the console logs.                                | |
+| `--config` | Path to the `stencil.config.ts` file. This flag is not needed in most cases since Stencil will find the config. Additionally, a Stencil config is not required.                                                                                    | `-c` |
+| `--debug` | Adds additional runtime code to help debug, and sets the log level for more verbose output.                                                                                                                                                        | |
+| `--dev` | Runs a development build.                                                                                                                                                                                                                          | |
+| `--docs` | Generate docs based on the component types, properties, methods, events, JSDocs, CSS Custom Properties, etc.                                                                                                                                       | |
 | `--es5` | Creates an ES5 compatible build. By default ES5 builds are not created during development in order to improve build times. However, ES5 builds are always created during production builds. Use this flag to create ES5 builds during development. | |
-| `--log` | Write logs for the `stencil build` into `stencil-build.log`. The log file is written in the same location as the config. | |
-| `--prerender` | Prerender the application using the `www` output target after the build has completed. | |
-| `--prod` | Runs a production build which will optimize each file, improve bundling, remove unused code, minify, etc. A production build is the default, this flag is only used to override the `--dev` flag. | |
-| `--max-workers` | Max number of workers the compiler should use. Defaults to use the same number of CPUs the Operating System has available. | |
-| `--next` | Opt-in to test the "next" Stencil compiler features. | |
-| `--no-cache` | Disables using the cache. | |
-| `--no-open` | By default the `--serve` command will open a browser window. Using the `--no-open` command will not automatically open a browser window. | |
-| `--port` | Port for the [Integrated Dev Server](./dev-server.md). Defaults to `3333`. | `-p` |
-| `--serve` | Starts the [Integrated Dev Server](./dev-server.md). | |
-| `--stats` | Write stats about the project to `stencil-stats.json`. The stats file is written in the same location as the config. | |
-| `--verbose` | Logs additional information about each step of the build. | |
-| `--watch` | Watches files during development and triggers a rebuild when files are updated. | |
+| `--log` | Write logs for the `stencil build` into `stencil-build.log`. The log file is written in the same location as the config.                                                                                                                           | |
+| `--prerender` | Prerender the application using the `www` output target after the build has completed.                                                                                                                                                             | |
+| `--prod` | Runs a production build which will optimize each file, improve bundling, remove unused code, minify, etc. A production build is the default, this flag is only used to override the `--dev` flag.                                                  | |
+| `--max-workers` | Max number of workers the compiler should use. Defaults to use the same number of CPUs the Operating System has available.                                                                                                                         | |
+| `--next` | Opt-in to test the "next" Stencil compiler features.                                                                                                                                                                                               | |
+| `--no-cache` | Disables using the cache.                                                                                                                                                                                                                          | |
+| `--no-open` | By default the `--serve` command will open a browser window. Using the `--no-open` command will not automatically open a browser window.                                                                                                           | |
+| `--port` | Port for the [Integrated Dev Server](./dev-server.md). Defaults to `3333`.                                                                                                                                                                         | `-p` |
+| `--serve` | Starts the [Integrated Dev Server](./dev-server.md).                                                                                                                                                                                               | |
+| `--stats` | Write stats about the project to `stencil-stats.json`. The stats file is written in the same location as the config.                                                                                                                               | |
+| `--verbose` | Logs additional information about each step of the build.                                                                                                                                                                                          | |
+| `--watch` | Watches files during development and triggers a rebuild when files are updated.                                                                                                                                                                    | |
 
 ## `stencil docs`
 

--- a/docs/documentation-generation/docs-readme.md
+++ b/docs/documentation-generation/docs-readme.md
@@ -140,7 +140,7 @@ If a component's JSDoc does not contain an overview, this section will be omitte
 ### Usage Examples
 
 Usage examples are user-generated markdown files that demonstrate how another developer might use a component.
-These files are separate from a component's README file, and are placed in a `usage/` adjacent to a component's implementation.
+These files are separate from a component's README file, and are placed in a `usage/` directory adjacent to a component's implementation.
 
 The content of these files will be added to a `Usage` section of the generated README. 
 This allows you to keep examples right next to the code, making it easy to include them in a documentation site or other downstream consumer(s) of your docs.

--- a/docs/documentation-generation/docs-readme.md
+++ b/docs/documentation-generation/docs-readme.md
@@ -28,32 +28,32 @@ export const config: Config = {
 
 ## Generating README Files
 
-### Using the Build Task
+### Using the Build Command
 
-If your project has a `docs-readme` output target configured in your Stencil configuration file, the Stencil [build task](../config/cli.md#stencil-build) is all that's needed to generate README docs:
+If your project has a `docs-readme` output target configured in your Stencil configuration file, the Stencil [build command](../config/cli.md#stencil-build) is all that's needed to generate README docs:
 ```bash
 npx stencil build
 ```
-If you're running the build task with the `--watch` flag, your project's README files will automatically update without requiring multiple explicit build commands:
+If you're running the build command with the `--watch` flag, your project's README files will automatically update without requiring multiple explicit build commands:
 ```bash
 npm stencil build --watch
 ```
 
 :::info
-When running the build task with the `--dev` flag, README files will not be generated.
+When running the build command with the `--dev` flag, README files will not be generated.
 This is to prevent unnecessary I/O operations during the development cycle.
 :::
 
-If you choose not to include a `docs-readme` output target in your Stencil configuration file, use the `--docs` CLI flag as a part of the build task:
+If you choose not to include a `docs-readme` output target in your Stencil configuration file, use the `--docs` CLI flag as a part of the build command:
 ```bash
 npx stencil build --docs
 ```
 
 This will cause the Stencil compiler to perform a one-time build of your entire project, including README files.
 
-### Using the Docs Task
+### Using the Docs Command
 
-As an alternative to the build task, the [docs task](../config/cli.md#stencil-docs) can be used to perform a one time generation of the documentation:
+As an alternative to the build command, the [docs command](../config/cli.md#stencil-docs) can be used to perform a one time generation of the documentation:
 ```bash
 npx stencil docs
 ```

--- a/docs/documentation-generation/docs-readme.md
+++ b/docs/documentation-generation/docs-readme.md
@@ -324,7 +324,7 @@ If a component does not use the `@Method()` decorator, this section will be omit
 
 ### @slot Details
 
-A component that uses [slots](../components/templating-and-jsx.md#slots) may describe the its slots in the component's JSDoc using the Stencil-specific `@slot` JSDoc tag.
+A component that uses [slots](../components/templating-and-jsx.md#slots) may describe its slots in the component's JSDoc using the Stencil-specific `@slot` JSDoc tag.
 The `@slot` tag follows the following format:
 ```
 @slot [slot-name] - [description]

--- a/docs/documentation-generation/docs-readme.md
+++ b/docs/documentation-generation/docs-readme.md
@@ -7,54 +7,459 @@ slug: /docs-readme
 
 # Docs Readme Markdown File Auto-Generation
 
-Stencil is able to auto-generate `readme.md` files in markdown. This
-feature will save the readme files as a sibling to the component's source file within the
-same directory. This can help you to maintain consistently formatted
-documentation for your components which live right next to them and render in
+Stencil is able to auto-generate `readme.md` files for your components.
+This can help you to maintain consistently formatted
+documentation for your components which lives right next to them and render in
 GitHub.
 
-To auto-generate readme files, add the `docs-readme` output target to your
-`stencil.config.ts` like so:
+## Setup
+
+To generate markdown files using the `docs-readme` output target, it is recommended to add the following to your Stencil configuration file:
 
 ```tsx title="stencil.config.ts"
 import { Config } from '@stencil/core';
 
 export const config: Config = {
   outputTargets: [
-    { type: 'docs-readme' }
+    { 
+      type: 'docs-readme'
+    }
   ]
 };
 ```
 
-Another option would be to use the `--docs` CLI flag as a part of the [build task](../config/cli.md#stencil-build), like so:
+## Generating README Files
 
+### Using the Build Task
+
+If your project has a `docs-readme` output target configured in your Stencil configuration file, the Stencil [build task](../config/cli.md#stencil-build) is all that's needed to generate readme docs:
 ```bash
-stencil build --docs
+npx stencil build
+```
+If you're running the build task with the `--watch` flag, your project's README files will automatically update without requiring multiple explicit build commands:
+```bash
+npm stencil build --watch
 ```
 
-This will cause the Stencil compiler to perform a one-time generation of README
-files as a part of the build process.
-
-:::note
-If you don't add the `docs-readme` output target to your Stencil configuration, the `--docs` flag must be applied to regenerate documentation.
+:::info
+When running the build task with the `--dev` flag, README files will not be generated.
+This is to prevent unnecessary I/O operations during the development cycle.
 :::
 
-Alternatively, the [docs task](../config/cli.md#stencil-docs) can be used to perform a one time generation of the documentation:
+If you choose not to include a `docs-readme` output target in your Stencil configuration file, use the `--docs` CLI flag as a part of the build task:
 ```bash
-stencil docs
+npx stencil build --docs
 ```
 
-## Adding Custom Markdown to Auto-Generated Files
+This will cause the Stencil compiler to perform a one-time build of your entire project, including README files.
 
-Once you've generated a `readme.md` file you can customize it with your own
-markdown content. Simply add your own markdown above the comment that reads:
-`<!-- Auto Generated Below -->`.
+### Using the Docs Task
 
-## Custom Footer
+As an alternative to the build task, the [docs task](../config/cli.md#stencil-docs) can be used to perform a one time generation of the documentation:
+```bash
+npx stencil docs
+```
+Running `stencil docs` will generate documentation for all documentation output targets, not just `docs-readme`.
+
+## Generating Content
+
+Most generated markdown content will automatically be generated without requiring any additional configuration.
+Content is generated based on its Stencil component, rather than requiring you to configure multiple flags.
+Each section below describes the different types of content Stencil recognizes and will automatically generate. 
+
+### Custom Markdown Content
+
+Once you've generated a `readme.md` file, you can add your own markdown content to the file.
+You may add any content above the following comment in a component's `readme.md`:
+```
+Custom content goes here!
+<!-- Auto Generated Below -->
+```
+
+Any custom content placed above this comment will be persisted on subsequent builds of the README file.
+
+### Deprecation Notices
+
+A Stencil component may be marked as deprecated using the [JSDoc `@deprecated` tag](https://jsdoc.app/tags-deprecated).
+By placing `@deprecated` in a component's class-level JSDoc will cause the generated README to denote the component is deprecated.
+
+```tsx title="my-component.tsx with @deprecated"
+/**
+ * A simple component for formatting names.
+ * 
+ * @deprecated since v2.0.0
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent { }
+```
+
+In the code block above, `@deprecated` is added to the JSDoc for `MyComponent`.
+This causes the generated README to contain:
+```
+> **[DEPRECATED]** since v2.0.0
+```
+
+The deprecation notice will always begin with `> **[DEPRECATED]**`, followed by the deprecation description.
+In this case, that description is "since v2.0.0".
+
+The deprecation notice will be placed after the [`<!-- Auto Generated Below -->` comment](#custom-markdown-content) in the README.
+
+If a component is not marked as deprecated, this section will be omitted from the generated README.
+
+### Overview Documentation
+
+A Stencil component that has a JSDoc comment on its class component like so:
+
+```tsx title="my-component.tsx with an overview"
+/**
+ * A simple component for formatting names
+ *
+ * This component will do some neat things!
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent { }
+```
+will generate the following section in your component's README:
+
+```
+## Overview
+
+A simple component for formatting names
+
+This component will do some neat things!
+```
+
+The overview will be placed after the [deprecation notice](#deprecation-notices) section of the README.
+If a component's JSDoc does not contain an overview, this section will be omitted from the generated README.
+
+### Usage Examples
+
+Usage examples are user-generated markdown files that demonstrate how another developer might use a component.
+These files are separate from a component's README file, and are placed in a `usage/` adjacent to a component's implementation.
+The content of these files will be added to a `Usage` section of the generated README. 
+This allows you to keep examples right next to the code, making it easy to include them in a documentation site or other downstream consumer(s) of your docs.
+
+The example usage file below gives us a high level overview of how to use the component, `my-component`:
+
+````md title="src/components/my-component/usage/my-component-usage.md"
+# How to Use `my-component`
+
+This component is used to provide a way to greet a user using their first, middle, and last name.
+This component will properly format the provided name, even when all fields aren't provided:
+
+```html
+<my-component first="Stencil"></my-component>
+<my-component first="Stencil" last="JS"></my-component>
+```
+````
+
+When the README for `my-component` is regenerated, following will be added to the README:
+
+````md
+## Usage
+
+### My-component-usage
+
+# How to Use `my-component`
+
+This component is used to provide a way to greet a user using their first, middle, and last name.
+This component will properly format the provided name, even when all fields aren't provided:
+
+```html
+<my-component first="Stencil"></my-component>
+<my-component first="Stencil" last="JS"></my-component>
+```
+````
+
+:::caution
+Stencil does not check that your usage examples are up-to-date.
+If you make any changes to your component's API, you'll need to update your usage examples manually.
+:::
+
+The usage section will be placed after the [overview section](#overview-documentation) of the README.
+
+If a component's directory does not contain any usage files, this section will be omitted from the generated README.
+
+### @Prop() Information
+
+Components that use Stencil's [`@Prop()` decorator](../components/properties.md) will have a section describing the fields that are decorated with `@Prop()`.
+This information is presented in a table containing the following columns:
+- **Property**: The name of the property on the TypeScript class.
+- **Attribute**: The name of the attribute associated with the property name.
+- **Description**: A description of the property, if one was given in a JSDoc comment for the property.
+- **Type**: The TypeScript type of the property.
+- **Default**: The default value of the property.
+
+For the following usages of `@Prop()` in a component:
+```ts
+export class MyComponent {
+  /**
+   * The first name
+   */
+  @Prop() first!: string;
+  /**
+   * @deprecated since v2.1.0
+   */
+  @Prop() middle: string;
+  @Prop() lastName = "Smith";
+
+  // ...
+}
+```
+
+The following section will be generated:
+```md
+## Properties
+
+| Property             | Attribute   | Description                                                            | Type     | Default     |
+| -------------------- | ----------- | ---------------------------------------------------------------------- | -------- | ----------- |
+| `first` _(required)_ | `first`     | The first name                                                         | `string` | `undefined` |
+| `lastName`           | `last-name` |                                                                        | `string` | `"Smith"`   |
+| `middle`             | `middle`    | <span style="color:red">**[DEPRECATED]**</span> since v2.1.0<br/><br/> | `string` | `undefined` |
+```
+
+The properties section will be placed after the [usage examples section](#usage-examples) of the README.
+
+If a component does not use `@Prop()`, this section will be omitted from the generated README.
+
+### @Event() Information
+
+Components that use Stencil's [`@Event()` decorator](../components/events.md) will have a section describing the fields that are decorated with `@Event()`.
+This information is presented in a table containing the following columns:
+- **Event**: The name of the property on the TypeScript class decorated with `@Event()`.
+- **Description**: A description of the property, if one was given in a JSDoc comment for the property.
+- **Type**: The TypeScript type of the property.
+
+For the following usages of `@Event()` in a component:
+```tsx
+export class MyComponent {
+  /**
+   * Emitted when an event is completed
+   */
+  @Event() todoCompleted: EventEmitter<number>;
+  /**
+   * @deprecated
+   */
+  @Event() todoUndo: EventEmitter<number>;
+
+  // ...
+}
+```
+
+The following section will be generated:
+
+```md
+## Events
+
+| Event           | Description                                                | Type                  |
+| --------------- | ---------------------------------------------------------- | --------------------- |
+| `todoCompleted` | Emitted when an event is completed                         | `CustomEvent<number>` |
+| `todoUndo`      | <span style="color:red">**[DEPRECATED]**</span> <br/><br/> | `CustomEvent<number>` |
+```
+
+The events section will be placed after the [@Prop() section](#prop-information) of the README.
+
+If a component does not use `@Event()`, this section will be omitted from the generated README.
+
+### @Method() Information
+
+Components that use Stencil's [`@Method()` decorator](../components/methods.md) will have a section describing each usage `@Method`.
+Each usage of `@Method` will have the following subsections generated:
+- A description of the method, if one was provided in a JSDoc
+- A table containing the name, TypeScript type, and description of each parameter of the method
+- A description of the return value of the method, including its return type.
+
+For the following usages of `@Method()` in a component:
+
+```ts
+export class MyComponent {
+  /**
+   * Scroll by a specified X/Y distance in the component.
+   *
+   * @param x The amount to scroll by on the horizontal axis.
+   * @param y The amount to scroll by on the vertical axis.
+   * @param duration The amount of time to take scrolling by that amount.
+   * @returns the total distance travelled
+   */
+  @Method()
+  // @ts-ignore
+  async scrollByPoint(x: number, y: number, duration: number): Promise<number> { /* omitted */ }
+
+  // ...
+}
+```
+
+The following section will be generated:
+
+```md
+## Methods
+
+### `scrollByPoint(x: number, y: number, duration: number) => Promise<number>`
+
+Scroll by a specified X/Y distance in the component.
+
+#### Parameters
+
+| Name       | Type     | Description                                          |
+| ---------- | -------- | ---------------------------------------------------- |
+| `x`        | `number` | The amount to scroll by on the horizontal axis.      |
+| `y`        | `number` | The amount to scroll by on the vertical axis.        |
+| `duration` | `number` | The amount of time to take scrolling by that amount. |
+
+#### Returns
+
+Type: `Promise<number>`
+
+the total distance travelled
+```
+
+The methods section will be placed after the [@Event section](#event-information) of the README.
+
+If a component does not use `@Method()`, this section will be omitted from the generated README.
+
+### @slot Details
+
+A component that uses [slots](../components/templating-and-jsx.md#slots) may describe the component's slots in the component's JSDoc using the Stencil-specific `@slot` JSDoc tag.
+The `@slot` tag follows the following format:
+```
+@slot [slot-name] - [description]
+```
+where `slot-name` corresponds to the name of the slot in the markup, and `description` describes the usage of the slot.
+
+For this tag to be read properly, the following is required:
+1. Either `slot-name` or `description` must be included. Both may be included though.
+2. The '-' separating the two is required.
+
+For the default slot, omit the `slot-name`.
+
+This information is presented in a table containing the following columns:
+- **Slot**: The name of the slot. The default slot will have no name/be empty.
+- **Description**: A description of the slot, if one was given.
+
+For the following usages of `@slot()` in a component:
+```tsx
+/**
+ * @slot - Content is placed between the named slots if provided without a slot.
+ * @slot primary - Content is placed to the right of the toolbar text.
+ * @slot secondary - Content is placed to the left of the toolbar text.
+ */
+export class MyComponent {
+  // ...
+}
+```
+
+The following table is generated:
+
+```md
+## Slots
+
+| Slot          | Description                                                           |
+| ------------- | --------------------------------------------------------------------- |
+|               | Content is placed between the named slots if provided without a slot. |
+| `"primary"`   | Content is placed to the right of the toolbar text.                   |
+| `"secondary"` | Content is placed to the left of the toolbar text.                    |
+
+```
+
+The slots section will be placed after the [@Method section](#method-information) of the README.
+
+If a component does not use `@slot`, this section will be omitted from the generated README.
+
+### Shadow Parts
+
+A component that uses [shadow parts](../components/styling.md#css-parts) may describe the component's shadow parts in the component's JSDoc using the Stencil-specific `@part` JSDoc tag.
+The `@part` tag follows the following format:
+```
+@part [part-name] - [description]
+```
+where `part-name` corresponds to the name of the css part in the markup, and `description` describes the usage of the shadow part.
+
+For this tag to be read properly, the following is required:
+1. Either `part-name` or `description` must be included, although using both is strongly encouraged.
+2. The '-' separating the two is required.
+
+This information is presented in a table containing the following columns:
+- **Part**: The name of the shadow part.
+- **Description**: A description of the shadow part, if one was given.
+
+For the following usages of `@part()` in a component:
+
+```tsx
+/**
+ * @part container - The container for the checkbox mark.
+ * @part label - The label text describing the checkbox.
+ * @part mark  The checkmark used to indicate the checked state.
+ */
+@Component({
+  tag: 'my-component',
+  styleUrl: 'my-component.css',
+  shadow: true,
+})
+export class MyComponent {
+  // ...
+}
+```
+
+The following table will be generated:
+```md
+## Shadow Parts
+
+| Part                                                        | Description                             |
+| ----------------------------------------------------------- | --------------------------------------- |
+| `"container"`                                               | The container for the checkbox mark.    |
+| `"label"`                                                   | The label text describing the checkbox. |
+| `"mark  The checkmark used to indicate the checked state."` |                                         |
+```
+
+The shadow parts section will be placed after the [@Slot Details](#slot-details) of the README.
+
+If a component does not use `@part`, this section will be omitted from the generated README.
+
+### Styling Details
+
+Styles can be documented in Stencil components as well.
+An example of this is a CSS variable that a component's styling depends on.
+Using the `@prop` JSDoc in a component's CSS file, Stencil can generate this documentation as well.
+
+This information is presented in a table containing the following columns:
+- **Name**: The name of the custom property.
+- **Description**: A description of the custom property, if one was given.
+
+For the following usages of `@prop()` in a component's css file:
+
+```css
+:host {
+  /**
+   * @prop --border-radius: Border radius of the avatar and inner image
+   */
+  border-radius: var(--border-radius);
+}
+```
+The following table will be generated:
+
+```md
+## CSS Custom Properties
+
+| Name              | Description                                 |
+| ----------------- | ------------------------------------------- |
+| `--border-radius` | Border radius of the avatar and inner image |
+```
+
+The styling details section will be placed after the [Shadow Parts Details](#shadow-parts) of the README.
+
+If a component does not include styling details, this section will be omitted from the generated README.
+
+### A Custom Footer
 
 Removing or customizing the footer can be done by adding a `footer` property to
 the output target. This string is added to the generated Markdown files without
-modification, so you can use Markdown syntax in it for rich formatting.
+modification, so you can use Markdown syntax in it for rich formatting:
 
 ```tsx title="stencil.config.ts"
 import { Config } from '@stencil/core';
@@ -69,10 +474,16 @@ export const config: Config = {
 };
 ```
 
-## Generating to a Directory
+The following footer will be placed at the bottom of your component's README file:
+```
+*Built with love!*
+```
+
+## Configuration
+### Specifying the Output Directory
 
 By default, a readme file will be generated in the same directory as the
-component corresponds to. This behavior can be changed by setting the `dir`
+component it corresponds to. This behavior can be changed by setting the `dir`
 property on the output target configuration. Specifying a directory will create
 the structure `{dir}/{component}/readme.md`.
 
@@ -89,10 +500,9 @@ export const config: Config = {
 };
 ```
 
-## Strict Mode
+### Strict Mode
 
-Adding `strict: true` to the output target configuration will cause Stencil to
-output a warning whenever the project is built with missing documentation.
+Adding `strict: true` to the output target configuration will cause Stencil to output a warning whenever the project is built with missing documentation.
 
 ```tsx title="stencil.config.ts"
 import { Config } from '@stencil/core';
@@ -106,3 +516,9 @@ export const config: Config = {
   ]
 };
 ```
+
+When strict mode is enabled, the following items are checked:
+1. `@Prop()` usages must be documented, unless the property is marked as `@deprecated`
+2. `@Method()` usages must be documented, unless the method is marked as `@deprecated`
+3. `@Event()` usages must be documented, unless the event is marked as `@deprecated`
+4. CSS Part usages must be documented

--- a/docs/documentation-generation/docs-readme.md
+++ b/docs/documentation-generation/docs-readme.md
@@ -8,7 +8,7 @@ slug: /docs-readme
 # Docs Readme Markdown File Auto-Generation
 
 Stencil is able to auto-generate `readme.md` files for your components.
-This can help you to maintain consistently formatted documentation for your components which lives right next to them and render in GitHub.
+This can help you to maintain consistently formatted documentation for your components which lives right next to them and renders in GitHub.
 
 ## Setup
 

--- a/docs/documentation-generation/docs-readme.md
+++ b/docs/documentation-generation/docs-readme.md
@@ -382,7 +382,7 @@ The following table is generated:
 
 ```
 
-The slots section will be placed after the [@Method section](#method-information) of the README.
+The slots section will be placed after the [@Method section](#method-details) of the README.
 
 If a component's top-level JSDoc does not use `@slot` tags, this section will be omitted from the generated README.
 

--- a/docs/documentation-generation/docs-readme.md
+++ b/docs/documentation-generation/docs-readme.md
@@ -8,13 +8,11 @@ slug: /docs-readme
 # Docs Readme Markdown File Auto-Generation
 
 Stencil is able to auto-generate `readme.md` files for your components.
-This can help you to maintain consistently formatted
-documentation for your components which lives right next to them and render in
-GitHub.
+This can help you to maintain consistently formatted documentation for your components which lives right next to them and render in GitHub.
 
 ## Setup
 
-To generate markdown files using the `docs-readme` output target, it is recommended to add the following to your Stencil configuration file:
+To generate markdown files, it is recommended to add the `docs-readme` output target to your Stencil configuration file:
 
 ```tsx title="stencil.config.ts"
 import { Config } from '@stencil/core';
@@ -32,7 +30,7 @@ export const config: Config = {
 
 ### Using the Build Task
 
-If your project has a `docs-readme` output target configured in your Stencil configuration file, the Stencil [build task](../config/cli.md#stencil-build) is all that's needed to generate readme docs:
+If your project has a `docs-readme` output target configured in your Stencil configuration file, the Stencil [build task](../config/cli.md#stencil-build) is all that's needed to generate README docs:
 ```bash
 npx stencil build
 ```
@@ -59,9 +57,9 @@ As an alternative to the build task, the [docs task](../config/cli.md#stencil-do
 ```bash
 npx stencil docs
 ```
-Running `stencil docs` will generate documentation for all documentation output targets, not just `docs-readme`.
+Running `stencil docs` will generate documentation for [all documentation output targets](./01-overview.md), not just `docs-readme`.
 
-## Generating Content
+## README Sections
 
 Most generated markdown content will automatically be generated without requiring any additional configuration.
 Content is generated based on its Stencil component, rather than requiring you to configure multiple flags.
@@ -83,17 +81,17 @@ Any custom content placed above this comment will be persisted on subsequent bui
 A Stencil component may be marked as deprecated using the [JSDoc `@deprecated` tag](https://jsdoc.app/tags-deprecated).
 By placing `@deprecated` in a component's class-level JSDoc will cause the generated README to denote the component is deprecated.
 
-```tsx title="my-component.tsx with @deprecated"
+For a component with the JSDoc:
+
+```tsx title="A component with @deprecated in its JSDoc"
 /**
- * A simple component for formatting names.
- * 
  * @deprecated since v2.0.0
  */
 @Component({
   tag: 'my-component',
   shadow: true,
 })
-export class MyComponent { }
+export class MyComponent { /* omitted */ }
 ```
 
 In the code block above, `@deprecated` is added to the JSDoc for `MyComponent`.
@@ -102,18 +100,18 @@ This causes the generated README to contain:
 > **[DEPRECATED]** since v2.0.0
 ```
 
-The deprecation notice will always begin with `> **[DEPRECATED]**`, followed by the deprecation description.
+The deprecation notice will always begin with `> **[DEPRECATED]**`, followed by the description provided in the JSDoc.
 In this case, that description is "since v2.0.0".
 
-The deprecation notice will be placed after the [`<!-- Auto Generated Below -->` comment](#custom-markdown-content) in the README.
+The deprecation notice will be placed after the [custom content](#custom-markdown-content) in the README.
 
 If a component is not marked as deprecated, this section will be omitted from the generated README.
 
-### Overview Documentation
+### Component Overview
 
 A Stencil component that has a JSDoc comment on its class component like so:
 
-```tsx title="my-component.tsx with an overview"
+```tsx title="A component with an overview in its JSDoc"
 /**
  * A simple component for formatting names
  *
@@ -136,16 +134,18 @@ This component will do some neat things!
 ```
 
 The overview will be placed after the [deprecation notice](#deprecation-notices) section of the README.
+
 If a component's JSDoc does not contain an overview, this section will be omitted from the generated README.
 
 ### Usage Examples
 
 Usage examples are user-generated markdown files that demonstrate how another developer might use a component.
 These files are separate from a component's README file, and are placed in a `usage/` adjacent to a component's implementation.
+
 The content of these files will be added to a `Usage` section of the generated README. 
 This allows you to keep examples right next to the code, making it easy to include them in a documentation site or other downstream consumer(s) of your docs.
 
-The example usage file below gives us a high level overview of how to use the component, `my-component`:
+The example usage file below describes how to use a component defined in `src/components/my-component/my-component.tsx`:
 
 ````md title="src/components/my-component/usage/my-component-usage.md"
 # How to Use `my-component`
@@ -182,14 +182,13 @@ Stencil does not check that your usage examples are up-to-date.
 If you make any changes to your component's API, you'll need to update your usage examples manually.
 :::
 
-The usage section will be placed after the [overview section](#overview-documentation) of the README.
+The usage section will be placed after the [overview section](#component-overview) of the README.
 
 If a component's directory does not contain any usage files, this section will be omitted from the generated README.
 
-### @Prop() Information
+### @Prop() Details
 
-Components that use Stencil's [`@Prop()` decorator](../components/properties.md) will have a section describing the fields that are decorated with `@Prop()`.
-This information is presented in a table containing the following columns:
+Usages of Stencil's [`@Prop()` decorator](../components/properties.md) are described in a table containing the following information for each usage of `@Prop()`:
 - **Property**: The name of the property on the TypeScript class.
 - **Attribute**: The name of the attribute associated with the property name.
 - **Description**: A description of the property, if one was given in a JSDoc comment for the property.
@@ -202,7 +201,7 @@ export class MyComponent {
   /**
    * The first name
    */
-  @Prop() first!: string;
+  @Prop() first!: string; // the '!' denotes a required property
   /**
    * @deprecated since v2.1.0
    */
@@ -226,12 +225,11 @@ The following section will be generated:
 
 The properties section will be placed after the [usage examples section](#usage-examples) of the README.
 
-If a component does not use `@Prop()`, this section will be omitted from the generated README.
+If a component does not use the `@Prop()` decorator, this section will be omitted from the generated README.
 
-### @Event() Information
+### @Event() Details
 
-Components that use Stencil's [`@Event()` decorator](../components/events.md) will have a section describing the fields that are decorated with `@Event()`.
-This information is presented in a table containing the following columns:
+Usages of Stencil's [`@Event()` decorator](../components/events.md) are described in a table containing the following information for each usage of `@Event()`:
 - **Event**: The name of the property on the TypeScript class decorated with `@Event()`.
 - **Description**: A description of the property, if one was given in a JSDoc comment for the property.
 - **Type**: The TypeScript type of the property.
@@ -263,17 +261,19 @@ The following section will be generated:
 | `todoUndo`      | <span style="color:red">**[DEPRECATED]**</span> <br/><br/> | `CustomEvent<number>` |
 ```
 
-The events section will be placed after the [@Prop() section](#prop-information) of the README.
+The events section will be placed after the [@Prop() section](#prop-details) of the README.
 
-If a component does not use `@Event()`, this section will be omitted from the generated README.
+If a component does not use the `@Event()` decorator, this section will be omitted from the generated README.
 
-### @Method() Information
+### @Method() Details
 
 Components that use Stencil's [`@Method()` decorator](../components/methods.md) will have a section describing each usage `@Method`.
-Each usage of `@Method` will have the following subsections generated:
-- A description of the method, if one was provided in a JSDoc
-- A table containing the name, TypeScript type, and description of each parameter of the method
-- A description of the return value of the method, including its return type.
+
+Each usage of `@Method` will be documented with its own subsection containing the following:
+- The method signature will be used as the heading for each subsection 
+- A description of the method will immediately follow, if one was provided in a JSDoc
+- A 'Parameters' section that contains a table the describes the name, TypeScript type, and description of each parameter of the method
+- A 'Returns' section that contains the return type of the method, along with a description of the returned value.
 
 For the following usages of `@Method()` in a component:
 
@@ -288,7 +288,6 @@ export class MyComponent {
    * @returns the total distance travelled
    */
   @Method()
-  // @ts-ignore
   async scrollByPoint(x: number, y: number, duration: number): Promise<number> { /* omitted */ }
 
   // ...
@@ -319,20 +318,20 @@ Type: `Promise<number>`
 the total distance travelled
 ```
 
-The methods section will be placed after the [@Event section](#event-information) of the README.
+The methods section will be placed after the [@Event section](#event-details) of the README.
 
-If a component does not use `@Method()`, this section will be omitted from the generated README.
+If a component does not use the `@Method()` decorator, this section will be omitted from the generated README.
 
 ### @slot Details
 
-A component that uses [slots](../components/templating-and-jsx.md#slots) may describe the component's slots in the component's JSDoc using the Stencil-specific `@slot` JSDoc tag.
+A component that uses [slots](../components/templating-and-jsx.md#slots) may describe the its slots in the component's JSDoc using the Stencil-specific `@slot` JSDoc tag.
 The `@slot` tag follows the following format:
 ```
 @slot [slot-name] - [description]
 ```
 where `slot-name` corresponds to the name of the slot in the markup, and `description` describes the usage of the slot.
 
-For this tag to be read properly, the following is required:
+For this JSDoc tag to be read properly, the following is required:
 1. Either `slot-name` or `description` must be included. Both may be included though.
 2. The '-' separating the two is required.
 
@@ -346,11 +345,27 @@ For the following usages of `@slot()` in a component:
 ```tsx
 /**
  * @slot - Content is placed between the named slots if provided without a slot.
- * @slot primary - Content is placed to the right of the toolbar text.
- * @slot secondary - Content is placed to the left of the toolbar text.
+ * @slot primary - Content is placed to the left of the main slotted-in text.
+ * @slot secondary - Content is placed to the right of the main slotted-in text.
  */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
 export class MyComponent {
   // ...
+  
+  render() {
+    return (
+      <section>
+        <slot name="primary"></slot>
+        <div class="content">
+          <slot></slot>
+        </div>
+        <slot name="secondary"></slot>
+      </section>
+    );
+  }
 }
 ```
 
@@ -362,23 +377,23 @@ The following table is generated:
 | Slot          | Description                                                           |
 | ------------- | --------------------------------------------------------------------- |
 |               | Content is placed between the named slots if provided without a slot. |
-| `"primary"`   | Content is placed to the right of the toolbar text.                   |
-| `"secondary"` | Content is placed to the left of the toolbar text.                    |
+| `"primary"`   | Content is placed to the left of the main slotted-in text.            |
+| `"secondary"` | Content is placed to the right of the main slotted-in text.           |
 
 ```
 
 The slots section will be placed after the [@Method section](#method-information) of the README.
 
-If a component does not use `@slot`, this section will be omitted from the generated README.
+If a component's top-level JSDoc does not use `@slot` tags, this section will be omitted from the generated README.
 
 ### Shadow Parts
 
-A component that uses [shadow parts](../components/styling.md#css-parts) may describe the component's shadow parts in the component's JSDoc using the Stencil-specific `@part` JSDoc tag.
+A component that uses [CSS shadow parts](../components/styling.md#css-parts) may describe the component's shadow parts in the component's JSDoc using the Stencil-specific `@part` JSDoc tag.
 The `@part` tag follows the following format:
 ```
 @part [part-name] - [description]
 ```
-where `part-name` corresponds to the name of the css part in the markup, and `description` describes the usage of the shadow part.
+where `part-name` corresponds to the name of the shadow part in the markup, and `description` describes its usage.
 
 For this tag to be read properly, the following is required:
 1. Either `part-name` or `description` must be included, although using both is strongly encouraged.
@@ -392,9 +407,7 @@ For the following usages of `@part()` in a component:
 
 ```tsx
 /**
- * @part container - The container for the checkbox mark.
- * @part label - The label text describing the checkbox.
- * @part mark  The checkmark used to indicate the checked state.
+ * @part label - The label text describing the component.
  */
 @Component({
   tag: 'my-component',
@@ -403,6 +416,14 @@ For the following usages of `@part()` in a component:
 })
 export class MyComponent {
   // ...
+
+  render() {
+    return (
+      <div part="label">
+        <slot></slot>
+      </div>
+    );
+  }
 }
 ```
 
@@ -410,28 +431,26 @@ The following table will be generated:
 ```md
 ## Shadow Parts
 
-| Part                                                        | Description                             |
-| ----------------------------------------------------------- | --------------------------------------- |
-| `"container"`                                               | The container for the checkbox mark.    |
-| `"label"`                                                   | The label text describing the checkbox. |
-| `"mark  The checkmark used to indicate the checked state."` |                                         |
+| Part                                                        | Description                              |
+| ----------------------------------------------------------- | ---------------------------------------- |
+| `"label"`                                                   | The label text describing the component. |
 ```
 
 The shadow parts section will be placed after the [@Slot Details](#slot-details) of the README.
 
-If a component does not use `@part`, this section will be omitted from the generated README.
+If a component's top-level JSDoc does not use `@part` tags, this section will be omitted from the generated README.
 
 ### Styling Details
 
-Styles can be documented in Stencil components as well.
-An example of this is a CSS variable that a component's styling depends on.
+Styling in CSS files can be documented in Stencil components as well.
+One use case for documenting styles using Stencil is to note a CSS variable that a component's styling depends on.
 Using the `@prop` JSDoc in a component's CSS file, Stencil can generate this documentation as well.
 
 This information is presented in a table containing the following columns:
 - **Name**: The name of the custom property.
 - **Description**: A description of the custom property, if one was given.
 
-For the following usages of `@prop()` in a component's css file:
+For the following usages of `@prop` in a component's css file:
 
 ```css
 :host {
@@ -453,9 +472,9 @@ The following table will be generated:
 
 The styling details section will be placed after the [Shadow Parts Details](#shadow-parts) of the README.
 
-If a component does not include styling details, this section will be omitted from the generated README.
+If a component's styles does not include styling details, this section will be omitted from the generated README.
 
-### A Custom Footer
+### Custom Footers
 
 Removing or customizing the footer can be done by adding a `footer` property to
 the output target. This string is added to the generated Markdown files without
@@ -482,7 +501,7 @@ The following footer will be placed at the bottom of your component's README fil
 ## Configuration
 ### Specifying the Output Directory
 
-By default, a readme file will be generated in the same directory as the
+By default, a README file will be generated in the same directory as the
 component it corresponds to. This behavior can be changed by setting the `dir`
 property on the output target configuration. Specifying a directory will create
 the structure `{dir}/{component}/readme.md`.

--- a/docs/documentation-generation/docs-readme.md
+++ b/docs/documentation-generation/docs-readme.md
@@ -79,7 +79,7 @@ Any custom content placed above this comment will be persisted on subsequent bui
 ### Deprecation Notices
 
 A Stencil component may be marked as deprecated using the [JSDoc `@deprecated` tag](https://jsdoc.app/tags-deprecated).
-By placing `@deprecated` in a component's class-level JSDoc will cause the generated README to denote the component is deprecated.
+By placing `@deprecated` in a component's class-level JSDoc it will cause the generated README to denote the component as deprecated.
 
 For a component with the JSDoc:
 

--- a/versioned_docs/version-v3/config/cli.md
+++ b/versioned_docs/version-v3/config/cli.md
@@ -18,7 +18,7 @@ Builds a Stencil project. The flags below are the available options for the `bui
 | `--config` | Path to the `stencil.config.ts` file. This flag is not needed in most cases since Stencil will find the config. Additionally, a Stencil config is not required. | `-c` |
 | `--debug` | Adds additional runtime code to help debug, and sets the log level for more verbose output. | |
 | `--dev` | Runs a development build. | |
-| `--docs-readme` | Generate `readme.md` docs based on the component types, properties, methods, events, JSDocs, CSS Custom Properties, etc. | |
+| `--docs` | Generate all docs based on the component types, properties, methods, events, JSDocs, CSS Custom Properties, etc. | |
 | `--es5` | Creates an ES5 compatible build. By default ES5 builds are not created during development in order to improve build times. However, ES5 builds are always created during production builds. Use this flag to create ES5 builds during development. | |
 | `--log` | Write logs for the `stencil build` into `stencil-build.log`. The log file is written in the same location as the config. | |
 | `--prerender` | Prerender the application using the `www` output target after the build has completed. | |

--- a/versioned_docs/version-v3/documentation-generation/docs-readme.md
+++ b/versioned_docs/version-v3/documentation-generation/docs-readme.md
@@ -7,51 +7,12 @@ slug: /docs-readme
 
 # Docs Readme Markdown File Auto-Generation
 
-Stencil is able to auto-generate `readme.md` files in markdown. This opt-in
-feature will save the readme files as a sibling to the component within the
-same directory. This can help you to maintain consistently formatted
-documentation for your components which live right next to them and render in
-GitHub.
+Stencil is able to auto-generate `readme.md` files for your components.
+This can help you to maintain consistently formatted documentation for your components which lives right next to them and renders in GitHub.
 
-To auto-generate readme files, add the `docs-readme` output target to your
-`stencil.config.ts` like so:
+## Setup
 
-```tsx title="stencil.config.ts"
-import { Config } from '@stencil/core';
-
-export const config: Config = {
-  outputTargets: [
-    { type: 'docs-readme' }
-  ]
-};
-```
-
-Another option would be to use the `--docs` CLI flag, like so:
-
-```bash
-stencil build --docs
-```
-
-This will cause the Stencil compiler to perform a one-time generation of README
-files.
-
-:::note
-If you use the `--docs` flag and don't add the `docs-readme` output target to
-your Stencil configuration your documentation won't be automatically updated
-when you build your project and could get out of date.
-:::
-
-## Adding Custom Markdown to Auto-Generated Files
-
-Once you've generated a `readme.md` file you can customize it with your own
-markdown content. Simply add your own markdown above the comment that reads:
-`<!-- Auto Generated Below -->`.
-
-## Custom Footer
-
-Removing or customizing the footer can be done by adding a `footer` property to
-the output target. This string is added to the generated Markdown files without
-modification, so you can use Markdown syntax in it for rich formatting.
+To generate markdown files, it is recommended to add the `docs-readme` output target to your Stencil configuration file:
 
 ```tsx title="stencil.config.ts"
 import { Config } from '@stencil/core';
@@ -59,6 +20,472 @@ import { Config } from '@stencil/core';
 export const config: Config = {
   outputTargets: [
     { 
+      type: 'docs-readme'
+    }
+  ]
+};
+```
+
+## Generating README Files
+
+### Using the Build Command
+
+If your project has a `docs-readme` output target configured in your Stencil configuration file, the Stencil [build command](../config/cli.md#stencil-build) is all that's needed to generate README docs:
+```bash
+npx stencil build
+```
+If you're running the build command with the `--watch` flag, your project's README files will automatically update without requiring multiple explicit build commands:
+```bash
+npm stencil build --watch
+```
+
+:::info
+When running the build command with the `--dev` flag, README files will not be generated.
+This is to prevent unnecessary I/O operations during the development cycle.
+:::
+
+If you choose not to include a `docs-readme` output target in your Stencil configuration file, use the `--docs` CLI flag as a part of the build command:
+```bash
+npx stencil build --docs
+```
+
+This will cause the Stencil compiler to perform a one-time build of your entire project, including README files.
+
+### Using the Docs Command
+
+As an alternative to the build command, the [docs command](../config/cli.md#stencil-docs) can be used to perform a one time generation of the documentation:
+```bash
+npx stencil docs
+```
+Running `stencil docs` will generate documentation for [all documentation output targets](./01-overview.md), not just `docs-readme`.
+
+## README Sections
+
+Most generated markdown content will automatically be generated without requiring any additional configuration.
+Content is generated based on its Stencil component, rather than requiring you to configure multiple flags.
+Each section below describes the different types of content Stencil recognizes and will automatically generate. 
+
+### Custom Markdown Content
+
+Once you've generated a `readme.md` file, you can add your own markdown content to the file.
+You may add any content above the following comment in a component's `readme.md`:
+```
+Custom content goes here!
+<!-- Auto Generated Below -->
+```
+
+Any custom content placed above this comment will be persisted on subsequent builds of the README file.
+
+### Deprecation Notices
+
+A Stencil component may be marked as deprecated using the [JSDoc `@deprecated` tag](https://jsdoc.app/tags-deprecated).
+By placing `@deprecated` in a component's class-level JSDoc it will cause the generated README to denote the component as deprecated.
+
+For a component with the JSDoc:
+
+```tsx title="A component with @deprecated in its JSDoc"
+/**
+ * @deprecated since v2.0.0
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent { /* omitted */ }
+```
+
+In the code block above, `@deprecated` is added to the JSDoc for `MyComponent`.
+This causes the generated README to contain:
+```
+> **[DEPRECATED]** since v2.0.0
+```
+
+The deprecation notice will always begin with `> **[DEPRECATED]**`, followed by the description provided in the JSDoc.
+In this case, that description is "since v2.0.0".
+
+The deprecation notice will be placed after the [custom content](#custom-markdown-content) in the README.
+
+If a component is not marked as deprecated, this section will be omitted from the generated README.
+
+### Component Overview
+
+A Stencil component that has a JSDoc comment on its class component like so:
+
+```tsx title="A component with an overview in its JSDoc"
+/**
+ * A simple component for formatting names
+ *
+ * This component will do some neat things!
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent { }
+```
+will generate the following section in your component's README:
+
+```
+## Overview
+
+A simple component for formatting names
+
+This component will do some neat things!
+```
+
+The overview will be placed after the [deprecation notice](#deprecation-notices) section of the README.
+
+If a component's JSDoc does not contain an overview, this section will be omitted from the generated README.
+
+### Usage Examples
+
+Usage examples are user-generated markdown files that demonstrate how another developer might use a component.
+These files are separate from a component's README file, and are placed in a `usage/` directory adjacent to a component's implementation.
+
+The content of these files will be added to a `Usage` section of the generated README. 
+This allows you to keep examples right next to the code, making it easy to include them in a documentation site or other downstream consumer(s) of your docs.
+
+The example usage file below describes how to use a component defined in `src/components/my-component/my-component.tsx`:
+
+````md title="src/components/my-component/usage/my-component-usage.md"
+# How to Use `my-component`
+
+This component is used to provide a way to greet a user using their first, middle, and last name.
+This component will properly format the provided name, even when all fields aren't provided:
+
+```html
+<my-component first="Stencil"></my-component>
+<my-component first="Stencil" last="JS"></my-component>
+```
+````
+
+When the README for `my-component` is regenerated, following will be added to the README:
+
+````md
+## Usage
+
+### My-component-usage
+
+# How to Use `my-component`
+
+This component is used to provide a way to greet a user using their first, middle, and last name.
+This component will properly format the provided name, even when all fields aren't provided:
+
+```html
+<my-component first="Stencil"></my-component>
+<my-component first="Stencil" last="JS"></my-component>
+```
+````
+
+:::caution
+Stencil does not check that your usage examples are up-to-date.
+If you make any changes to your component's API, you'll need to update your usage examples manually.
+:::
+
+The usage section will be placed after the [overview section](#component-overview) of the README.
+
+If a component's directory does not contain any usage files, this section will be omitted from the generated README.
+
+### @Prop() Details
+
+Usages of Stencil's [`@Prop()` decorator](../components/properties.md) are described in a table containing the following information for each usage of `@Prop()`:
+- **Property**: The name of the property on the TypeScript class.
+- **Attribute**: The name of the attribute associated with the property name.
+- **Description**: A description of the property, if one was given in a JSDoc comment for the property.
+- **Type**: The TypeScript type of the property.
+- **Default**: The default value of the property.
+
+For the following usages of `@Prop()` in a component:
+```ts
+export class MyComponent {
+  /**
+   * The first name
+   */
+  @Prop() first!: string; // the '!' denotes a required property
+  /**
+   * @deprecated since v2.1.0
+   */
+  @Prop() middle: string;
+  @Prop() lastName = "Smith";
+
+  // ...
+}
+```
+
+The following section will be generated:
+```md
+## Properties
+
+| Property             | Attribute   | Description                                                            | Type     | Default     |
+| -------------------- | ----------- | ---------------------------------------------------------------------- | -------- | ----------- |
+| `first` _(required)_ | `first`     | The first name                                                         | `string` | `undefined` |
+| `lastName`           | `last-name` |                                                                        | `string` | `"Smith"`   |
+| `middle`             | `middle`    | <span style="color:red">**[DEPRECATED]**</span> since v2.1.0<br/><br/> | `string` | `undefined` |
+```
+
+The properties section will be placed after the [usage examples section](#usage-examples) of the README.
+
+If a component does not use the `@Prop()` decorator, this section will be omitted from the generated README.
+
+### @Event() Details
+
+Usages of Stencil's [`@Event()` decorator](../components/events.md) are described in a table containing the following information for each usage of `@Event()`:
+- **Event**: The name of the property on the TypeScript class decorated with `@Event()`.
+- **Description**: A description of the property, if one was given in a JSDoc comment for the property.
+- **Type**: The TypeScript type of the property.
+
+For the following usages of `@Event()` in a component:
+```tsx
+export class MyComponent {
+  /**
+   * Emitted when an event is completed
+   */
+  @Event() todoCompleted: EventEmitter<number>;
+  /**
+   * @deprecated
+   */
+  @Event() todoUndo: EventEmitter<number>;
+
+  // ...
+}
+```
+
+The following section will be generated:
+
+```md
+## Events
+
+| Event           | Description                                                | Type                  |
+| --------------- | ---------------------------------------------------------- | --------------------- |
+| `todoCompleted` | Emitted when an event is completed                         | `CustomEvent<number>` |
+| `todoUndo`      | <span style="color:red">**[DEPRECATED]**</span> <br/><br/> | `CustomEvent<number>` |
+```
+
+The events section will be placed after the [@Prop() section](#prop-details) of the README.
+
+If a component does not use the `@Event()` decorator, this section will be omitted from the generated README.
+
+### @Method() Details
+
+Components that use Stencil's [`@Method()` decorator](../components/methods.md) will have a section describing each usage `@Method`.
+
+Each usage of `@Method` will be documented with its own subsection containing the following:
+- The method signature will be used as the heading for each subsection 
+- A description of the method will immediately follow, if one was provided in a JSDoc
+- A 'Parameters' section that contains a table the describes the name, TypeScript type, and description of each parameter of the method
+- A 'Returns' section that contains the return type of the method, along with a description of the returned value.
+
+For the following usages of `@Method()` in a component:
+
+```ts
+export class MyComponent {
+  /**
+   * Scroll by a specified X/Y distance in the component.
+   *
+   * @param x The amount to scroll by on the horizontal axis.
+   * @param y The amount to scroll by on the vertical axis.
+   * @param duration The amount of time to take scrolling by that amount.
+   * @returns the total distance travelled
+   */
+  @Method()
+  async scrollByPoint(x: number, y: number, duration: number): Promise<number> { /* omitted */ }
+
+  // ...
+}
+```
+
+The following section will be generated:
+
+```md
+## Methods
+
+### `scrollByPoint(x: number, y: number, duration: number) => Promise<number>`
+
+Scroll by a specified X/Y distance in the component.
+
+#### Parameters
+
+| Name       | Type     | Description                                          |
+| ---------- | -------- | ---------------------------------------------------- |
+| `x`        | `number` | The amount to scroll by on the horizontal axis.      |
+| `y`        | `number` | The amount to scroll by on the vertical axis.        |
+| `duration` | `number` | The amount of time to take scrolling by that amount. |
+
+#### Returns
+
+Type: `Promise<number>`
+
+the total distance travelled
+```
+
+The methods section will be placed after the [@Event section](#event-details) of the README.
+
+If a component does not use the `@Method()` decorator, this section will be omitted from the generated README.
+
+### @slot Details
+
+A component that uses [slots](../components/templating-and-jsx.md#slots) may describe its slots in the component's JSDoc using the Stencil-specific `@slot` JSDoc tag.
+The `@slot` tag follows the following format:
+```
+@slot [slot-name] - [description]
+```
+where `slot-name` corresponds to the name of the slot in the markup, and `description` describes the usage of the slot.
+
+For this JSDoc tag to be read properly, the following is required:
+1. Either `slot-name` or `description` must be included. Both may be included though.
+2. The '-' separating the two is required.
+
+For the default slot, omit the `slot-name`.
+
+This information is presented in a table containing the following columns:
+- **Slot**: The name of the slot. The default slot will have no name/be empty.
+- **Description**: A description of the slot, if one was given.
+
+For the following usages of `@slot()` in a component:
+```tsx
+/**
+ * @slot - Content is placed between the named slots if provided without a slot.
+ * @slot primary - Content is placed to the left of the main slotted-in text.
+ * @slot secondary - Content is placed to the right of the main slotted-in text.
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent {
+  // ...
+  
+  render() {
+    return (
+      <section>
+        <slot name="primary"></slot>
+        <div class="content">
+          <slot></slot>
+        </div>
+        <slot name="secondary"></slot>
+      </section>
+    );
+  }
+}
+```
+
+The following table is generated:
+
+```md
+## Slots
+
+| Slot          | Description                                                           |
+| ------------- | --------------------------------------------------------------------- |
+|               | Content is placed between the named slots if provided without a slot. |
+| `"primary"`   | Content is placed to the left of the main slotted-in text.            |
+| `"secondary"` | Content is placed to the right of the main slotted-in text.           |
+
+```
+
+The slots section will be placed after the [@Method section](#method-details) of the README.
+
+If a component's top-level JSDoc does not use `@slot` tags, this section will be omitted from the generated README.
+
+### Shadow Parts
+
+A component that uses [CSS shadow parts](../components/styling.md#css-parts) may describe the component's shadow parts in the component's JSDoc using the Stencil-specific `@part` JSDoc tag.
+The `@part` tag follows the following format:
+```
+@part [part-name] - [description]
+```
+where `part-name` corresponds to the name of the shadow part in the markup, and `description` describes its usage.
+
+For this tag to be read properly, the following is required:
+1. Either `part-name` or `description` must be included, although using both is strongly encouraged.
+2. The '-' separating the two is required.
+
+This information is presented in a table containing the following columns:
+- **Part**: The name of the shadow part.
+- **Description**: A description of the shadow part, if one was given.
+
+For the following usages of `@part()` in a component:
+
+```tsx
+/**
+ * @part label - The label text describing the component.
+ */
+@Component({
+  tag: 'my-component',
+  styleUrl: 'my-component.css',
+  shadow: true,
+})
+export class MyComponent {
+  // ...
+
+  render() {
+    return (
+      <div part="label">
+        <slot></slot>
+      </div>
+    );
+  }
+}
+```
+
+The following table will be generated:
+```md
+## Shadow Parts
+
+| Part                                                        | Description                              |
+| ----------------------------------------------------------- | ---------------------------------------- |
+| `"label"`                                                   | The label text describing the component. |
+```
+
+The shadow parts section will be placed after the [@Slot Details](#slot-details) of the README.
+
+If a component's top-level JSDoc does not use `@part` tags, this section will be omitted from the generated README.
+
+### Styling Details
+
+Styling in CSS files can be documented in Stencil components as well.
+One use case for documenting styles using Stencil is to note a CSS variable that a component's styling depends on.
+Using the `@prop` JSDoc in a component's CSS file, Stencil can generate this documentation as well.
+
+This information is presented in a table containing the following columns:
+- **Name**: The name of the custom property.
+- **Description**: A description of the custom property, if one was given.
+
+For the following usages of `@prop` in a component's css file:
+
+```css
+:host {
+  /**
+   * @prop --border-radius: Border radius of the avatar and inner image
+   */
+  border-radius: var(--border-radius);
+}
+```
+The following table will be generated:
+
+```md
+## CSS Custom Properties
+
+| Name              | Description                                 |
+| ----------------- | ------------------------------------------- |
+| `--border-radius` | Border radius of the avatar and inner image |
+```
+
+The styling details section will be placed after the [Shadow Parts Details](#shadow-parts) of the README.
+
+If a component's styles does not include styling details, this section will be omitted from the generated README.
+
+### Custom Footers
+
+Removing or customizing the footer can be done by adding a `footer` property to
+the output target. This string is added to the generated Markdown files without
+modification, so you can use Markdown syntax in it for rich formatting:
+
+```tsx title="stencil.config.ts"
+import { Config } from '@stencil/core';
+
+export const config: Config = {
+  outputTargets: [
+    {
       type: 'docs-readme',
       footer: '*Built with love!*',
     }
@@ -66,10 +493,16 @@ export const config: Config = {
 };
 ```
 
-## Generating to a Directory
+The following footer will be placed at the bottom of your component's README file:
+```
+*Built with love!*
+```
 
-By default, a readme file will be generated in the same directory as the
-component is corresponds to. This behavior can be changed by setting the `dir`
+## Configuration
+### Specifying the Output Directory
+
+By default, a README file will be generated in the same directory as the
+component it corresponds to. This behavior can be changed by setting the `dir`
 property on the output target configuration. Specifying a directory will create
 the structure `{dir}/{component}/readme.md`.
 
@@ -78,7 +511,7 @@ import { Config } from '@stencil/core';
 
 export const config: Config = {
   outputTargets: [
-    { 
+    {
       type: 'docs-readme',
       dir: 'output'
     }
@@ -86,20 +519,25 @@ export const config: Config = {
 };
 ```
 
-## Strict Mode
+### Strict Mode
 
-Adding `strict: true` to the output target configuration will cause Stencil to
-output a warning whenever the project is built with missing documentation.
+Adding `strict: true` to the output target configuration will cause Stencil to output a warning whenever the project is built with missing documentation.
 
 ```tsx title="stencil.config.ts"
 import { Config } from '@stencil/core';
 
 export const config: Config = {
   outputTargets: [
-    { 
+    {
       type: 'docs-readme',
       strict: true
     }
   ]
 };
 ```
+
+When strict mode is enabled, the following items are checked:
+1. `@Prop()` usages must be documented, unless the property is marked as `@deprecated`
+2. `@Method()` usages must be documented, unless the method is marked as `@deprecated`
+3. `@Event()` usages must be documented, unless the event is marked as `@deprecated`
+4. CSS Part usages must be documented

--- a/versioned_docs/version-v3/documentation-generation/docs-readme.md
+++ b/versioned_docs/version-v3/documentation-generation/docs-readme.md
@@ -53,7 +53,7 @@ This will cause the Stencil compiler to perform a one-time build of your entire 
 
 ### Using the Docs Command
 
-As an alternative to the build command, the [docs command](../config/cli.md#stencil-docs) can be used to perform a one time generation of the documentation:
+As an alternative to the build command, the docs command can be used to perform a one time generation of the documentation:
 ```bash
 npx stencil docs
 ```

--- a/versioned_docs/version-v4.0/config/cli.md
+++ b/versioned_docs/version-v4.0/config/cli.md
@@ -20,7 +20,7 @@ Builds a Stencil project. The flags below are the available options for the `bui
 | `--config` | Path to the `stencil.config.ts` file. This flag is not needed in most cases since Stencil will find the config. Additionally, a Stencil config is not required. | `-c` |
 | `--debug` | Adds additional runtime code to help debug, and sets the log level for more verbose output. | |
 | `--dev` | Runs a development build. | |
-| `--docs-readme` | Generate `readme.md` docs based on the component types, properties, methods, events, JSDocs, CSS Custom Properties, etc. | |
+| `--docs` | Generate all docs based on the component types, properties, methods, events, JSDocs, CSS Custom Properties, etc. | |
 | `--es5` | Creates an ES5 compatible build. By default ES5 builds are not created during development in order to improve build times. However, ES5 builds are always created during production builds. Use this flag to create ES5 builds during development. | |
 | `--log` | Write logs for the `stencil build` into `stencil-build.log`. The log file is written in the same location as the config. | |
 | `--prerender` | Prerender the application using the `www` output target after the build has completed. | |

--- a/versioned_docs/version-v4.0/documentation-generation/docs-readme.md
+++ b/versioned_docs/version-v4.0/documentation-generation/docs-readme.md
@@ -7,54 +7,12 @@ slug: /docs-readme
 
 # Docs Readme Markdown File Auto-Generation
 
-Stencil is able to auto-generate `readme.md` files in markdown. This
-feature will save the readme files as a sibling to the component's source file within the
-same directory. This can help you to maintain consistently formatted
-documentation for your components which live right next to them and render in
-GitHub.
+Stencil is able to auto-generate `readme.md` files for your components.
+This can help you to maintain consistently formatted documentation for your components which lives right next to them and renders in GitHub.
 
-To auto-generate readme files, add the `docs-readme` output target to your
-`stencil.config.ts` like so:
+## Setup
 
-```tsx title="stencil.config.ts"
-import { Config } from '@stencil/core';
-
-export const config: Config = {
-  outputTargets: [
-    { type: 'docs-readme' }
-  ]
-};
-```
-
-Another option would be to use the `--docs` CLI flag as a part of the [build task](../config/cli.md#stencil-build), like so:
-
-```bash
-stencil build --docs
-```
-
-This will cause the Stencil compiler to perform a one-time generation of README
-files as a part of the build process.
-
-:::note
-If you don't add the `docs-readme` output target to your Stencil configuration, the `--docs` flag must be applied to regenerate documentation.
-:::
-
-Alternatively, the [docs task](../config/cli.md#stencil-docs) can be used to perform a one time generation of the documentation:
-```bash
-stencil docs
-```
-
-## Adding Custom Markdown to Auto-Generated Files
-
-Once you've generated a `readme.md` file you can customize it with your own
-markdown content. Simply add your own markdown above the comment that reads:
-`<!-- Auto Generated Below -->`.
-
-## Custom Footer
-
-Removing or customizing the footer can be done by adding a `footer` property to
-the output target. This string is added to the generated Markdown files without
-modification, so you can use Markdown syntax in it for rich formatting.
+To generate markdown files, it is recommended to add the `docs-readme` output target to your Stencil configuration file:
 
 ```tsx title="stencil.config.ts"
 import { Config } from '@stencil/core';
@@ -62,6 +20,472 @@ import { Config } from '@stencil/core';
 export const config: Config = {
   outputTargets: [
     { 
+      type: 'docs-readme'
+    }
+  ]
+};
+```
+
+## Generating README Files
+
+### Using the Build Command
+
+If your project has a `docs-readme` output target configured in your Stencil configuration file, the Stencil [build command](../config/cli.md#stencil-build) is all that's needed to generate README docs:
+```bash
+npx stencil build
+```
+If you're running the build command with the `--watch` flag, your project's README files will automatically update without requiring multiple explicit build commands:
+```bash
+npm stencil build --watch
+```
+
+:::info
+When running the build command with the `--dev` flag, README files will not be generated.
+This is to prevent unnecessary I/O operations during the development cycle.
+:::
+
+If you choose not to include a `docs-readme` output target in your Stencil configuration file, use the `--docs` CLI flag as a part of the build command:
+```bash
+npx stencil build --docs
+```
+
+This will cause the Stencil compiler to perform a one-time build of your entire project, including README files.
+
+### Using the Docs Command
+
+As an alternative to the build command, the [docs command](../config/cli.md#stencil-docs) can be used to perform a one time generation of the documentation:
+```bash
+npx stencil docs
+```
+Running `stencil docs` will generate documentation for [all documentation output targets](./01-overview.md), not just `docs-readme`.
+
+## README Sections
+
+Most generated markdown content will automatically be generated without requiring any additional configuration.
+Content is generated based on its Stencil component, rather than requiring you to configure multiple flags.
+Each section below describes the different types of content Stencil recognizes and will automatically generate. 
+
+### Custom Markdown Content
+
+Once you've generated a `readme.md` file, you can add your own markdown content to the file.
+You may add any content above the following comment in a component's `readme.md`:
+```
+Custom content goes here!
+<!-- Auto Generated Below -->
+```
+
+Any custom content placed above this comment will be persisted on subsequent builds of the README file.
+
+### Deprecation Notices
+
+A Stencil component may be marked as deprecated using the [JSDoc `@deprecated` tag](https://jsdoc.app/tags-deprecated).
+By placing `@deprecated` in a component's class-level JSDoc it will cause the generated README to denote the component as deprecated.
+
+For a component with the JSDoc:
+
+```tsx title="A component with @deprecated in its JSDoc"
+/**
+ * @deprecated since v2.0.0
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent { /* omitted */ }
+```
+
+In the code block above, `@deprecated` is added to the JSDoc for `MyComponent`.
+This causes the generated README to contain:
+```
+> **[DEPRECATED]** since v2.0.0
+```
+
+The deprecation notice will always begin with `> **[DEPRECATED]**`, followed by the description provided in the JSDoc.
+In this case, that description is "since v2.0.0".
+
+The deprecation notice will be placed after the [custom content](#custom-markdown-content) in the README.
+
+If a component is not marked as deprecated, this section will be omitted from the generated README.
+
+### Component Overview
+
+A Stencil component that has a JSDoc comment on its class component like so:
+
+```tsx title="A component with an overview in its JSDoc"
+/**
+ * A simple component for formatting names
+ *
+ * This component will do some neat things!
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent { }
+```
+will generate the following section in your component's README:
+
+```
+## Overview
+
+A simple component for formatting names
+
+This component will do some neat things!
+```
+
+The overview will be placed after the [deprecation notice](#deprecation-notices) section of the README.
+
+If a component's JSDoc does not contain an overview, this section will be omitted from the generated README.
+
+### Usage Examples
+
+Usage examples are user-generated markdown files that demonstrate how another developer might use a component.
+These files are separate from a component's README file, and are placed in a `usage/` directory adjacent to a component's implementation.
+
+The content of these files will be added to a `Usage` section of the generated README. 
+This allows you to keep examples right next to the code, making it easy to include them in a documentation site or other downstream consumer(s) of your docs.
+
+The example usage file below describes how to use a component defined in `src/components/my-component/my-component.tsx`:
+
+````md title="src/components/my-component/usage/my-component-usage.md"
+# How to Use `my-component`
+
+This component is used to provide a way to greet a user using their first, middle, and last name.
+This component will properly format the provided name, even when all fields aren't provided:
+
+```html
+<my-component first="Stencil"></my-component>
+<my-component first="Stencil" last="JS"></my-component>
+```
+````
+
+When the README for `my-component` is regenerated, following will be added to the README:
+
+````md
+## Usage
+
+### My-component-usage
+
+# How to Use `my-component`
+
+This component is used to provide a way to greet a user using their first, middle, and last name.
+This component will properly format the provided name, even when all fields aren't provided:
+
+```html
+<my-component first="Stencil"></my-component>
+<my-component first="Stencil" last="JS"></my-component>
+```
+````
+
+:::caution
+Stencil does not check that your usage examples are up-to-date.
+If you make any changes to your component's API, you'll need to update your usage examples manually.
+:::
+
+The usage section will be placed after the [overview section](#component-overview) of the README.
+
+If a component's directory does not contain any usage files, this section will be omitted from the generated README.
+
+### @Prop() Details
+
+Usages of Stencil's [`@Prop()` decorator](../components/properties.md) are described in a table containing the following information for each usage of `@Prop()`:
+- **Property**: The name of the property on the TypeScript class.
+- **Attribute**: The name of the attribute associated with the property name.
+- **Description**: A description of the property, if one was given in a JSDoc comment for the property.
+- **Type**: The TypeScript type of the property.
+- **Default**: The default value of the property.
+
+For the following usages of `@Prop()` in a component:
+```ts
+export class MyComponent {
+  /**
+   * The first name
+   */
+  @Prop() first!: string; // the '!' denotes a required property
+  /**
+   * @deprecated since v2.1.0
+   */
+  @Prop() middle: string;
+  @Prop() lastName = "Smith";
+
+  // ...
+}
+```
+
+The following section will be generated:
+```md
+## Properties
+
+| Property             | Attribute   | Description                                                            | Type     | Default     |
+| -------------------- | ----------- | ---------------------------------------------------------------------- | -------- | ----------- |
+| `first` _(required)_ | `first`     | The first name                                                         | `string` | `undefined` |
+| `lastName`           | `last-name` |                                                                        | `string` | `"Smith"`   |
+| `middle`             | `middle`    | <span style="color:red">**[DEPRECATED]**</span> since v2.1.0<br/><br/> | `string` | `undefined` |
+```
+
+The properties section will be placed after the [usage examples section](#usage-examples) of the README.
+
+If a component does not use the `@Prop()` decorator, this section will be omitted from the generated README.
+
+### @Event() Details
+
+Usages of Stencil's [`@Event()` decorator](../components/events.md) are described in a table containing the following information for each usage of `@Event()`:
+- **Event**: The name of the property on the TypeScript class decorated with `@Event()`.
+- **Description**: A description of the property, if one was given in a JSDoc comment for the property.
+- **Type**: The TypeScript type of the property.
+
+For the following usages of `@Event()` in a component:
+```tsx
+export class MyComponent {
+  /**
+   * Emitted when an event is completed
+   */
+  @Event() todoCompleted: EventEmitter<number>;
+  /**
+   * @deprecated
+   */
+  @Event() todoUndo: EventEmitter<number>;
+
+  // ...
+}
+```
+
+The following section will be generated:
+
+```md
+## Events
+
+| Event           | Description                                                | Type                  |
+| --------------- | ---------------------------------------------------------- | --------------------- |
+| `todoCompleted` | Emitted when an event is completed                         | `CustomEvent<number>` |
+| `todoUndo`      | <span style="color:red">**[DEPRECATED]**</span> <br/><br/> | `CustomEvent<number>` |
+```
+
+The events section will be placed after the [@Prop() section](#prop-details) of the README.
+
+If a component does not use the `@Event()` decorator, this section will be omitted from the generated README.
+
+### @Method() Details
+
+Components that use Stencil's [`@Method()` decorator](../components/methods.md) will have a section describing each usage `@Method`.
+
+Each usage of `@Method` will be documented with its own subsection containing the following:
+- The method signature will be used as the heading for each subsection 
+- A description of the method will immediately follow, if one was provided in a JSDoc
+- A 'Parameters' section that contains a table the describes the name, TypeScript type, and description of each parameter of the method
+- A 'Returns' section that contains the return type of the method, along with a description of the returned value.
+
+For the following usages of `@Method()` in a component:
+
+```ts
+export class MyComponent {
+  /**
+   * Scroll by a specified X/Y distance in the component.
+   *
+   * @param x The amount to scroll by on the horizontal axis.
+   * @param y The amount to scroll by on the vertical axis.
+   * @param duration The amount of time to take scrolling by that amount.
+   * @returns the total distance travelled
+   */
+  @Method()
+  async scrollByPoint(x: number, y: number, duration: number): Promise<number> { /* omitted */ }
+
+  // ...
+}
+```
+
+The following section will be generated:
+
+```md
+## Methods
+
+### `scrollByPoint(x: number, y: number, duration: number) => Promise<number>`
+
+Scroll by a specified X/Y distance in the component.
+
+#### Parameters
+
+| Name       | Type     | Description                                          |
+| ---------- | -------- | ---------------------------------------------------- |
+| `x`        | `number` | The amount to scroll by on the horizontal axis.      |
+| `y`        | `number` | The amount to scroll by on the vertical axis.        |
+| `duration` | `number` | The amount of time to take scrolling by that amount. |
+
+#### Returns
+
+Type: `Promise<number>`
+
+the total distance travelled
+```
+
+The methods section will be placed after the [@Event section](#event-details) of the README.
+
+If a component does not use the `@Method()` decorator, this section will be omitted from the generated README.
+
+### @slot Details
+
+A component that uses [slots](../components/templating-and-jsx.md#slots) may describe its slots in the component's JSDoc using the Stencil-specific `@slot` JSDoc tag.
+The `@slot` tag follows the following format:
+```
+@slot [slot-name] - [description]
+```
+where `slot-name` corresponds to the name of the slot in the markup, and `description` describes the usage of the slot.
+
+For this JSDoc tag to be read properly, the following is required:
+1. Either `slot-name` or `description` must be included. Both may be included though.
+2. The '-' separating the two is required.
+
+For the default slot, omit the `slot-name`.
+
+This information is presented in a table containing the following columns:
+- **Slot**: The name of the slot. The default slot will have no name/be empty.
+- **Description**: A description of the slot, if one was given.
+
+For the following usages of `@slot()` in a component:
+```tsx
+/**
+ * @slot - Content is placed between the named slots if provided without a slot.
+ * @slot primary - Content is placed to the left of the main slotted-in text.
+ * @slot secondary - Content is placed to the right of the main slotted-in text.
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent {
+  // ...
+  
+  render() {
+    return (
+      <section>
+        <slot name="primary"></slot>
+        <div class="content">
+          <slot></slot>
+        </div>
+        <slot name="secondary"></slot>
+      </section>
+    );
+  }
+}
+```
+
+The following table is generated:
+
+```md
+## Slots
+
+| Slot          | Description                                                           |
+| ------------- | --------------------------------------------------------------------- |
+|               | Content is placed between the named slots if provided without a slot. |
+| `"primary"`   | Content is placed to the left of the main slotted-in text.            |
+| `"secondary"` | Content is placed to the right of the main slotted-in text.           |
+
+```
+
+The slots section will be placed after the [@Method section](#method-details) of the README.
+
+If a component's top-level JSDoc does not use `@slot` tags, this section will be omitted from the generated README.
+
+### Shadow Parts
+
+A component that uses [CSS shadow parts](../components/styling.md#css-parts) may describe the component's shadow parts in the component's JSDoc using the Stencil-specific `@part` JSDoc tag.
+The `@part` tag follows the following format:
+```
+@part [part-name] - [description]
+```
+where `part-name` corresponds to the name of the shadow part in the markup, and `description` describes its usage.
+
+For this tag to be read properly, the following is required:
+1. Either `part-name` or `description` must be included, although using both is strongly encouraged.
+2. The '-' separating the two is required.
+
+This information is presented in a table containing the following columns:
+- **Part**: The name of the shadow part.
+- **Description**: A description of the shadow part, if one was given.
+
+For the following usages of `@part()` in a component:
+
+```tsx
+/**
+ * @part label - The label text describing the component.
+ */
+@Component({
+  tag: 'my-component',
+  styleUrl: 'my-component.css',
+  shadow: true,
+})
+export class MyComponent {
+  // ...
+
+  render() {
+    return (
+      <div part="label">
+        <slot></slot>
+      </div>
+    );
+  }
+}
+```
+
+The following table will be generated:
+```md
+## Shadow Parts
+
+| Part                                                        | Description                              |
+| ----------------------------------------------------------- | ---------------------------------------- |
+| `"label"`                                                   | The label text describing the component. |
+```
+
+The shadow parts section will be placed after the [@Slot Details](#slot-details) of the README.
+
+If a component's top-level JSDoc does not use `@part` tags, this section will be omitted from the generated README.
+
+### Styling Details
+
+Styling in CSS files can be documented in Stencil components as well.
+One use case for documenting styles using Stencil is to note a CSS variable that a component's styling depends on.
+Using the `@prop` JSDoc in a component's CSS file, Stencil can generate this documentation as well.
+
+This information is presented in a table containing the following columns:
+- **Name**: The name of the custom property.
+- **Description**: A description of the custom property, if one was given.
+
+For the following usages of `@prop` in a component's css file:
+
+```css
+:host {
+  /**
+   * @prop --border-radius: Border radius of the avatar and inner image
+   */
+  border-radius: var(--border-radius);
+}
+```
+The following table will be generated:
+
+```md
+## CSS Custom Properties
+
+| Name              | Description                                 |
+| ----------------- | ------------------------------------------- |
+| `--border-radius` | Border radius of the avatar and inner image |
+```
+
+The styling details section will be placed after the [Shadow Parts Details](#shadow-parts) of the README.
+
+If a component's styles does not include styling details, this section will be omitted from the generated README.
+
+### Custom Footers
+
+Removing or customizing the footer can be done by adding a `footer` property to
+the output target. This string is added to the generated Markdown files without
+modification, so you can use Markdown syntax in it for rich formatting:
+
+```tsx title="stencil.config.ts"
+import { Config } from '@stencil/core';
+
+export const config: Config = {
+  outputTargets: [
+    {
       type: 'docs-readme',
       footer: '*Built with love!*',
     }
@@ -69,10 +493,16 @@ export const config: Config = {
 };
 ```
 
-## Generating to a Directory
+The following footer will be placed at the bottom of your component's README file:
+```
+*Built with love!*
+```
 
-By default, a readme file will be generated in the same directory as the
-component corresponds to. This behavior can be changed by setting the `dir`
+## Configuration
+### Specifying the Output Directory
+
+By default, a README file will be generated in the same directory as the
+component it corresponds to. This behavior can be changed by setting the `dir`
 property on the output target configuration. Specifying a directory will create
 the structure `{dir}/{component}/readme.md`.
 
@@ -89,10 +519,9 @@ export const config: Config = {
 };
 ```
 
-## Strict Mode
+### Strict Mode
 
-Adding `strict: true` to the output target configuration will cause Stencil to
-output a warning whenever the project is built with missing documentation.
+Adding `strict: true` to the output target configuration will cause Stencil to output a warning whenever the project is built with missing documentation.
 
 ```tsx title="stencil.config.ts"
 import { Config } from '@stencil/core';
@@ -106,3 +535,9 @@ export const config: Config = {
   ]
 };
 ```
+
+When strict mode is enabled, the following items are checked:
+1. `@Prop()` usages must be documented, unless the property is marked as `@deprecated`
+2. `@Method()` usages must be documented, unless the method is marked as `@deprecated`
+3. `@Event()` usages must be documented, unless the event is marked as `@deprecated`
+4. CSS Part usages must be documented

--- a/versioned_docs/version-v4.1/config/cli.md
+++ b/versioned_docs/version-v4.1/config/cli.md
@@ -20,7 +20,7 @@ Builds a Stencil project. The flags below are the available options for the `bui
 | `--config` | Path to the `stencil.config.ts` file. This flag is not needed in most cases since Stencil will find the config. Additionally, a Stencil config is not required. | `-c` |
 | `--debug` | Adds additional runtime code to help debug, and sets the log level for more verbose output. | |
 | `--dev` | Runs a development build. | |
-| `--docs-readme` | Generate `readme.md` docs based on the component types, properties, methods, events, JSDocs, CSS Custom Properties, etc. | |
+| `--docs` | Generate all docs based on the component types, properties, methods, events, JSDocs, CSS Custom Properties, etc. | |
 | `--es5` | Creates an ES5 compatible build. By default ES5 builds are not created during development in order to improve build times. However, ES5 builds are always created during production builds. Use this flag to create ES5 builds during development. | |
 | `--log` | Write logs for the `stencil build` into `stencil-build.log`. The log file is written in the same location as the config. | |
 | `--prerender` | Prerender the application using the `www` output target after the build has completed. | |

--- a/versioned_docs/version-v4.1/documentation-generation/docs-readme.md
+++ b/versioned_docs/version-v4.1/documentation-generation/docs-readme.md
@@ -7,54 +7,12 @@ slug: /docs-readme
 
 # Docs Readme Markdown File Auto-Generation
 
-Stencil is able to auto-generate `readme.md` files in markdown. This
-feature will save the readme files as a sibling to the component's source file within the
-same directory. This can help you to maintain consistently formatted
-documentation for your components which live right next to them and render in
-GitHub.
+Stencil is able to auto-generate `readme.md` files for your components.
+This can help you to maintain consistently formatted documentation for your components which lives right next to them and renders in GitHub.
 
-To auto-generate readme files, add the `docs-readme` output target to your
-`stencil.config.ts` like so:
+## Setup
 
-```tsx title="stencil.config.ts"
-import { Config } from '@stencil/core';
-
-export const config: Config = {
-  outputTargets: [
-    { type: 'docs-readme' }
-  ]
-};
-```
-
-Another option would be to use the `--docs` CLI flag as a part of the [build task](../config/cli.md#stencil-build), like so:
-
-```bash
-stencil build --docs
-```
-
-This will cause the Stencil compiler to perform a one-time generation of README
-files as a part of the build process.
-
-:::note
-If you don't add the `docs-readme` output target to your Stencil configuration, the `--docs` flag must be applied to regenerate documentation.
-:::
-
-Alternatively, the [docs task](../config/cli.md#stencil-docs) can be used to perform a one time generation of the documentation:
-```bash
-stencil docs
-```
-
-## Adding Custom Markdown to Auto-Generated Files
-
-Once you've generated a `readme.md` file you can customize it with your own
-markdown content. Simply add your own markdown above the comment that reads:
-`<!-- Auto Generated Below -->`.
-
-## Custom Footer
-
-Removing or customizing the footer can be done by adding a `footer` property to
-the output target. This string is added to the generated Markdown files without
-modification, so you can use Markdown syntax in it for rich formatting.
+To generate markdown files, it is recommended to add the `docs-readme` output target to your Stencil configuration file:
 
 ```tsx title="stencil.config.ts"
 import { Config } from '@stencil/core';
@@ -62,6 +20,472 @@ import { Config } from '@stencil/core';
 export const config: Config = {
   outputTargets: [
     { 
+      type: 'docs-readme'
+    }
+  ]
+};
+```
+
+## Generating README Files
+
+### Using the Build Command
+
+If your project has a `docs-readme` output target configured in your Stencil configuration file, the Stencil [build command](../config/cli.md#stencil-build) is all that's needed to generate README docs:
+```bash
+npx stencil build
+```
+If you're running the build command with the `--watch` flag, your project's README files will automatically update without requiring multiple explicit build commands:
+```bash
+npm stencil build --watch
+```
+
+:::info
+When running the build command with the `--dev` flag, README files will not be generated.
+This is to prevent unnecessary I/O operations during the development cycle.
+:::
+
+If you choose not to include a `docs-readme` output target in your Stencil configuration file, use the `--docs` CLI flag as a part of the build command:
+```bash
+npx stencil build --docs
+```
+
+This will cause the Stencil compiler to perform a one-time build of your entire project, including README files.
+
+### Using the Docs Command
+
+As an alternative to the build command, the [docs command](../config/cli.md#stencil-docs) can be used to perform a one time generation of the documentation:
+```bash
+npx stencil docs
+```
+Running `stencil docs` will generate documentation for [all documentation output targets](./01-overview.md), not just `docs-readme`.
+
+## README Sections
+
+Most generated markdown content will automatically be generated without requiring any additional configuration.
+Content is generated based on its Stencil component, rather than requiring you to configure multiple flags.
+Each section below describes the different types of content Stencil recognizes and will automatically generate. 
+
+### Custom Markdown Content
+
+Once you've generated a `readme.md` file, you can add your own markdown content to the file.
+You may add any content above the following comment in a component's `readme.md`:
+```
+Custom content goes here!
+<!-- Auto Generated Below -->
+```
+
+Any custom content placed above this comment will be persisted on subsequent builds of the README file.
+
+### Deprecation Notices
+
+A Stencil component may be marked as deprecated using the [JSDoc `@deprecated` tag](https://jsdoc.app/tags-deprecated).
+By placing `@deprecated` in a component's class-level JSDoc it will cause the generated README to denote the component as deprecated.
+
+For a component with the JSDoc:
+
+```tsx title="A component with @deprecated in its JSDoc"
+/**
+ * @deprecated since v2.0.0
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent { /* omitted */ }
+```
+
+In the code block above, `@deprecated` is added to the JSDoc for `MyComponent`.
+This causes the generated README to contain:
+```
+> **[DEPRECATED]** since v2.0.0
+```
+
+The deprecation notice will always begin with `> **[DEPRECATED]**`, followed by the description provided in the JSDoc.
+In this case, that description is "since v2.0.0".
+
+The deprecation notice will be placed after the [custom content](#custom-markdown-content) in the README.
+
+If a component is not marked as deprecated, this section will be omitted from the generated README.
+
+### Component Overview
+
+A Stencil component that has a JSDoc comment on its class component like so:
+
+```tsx title="A component with an overview in its JSDoc"
+/**
+ * A simple component for formatting names
+ *
+ * This component will do some neat things!
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent { }
+```
+will generate the following section in your component's README:
+
+```
+## Overview
+
+A simple component for formatting names
+
+This component will do some neat things!
+```
+
+The overview will be placed after the [deprecation notice](#deprecation-notices) section of the README.
+
+If a component's JSDoc does not contain an overview, this section will be omitted from the generated README.
+
+### Usage Examples
+
+Usage examples are user-generated markdown files that demonstrate how another developer might use a component.
+These files are separate from a component's README file, and are placed in a `usage/` directory adjacent to a component's implementation.
+
+The content of these files will be added to a `Usage` section of the generated README. 
+This allows you to keep examples right next to the code, making it easy to include them in a documentation site or other downstream consumer(s) of your docs.
+
+The example usage file below describes how to use a component defined in `src/components/my-component/my-component.tsx`:
+
+````md title="src/components/my-component/usage/my-component-usage.md"
+# How to Use `my-component`
+
+This component is used to provide a way to greet a user using their first, middle, and last name.
+This component will properly format the provided name, even when all fields aren't provided:
+
+```html
+<my-component first="Stencil"></my-component>
+<my-component first="Stencil" last="JS"></my-component>
+```
+````
+
+When the README for `my-component` is regenerated, following will be added to the README:
+
+````md
+## Usage
+
+### My-component-usage
+
+# How to Use `my-component`
+
+This component is used to provide a way to greet a user using their first, middle, and last name.
+This component will properly format the provided name, even when all fields aren't provided:
+
+```html
+<my-component first="Stencil"></my-component>
+<my-component first="Stencil" last="JS"></my-component>
+```
+````
+
+:::caution
+Stencil does not check that your usage examples are up-to-date.
+If you make any changes to your component's API, you'll need to update your usage examples manually.
+:::
+
+The usage section will be placed after the [overview section](#component-overview) of the README.
+
+If a component's directory does not contain any usage files, this section will be omitted from the generated README.
+
+### @Prop() Details
+
+Usages of Stencil's [`@Prop()` decorator](../components/properties.md) are described in a table containing the following information for each usage of `@Prop()`:
+- **Property**: The name of the property on the TypeScript class.
+- **Attribute**: The name of the attribute associated with the property name.
+- **Description**: A description of the property, if one was given in a JSDoc comment for the property.
+- **Type**: The TypeScript type of the property.
+- **Default**: The default value of the property.
+
+For the following usages of `@Prop()` in a component:
+```ts
+export class MyComponent {
+  /**
+   * The first name
+   */
+  @Prop() first!: string; // the '!' denotes a required property
+  /**
+   * @deprecated since v2.1.0
+   */
+  @Prop() middle: string;
+  @Prop() lastName = "Smith";
+
+  // ...
+}
+```
+
+The following section will be generated:
+```md
+## Properties
+
+| Property             | Attribute   | Description                                                            | Type     | Default     |
+| -------------------- | ----------- | ---------------------------------------------------------------------- | -------- | ----------- |
+| `first` _(required)_ | `first`     | The first name                                                         | `string` | `undefined` |
+| `lastName`           | `last-name` |                                                                        | `string` | `"Smith"`   |
+| `middle`             | `middle`    | <span style="color:red">**[DEPRECATED]**</span> since v2.1.0<br/><br/> | `string` | `undefined` |
+```
+
+The properties section will be placed after the [usage examples section](#usage-examples) of the README.
+
+If a component does not use the `@Prop()` decorator, this section will be omitted from the generated README.
+
+### @Event() Details
+
+Usages of Stencil's [`@Event()` decorator](../components/events.md) are described in a table containing the following information for each usage of `@Event()`:
+- **Event**: The name of the property on the TypeScript class decorated with `@Event()`.
+- **Description**: A description of the property, if one was given in a JSDoc comment for the property.
+- **Type**: The TypeScript type of the property.
+
+For the following usages of `@Event()` in a component:
+```tsx
+export class MyComponent {
+  /**
+   * Emitted when an event is completed
+   */
+  @Event() todoCompleted: EventEmitter<number>;
+  /**
+   * @deprecated
+   */
+  @Event() todoUndo: EventEmitter<number>;
+
+  // ...
+}
+```
+
+The following section will be generated:
+
+```md
+## Events
+
+| Event           | Description                                                | Type                  |
+| --------------- | ---------------------------------------------------------- | --------------------- |
+| `todoCompleted` | Emitted when an event is completed                         | `CustomEvent<number>` |
+| `todoUndo`      | <span style="color:red">**[DEPRECATED]**</span> <br/><br/> | `CustomEvent<number>` |
+```
+
+The events section will be placed after the [@Prop() section](#prop-details) of the README.
+
+If a component does not use the `@Event()` decorator, this section will be omitted from the generated README.
+
+### @Method() Details
+
+Components that use Stencil's [`@Method()` decorator](../components/methods.md) will have a section describing each usage `@Method`.
+
+Each usage of `@Method` will be documented with its own subsection containing the following:
+- The method signature will be used as the heading for each subsection 
+- A description of the method will immediately follow, if one was provided in a JSDoc
+- A 'Parameters' section that contains a table the describes the name, TypeScript type, and description of each parameter of the method
+- A 'Returns' section that contains the return type of the method, along with a description of the returned value.
+
+For the following usages of `@Method()` in a component:
+
+```ts
+export class MyComponent {
+  /**
+   * Scroll by a specified X/Y distance in the component.
+   *
+   * @param x The amount to scroll by on the horizontal axis.
+   * @param y The amount to scroll by on the vertical axis.
+   * @param duration The amount of time to take scrolling by that amount.
+   * @returns the total distance travelled
+   */
+  @Method()
+  async scrollByPoint(x: number, y: number, duration: number): Promise<number> { /* omitted */ }
+
+  // ...
+}
+```
+
+The following section will be generated:
+
+```md
+## Methods
+
+### `scrollByPoint(x: number, y: number, duration: number) => Promise<number>`
+
+Scroll by a specified X/Y distance in the component.
+
+#### Parameters
+
+| Name       | Type     | Description                                          |
+| ---------- | -------- | ---------------------------------------------------- |
+| `x`        | `number` | The amount to scroll by on the horizontal axis.      |
+| `y`        | `number` | The amount to scroll by on the vertical axis.        |
+| `duration` | `number` | The amount of time to take scrolling by that amount. |
+
+#### Returns
+
+Type: `Promise<number>`
+
+the total distance travelled
+```
+
+The methods section will be placed after the [@Event section](#event-details) of the README.
+
+If a component does not use the `@Method()` decorator, this section will be omitted from the generated README.
+
+### @slot Details
+
+A component that uses [slots](../components/templating-and-jsx.md#slots) may describe its slots in the component's JSDoc using the Stencil-specific `@slot` JSDoc tag.
+The `@slot` tag follows the following format:
+```
+@slot [slot-name] - [description]
+```
+where `slot-name` corresponds to the name of the slot in the markup, and `description` describes the usage of the slot.
+
+For this JSDoc tag to be read properly, the following is required:
+1. Either `slot-name` or `description` must be included. Both may be included though.
+2. The '-' separating the two is required.
+
+For the default slot, omit the `slot-name`.
+
+This information is presented in a table containing the following columns:
+- **Slot**: The name of the slot. The default slot will have no name/be empty.
+- **Description**: A description of the slot, if one was given.
+
+For the following usages of `@slot()` in a component:
+```tsx
+/**
+ * @slot - Content is placed between the named slots if provided without a slot.
+ * @slot primary - Content is placed to the left of the main slotted-in text.
+ * @slot secondary - Content is placed to the right of the main slotted-in text.
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent {
+  // ...
+  
+  render() {
+    return (
+      <section>
+        <slot name="primary"></slot>
+        <div class="content">
+          <slot></slot>
+        </div>
+        <slot name="secondary"></slot>
+      </section>
+    );
+  }
+}
+```
+
+The following table is generated:
+
+```md
+## Slots
+
+| Slot          | Description                                                           |
+| ------------- | --------------------------------------------------------------------- |
+|               | Content is placed between the named slots if provided without a slot. |
+| `"primary"`   | Content is placed to the left of the main slotted-in text.            |
+| `"secondary"` | Content is placed to the right of the main slotted-in text.           |
+
+```
+
+The slots section will be placed after the [@Method section](#method-details) of the README.
+
+If a component's top-level JSDoc does not use `@slot` tags, this section will be omitted from the generated README.
+
+### Shadow Parts
+
+A component that uses [CSS shadow parts](../components/styling.md#css-parts) may describe the component's shadow parts in the component's JSDoc using the Stencil-specific `@part` JSDoc tag.
+The `@part` tag follows the following format:
+```
+@part [part-name] - [description]
+```
+where `part-name` corresponds to the name of the shadow part in the markup, and `description` describes its usage.
+
+For this tag to be read properly, the following is required:
+1. Either `part-name` or `description` must be included, although using both is strongly encouraged.
+2. The '-' separating the two is required.
+
+This information is presented in a table containing the following columns:
+- **Part**: The name of the shadow part.
+- **Description**: A description of the shadow part, if one was given.
+
+For the following usages of `@part()` in a component:
+
+```tsx
+/**
+ * @part label - The label text describing the component.
+ */
+@Component({
+  tag: 'my-component',
+  styleUrl: 'my-component.css',
+  shadow: true,
+})
+export class MyComponent {
+  // ...
+
+  render() {
+    return (
+      <div part="label">
+        <slot></slot>
+      </div>
+    );
+  }
+}
+```
+
+The following table will be generated:
+```md
+## Shadow Parts
+
+| Part                                                        | Description                              |
+| ----------------------------------------------------------- | ---------------------------------------- |
+| `"label"`                                                   | The label text describing the component. |
+```
+
+The shadow parts section will be placed after the [@Slot Details](#slot-details) of the README.
+
+If a component's top-level JSDoc does not use `@part` tags, this section will be omitted from the generated README.
+
+### Styling Details
+
+Styling in CSS files can be documented in Stencil components as well.
+One use case for documenting styles using Stencil is to note a CSS variable that a component's styling depends on.
+Using the `@prop` JSDoc in a component's CSS file, Stencil can generate this documentation as well.
+
+This information is presented in a table containing the following columns:
+- **Name**: The name of the custom property.
+- **Description**: A description of the custom property, if one was given.
+
+For the following usages of `@prop` in a component's css file:
+
+```css
+:host {
+  /**
+   * @prop --border-radius: Border radius of the avatar and inner image
+   */
+  border-radius: var(--border-radius);
+}
+```
+The following table will be generated:
+
+```md
+## CSS Custom Properties
+
+| Name              | Description                                 |
+| ----------------- | ------------------------------------------- |
+| `--border-radius` | Border radius of the avatar and inner image |
+```
+
+The styling details section will be placed after the [Shadow Parts Details](#shadow-parts) of the README.
+
+If a component's styles does not include styling details, this section will be omitted from the generated README.
+
+### Custom Footers
+
+Removing or customizing the footer can be done by adding a `footer` property to
+the output target. This string is added to the generated Markdown files without
+modification, so you can use Markdown syntax in it for rich formatting:
+
+```tsx title="stencil.config.ts"
+import { Config } from '@stencil/core';
+
+export const config: Config = {
+  outputTargets: [
+    {
       type: 'docs-readme',
       footer: '*Built with love!*',
     }
@@ -69,10 +493,16 @@ export const config: Config = {
 };
 ```
 
-## Generating to a Directory
+The following footer will be placed at the bottom of your component's README file:
+```
+*Built with love!*
+```
 
-By default, a readme file will be generated in the same directory as the
-component corresponds to. This behavior can be changed by setting the `dir`
+## Configuration
+### Specifying the Output Directory
+
+By default, a README file will be generated in the same directory as the
+component it corresponds to. This behavior can be changed by setting the `dir`
 property on the output target configuration. Specifying a directory will create
 the structure `{dir}/{component}/readme.md`.
 
@@ -89,10 +519,9 @@ export const config: Config = {
 };
 ```
 
-## Strict Mode
+### Strict Mode
 
-Adding `strict: true` to the output target configuration will cause Stencil to
-output a warning whenever the project is built with missing documentation.
+Adding `strict: true` to the output target configuration will cause Stencil to output a warning whenever the project is built with missing documentation.
 
 ```tsx title="stencil.config.ts"
 import { Config } from '@stencil/core';
@@ -106,3 +535,9 @@ export const config: Config = {
   ]
 };
 ```
+
+When strict mode is enabled, the following items are checked:
+1. `@Prop()` usages must be documented, unless the property is marked as `@deprecated`
+2. `@Method()` usages must be documented, unless the method is marked as `@deprecated`
+3. `@Event()` usages must be documented, unless the event is marked as `@deprecated`
+4. CSS Part usages must be documented

--- a/versioned_docs/version-v4.10/config/cli.md
+++ b/versioned_docs/version-v4.10/config/cli.md
@@ -20,7 +20,7 @@ Builds a Stencil project. The flags below are the available options for the `bui
 | `--config` | Path to the `stencil.config.ts` file. This flag is not needed in most cases since Stencil will find the config. Additionally, a Stencil config is not required. | `-c` |
 | `--debug` | Adds additional runtime code to help debug, and sets the log level for more verbose output. | |
 | `--dev` | Runs a development build. | |
-| `--docs-readme` | Generate `readme.md` docs based on the component types, properties, methods, events, JSDocs, CSS Custom Properties, etc. | |
+| `--docs` | Generate all docs based on the component types, properties, methods, events, JSDocs, CSS Custom Properties, etc. | |
 | `--es5` | Creates an ES5 compatible build. By default ES5 builds are not created during development in order to improve build times. However, ES5 builds are always created during production builds. Use this flag to create ES5 builds during development. | |
 | `--log` | Write logs for the `stencil build` into `stencil-build.log`. The log file is written in the same location as the config. | |
 | `--prerender` | Prerender the application using the `www` output target after the build has completed. | |

--- a/versioned_docs/version-v4.10/documentation-generation/docs-readme.md
+++ b/versioned_docs/version-v4.10/documentation-generation/docs-readme.md
@@ -7,54 +7,478 @@ slug: /docs-readme
 
 # Docs Readme Markdown File Auto-Generation
 
-Stencil is able to auto-generate `readme.md` files in markdown. This
-feature will save the readme files as a sibling to the component's source file within the
-same directory. This can help you to maintain consistently formatted
-documentation for your components which live right next to them and render in
-GitHub.
+Stencil is able to auto-generate `readme.md` files for your components.
+This can help you to maintain consistently formatted documentation for your components which lives right next to them and renders in GitHub.
 
-To auto-generate readme files, add the `docs-readme` output target to your
-`stencil.config.ts` like so:
+## Setup
+
+To generate markdown files, it is recommended to add the `docs-readme` output target to your Stencil configuration file:
 
 ```tsx title="stencil.config.ts"
 import { Config } from '@stencil/core';
 
 export const config: Config = {
   outputTargets: [
-    { type: 'docs-readme' }
+    { 
+      type: 'docs-readme'
+    }
   ]
 };
 ```
 
-Another option would be to use the `--docs` CLI flag as a part of the [build task](../config/cli.md#stencil-build), like so:
+## Generating README Files
 
+### Using the Build Command
+
+If your project has a `docs-readme` output target configured in your Stencil configuration file, the Stencil [build command](../config/cli.md#stencil-build) is all that's needed to generate README docs:
 ```bash
-stencil build --docs
+npx stencil build
+```
+If you're running the build command with the `--watch` flag, your project's README files will automatically update without requiring multiple explicit build commands:
+```bash
+npm stencil build --watch
 ```
 
-This will cause the Stencil compiler to perform a one-time generation of README
-files as a part of the build process.
-
-:::note
-If you don't add the `docs-readme` output target to your Stencil configuration, the `--docs` flag must be applied to regenerate documentation.
+:::info
+When running the build command with the `--dev` flag, README files will not be generated.
+This is to prevent unnecessary I/O operations during the development cycle.
 :::
 
-Alternatively, the [docs task](../config/cli.md#stencil-docs) can be used to perform a one time generation of the documentation:
+If you choose not to include a `docs-readme` output target in your Stencil configuration file, use the `--docs` CLI flag as a part of the build command:
 ```bash
-stencil docs
+npx stencil build --docs
 ```
 
-## Adding Custom Markdown to Auto-Generated Files
+This will cause the Stencil compiler to perform a one-time build of your entire project, including README files.
 
-Once you've generated a `readme.md` file you can customize it with your own
-markdown content. Simply add your own markdown above the comment that reads:
-`<!-- Auto Generated Below -->`.
+### Using the Docs Command
 
-## Custom Footer
+As an alternative to the build command, the [docs command](../config/cli.md#stencil-docs) can be used to perform a one time generation of the documentation:
+```bash
+npx stencil docs
+```
+Running `stencil docs` will generate documentation for [all documentation output targets](./01-overview.md), not just `docs-readme`.
+
+## README Sections
+
+Most generated markdown content will automatically be generated without requiring any additional configuration.
+Content is generated based on its Stencil component, rather than requiring you to configure multiple flags.
+Each section below describes the different types of content Stencil recognizes and will automatically generate. 
+
+### Custom Markdown Content
+
+Once you've generated a `readme.md` file, you can add your own markdown content to the file.
+You may add any content above the following comment in a component's `readme.md`:
+```
+Custom content goes here!
+<!-- Auto Generated Below -->
+```
+
+Any custom content placed above this comment will be persisted on subsequent builds of the README file.
+
+### Deprecation Notices
+
+A Stencil component may be marked as deprecated using the [JSDoc `@deprecated` tag](https://jsdoc.app/tags-deprecated).
+By placing `@deprecated` in a component's class-level JSDoc it will cause the generated README to denote the component as deprecated.
+
+For a component with the JSDoc:
+
+```tsx title="A component with @deprecated in its JSDoc"
+/**
+ * @deprecated since v2.0.0
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent { /* omitted */ }
+```
+
+In the code block above, `@deprecated` is added to the JSDoc for `MyComponent`.
+This causes the generated README to contain:
+```
+> **[DEPRECATED]** since v2.0.0
+```
+
+The deprecation notice will always begin with `> **[DEPRECATED]**`, followed by the description provided in the JSDoc.
+In this case, that description is "since v2.0.0".
+
+The deprecation notice will be placed after the [custom content](#custom-markdown-content) in the README.
+
+If a component is not marked as deprecated, this section will be omitted from the generated README.
+
+### Component Overview
+
+A Stencil component that has a JSDoc comment on its class component like so:
+
+```tsx title="A component with an overview in its JSDoc"
+/**
+ * A simple component for formatting names
+ *
+ * This component will do some neat things!
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent { }
+```
+will generate the following section in your component's README:
+
+```
+## Overview
+
+A simple component for formatting names
+
+This component will do some neat things!
+```
+
+The overview will be placed after the [deprecation notice](#deprecation-notices) section of the README.
+
+If a component's JSDoc does not contain an overview, this section will be omitted from the generated README.
+
+### Usage Examples
+
+Usage examples are user-generated markdown files that demonstrate how another developer might use a component.
+These files are separate from a component's README file, and are placed in a `usage/` directory adjacent to a component's implementation.
+
+The content of these files will be added to a `Usage` section of the generated README. 
+This allows you to keep examples right next to the code, making it easy to include them in a documentation site or other downstream consumer(s) of your docs.
+
+The example usage file below describes how to use a component defined in `src/components/my-component/my-component.tsx`:
+
+````md title="src/components/my-component/usage/my-component-usage.md"
+# How to Use `my-component`
+
+This component is used to provide a way to greet a user using their first, middle, and last name.
+This component will properly format the provided name, even when all fields aren't provided:
+
+```html
+<my-component first="Stencil"></my-component>
+<my-component first="Stencil" last="JS"></my-component>
+```
+````
+
+When the README for `my-component` is regenerated, following will be added to the README:
+
+````md
+## Usage
+
+### My-component-usage
+
+# How to Use `my-component`
+
+This component is used to provide a way to greet a user using their first, middle, and last name.
+This component will properly format the provided name, even when all fields aren't provided:
+
+```html
+<my-component first="Stencil"></my-component>
+<my-component first="Stencil" last="JS"></my-component>
+```
+````
+
+:::caution
+Stencil does not check that your usage examples are up-to-date.
+If you make any changes to your component's API, you'll need to update your usage examples manually.
+:::
+
+The usage section will be placed after the [overview section](#component-overview) of the README.
+
+If a component's directory does not contain any usage files, this section will be omitted from the generated README.
+
+### @Prop() Details
+
+Usages of Stencil's [`@Prop()` decorator](../components/properties.md) are described in a table containing the following information for each usage of `@Prop()`:
+- **Property**: The name of the property on the TypeScript class.
+- **Attribute**: The name of the attribute associated with the property name.
+- **Description**: A description of the property, if one was given in a JSDoc comment for the property.
+- **Type**: The TypeScript type of the property.
+- **Default**: The default value of the property.
+
+For the following usages of `@Prop()` in a component:
+```ts
+export class MyComponent {
+  /**
+   * The first name
+   */
+  @Prop() first!: string; // the '!' denotes a required property
+  /**
+   * @deprecated since v2.1.0
+   */
+  @Prop() middle: string;
+  @Prop() lastName = "Smith";
+
+  // ...
+}
+```
+
+The following section will be generated:
+```md
+## Properties
+
+| Property             | Attribute   | Description                                                            | Type     | Default     |
+| -------------------- | ----------- | ---------------------------------------------------------------------- | -------- | ----------- |
+| `first` _(required)_ | `first`     | The first name                                                         | `string` | `undefined` |
+| `lastName`           | `last-name` |                                                                        | `string` | `"Smith"`   |
+| `middle`             | `middle`    | <span style="color:red">**[DEPRECATED]**</span> since v2.1.0<br/><br/> | `string` | `undefined` |
+```
+
+The properties section will be placed after the [usage examples section](#usage-examples) of the README.
+
+If a component does not use the `@Prop()` decorator, this section will be omitted from the generated README.
+
+### @Event() Details
+
+Usages of Stencil's [`@Event()` decorator](../components/events.md) are described in a table containing the following information for each usage of `@Event()`:
+- **Event**: The name of the property on the TypeScript class decorated with `@Event()`.
+- **Description**: A description of the property, if one was given in a JSDoc comment for the property.
+- **Type**: The TypeScript type of the property.
+
+For the following usages of `@Event()` in a component:
+```tsx
+export class MyComponent {
+  /**
+   * Emitted when an event is completed
+   */
+  @Event() todoCompleted: EventEmitter<number>;
+  /**
+   * @deprecated
+   */
+  @Event() todoUndo: EventEmitter<number>;
+
+  // ...
+}
+```
+
+The following section will be generated:
+
+```md
+## Events
+
+| Event           | Description                                                | Type                  |
+| --------------- | ---------------------------------------------------------- | --------------------- |
+| `todoCompleted` | Emitted when an event is completed                         | `CustomEvent<number>` |
+| `todoUndo`      | <span style="color:red">**[DEPRECATED]**</span> <br/><br/> | `CustomEvent<number>` |
+```
+
+The events section will be placed after the [@Prop() section](#prop-details) of the README.
+
+If a component does not use the `@Event()` decorator, this section will be omitted from the generated README.
+
+### @Method() Details
+
+Components that use Stencil's [`@Method()` decorator](../components/methods.md) will have a section describing each usage `@Method`.
+
+Each usage of `@Method` will be documented with its own subsection containing the following:
+- The method signature will be used as the heading for each subsection 
+- A description of the method will immediately follow, if one was provided in a JSDoc
+- A 'Parameters' section that contains a table the describes the name, TypeScript type, and description of each parameter of the method
+- A 'Returns' section that contains the return type of the method, along with a description of the returned value.
+
+For the following usages of `@Method()` in a component:
+
+```ts
+export class MyComponent {
+  /**
+   * Scroll by a specified X/Y distance in the component.
+   *
+   * @param x The amount to scroll by on the horizontal axis.
+   * @param y The amount to scroll by on the vertical axis.
+   * @param duration The amount of time to take scrolling by that amount.
+   * @returns the total distance travelled
+   */
+  @Method()
+  async scrollByPoint(x: number, y: number, duration: number): Promise<number> { /* omitted */ }
+
+  // ...
+}
+```
+
+The following section will be generated:
+
+```md
+## Methods
+
+### `scrollByPoint(x: number, y: number, duration: number) => Promise<number>`
+
+Scroll by a specified X/Y distance in the component.
+
+#### Parameters
+
+| Name       | Type     | Description                                          |
+| ---------- | -------- | ---------------------------------------------------- |
+| `x`        | `number` | The amount to scroll by on the horizontal axis.      |
+| `y`        | `number` | The amount to scroll by on the vertical axis.        |
+| `duration` | `number` | The amount of time to take scrolling by that amount. |
+
+#### Returns
+
+Type: `Promise<number>`
+
+the total distance travelled
+```
+
+The methods section will be placed after the [@Event section](#event-details) of the README.
+
+If a component does not use the `@Method()` decorator, this section will be omitted from the generated README.
+
+### @slot Details
+
+A component that uses [slots](../components/templating-and-jsx.md#slots) may describe its slots in the component's JSDoc using the Stencil-specific `@slot` JSDoc tag.
+The `@slot` tag follows the following format:
+```
+@slot [slot-name] - [description]
+```
+where `slot-name` corresponds to the name of the slot in the markup, and `description` describes the usage of the slot.
+
+For this JSDoc tag to be read properly, the following is required:
+1. Either `slot-name` or `description` must be included. Both may be included though.
+2. The '-' separating the two is required.
+
+For the default slot, omit the `slot-name`.
+
+This information is presented in a table containing the following columns:
+- **Slot**: The name of the slot. The default slot will have no name/be empty.
+- **Description**: A description of the slot, if one was given.
+
+For the following usages of `@slot()` in a component:
+```tsx
+/**
+ * @slot - Content is placed between the named slots if provided without a slot.
+ * @slot primary - Content is placed to the left of the main slotted-in text.
+ * @slot secondary - Content is placed to the right of the main slotted-in text.
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent {
+  // ...
+  
+  render() {
+    return (
+      <section>
+        <slot name="primary"></slot>
+        <div class="content">
+          <slot></slot>
+        </div>
+        <slot name="secondary"></slot>
+      </section>
+    );
+  }
+}
+```
+
+The following table is generated:
+
+```md
+## Slots
+
+| Slot          | Description                                                           |
+| ------------- | --------------------------------------------------------------------- |
+|               | Content is placed between the named slots if provided without a slot. |
+| `"primary"`   | Content is placed to the left of the main slotted-in text.            |
+| `"secondary"` | Content is placed to the right of the main slotted-in text.           |
+
+```
+
+The slots section will be placed after the [@Method section](#method-details) of the README.
+
+If a component's top-level JSDoc does not use `@slot` tags, this section will be omitted from the generated README.
+
+### Shadow Parts
+
+A component that uses [CSS shadow parts](../components/styling.md#css-parts) may describe the component's shadow parts in the component's JSDoc using the Stencil-specific `@part` JSDoc tag.
+The `@part` tag follows the following format:
+```
+@part [part-name] - [description]
+```
+where `part-name` corresponds to the name of the shadow part in the markup, and `description` describes its usage.
+
+For this tag to be read properly, the following is required:
+1. Either `part-name` or `description` must be included, although using both is strongly encouraged.
+2. The '-' separating the two is required.
+
+This information is presented in a table containing the following columns:
+- **Part**: The name of the shadow part.
+- **Description**: A description of the shadow part, if one was given.
+
+For the following usages of `@part()` in a component:
+
+```tsx
+/**
+ * @part label - The label text describing the component.
+ */
+@Component({
+  tag: 'my-component',
+  styleUrl: 'my-component.css',
+  shadow: true,
+})
+export class MyComponent {
+  // ...
+
+  render() {
+    return (
+      <div part="label">
+        <slot></slot>
+      </div>
+    );
+  }
+}
+```
+
+The following table will be generated:
+```md
+## Shadow Parts
+
+| Part                                                        | Description                              |
+| ----------------------------------------------------------- | ---------------------------------------- |
+| `"label"`                                                   | The label text describing the component. |
+```
+
+The shadow parts section will be placed after the [@Slot Details](#slot-details) of the README.
+
+If a component's top-level JSDoc does not use `@part` tags, this section will be omitted from the generated README.
+
+### Styling Details
+
+Styling in CSS files can be documented in Stencil components as well.
+One use case for documenting styles using Stencil is to note a CSS variable that a component's styling depends on.
+Using the `@prop` JSDoc in a component's CSS file, Stencil can generate this documentation as well.
+
+This information is presented in a table containing the following columns:
+- **Name**: The name of the custom property.
+- **Description**: A description of the custom property, if one was given.
+
+For the following usages of `@prop` in a component's css file:
+
+```css
+:host {
+  /**
+   * @prop --border-radius: Border radius of the avatar and inner image
+   */
+  border-radius: var(--border-radius);
+}
+```
+The following table will be generated:
+
+```md
+## CSS Custom Properties
+
+| Name              | Description                                 |
+| ----------------- | ------------------------------------------- |
+| `--border-radius` | Border radius of the avatar and inner image |
+```
+
+The styling details section will be placed after the [Shadow Parts Details](#shadow-parts) of the README.
+
+If a component's styles does not include styling details, this section will be omitted from the generated README.
+
+### Custom Footers
 
 Removing or customizing the footer can be done by adding a `footer` property to
 the output target. This string is added to the generated Markdown files without
-modification, so you can use Markdown syntax in it for rich formatting.
+modification, so you can use Markdown syntax in it for rich formatting:
 
 ```tsx title="stencil.config.ts"
 import { Config } from '@stencil/core';
@@ -69,10 +493,16 @@ export const config: Config = {
 };
 ```
 
-## Generating to a Directory
+The following footer will be placed at the bottom of your component's README file:
+```
+*Built with love!*
+```
 
-By default, a readme file will be generated in the same directory as the
-component corresponds to. This behavior can be changed by setting the `dir`
+## Configuration
+### Specifying the Output Directory
+
+By default, a README file will be generated in the same directory as the
+component it corresponds to. This behavior can be changed by setting the `dir`
 property on the output target configuration. Specifying a directory will create
 the structure `{dir}/{component}/readme.md`.
 
@@ -89,10 +519,9 @@ export const config: Config = {
 };
 ```
 
-## Strict Mode
+### Strict Mode
 
-Adding `strict: true` to the output target configuration will cause Stencil to
-output a warning whenever the project is built with missing documentation.
+Adding `strict: true` to the output target configuration will cause Stencil to output a warning whenever the project is built with missing documentation.
 
 ```tsx title="stencil.config.ts"
 import { Config } from '@stencil/core';
@@ -106,3 +535,9 @@ export const config: Config = {
   ]
 };
 ```
+
+When strict mode is enabled, the following items are checked:
+1. `@Prop()` usages must be documented, unless the property is marked as `@deprecated`
+2. `@Method()` usages must be documented, unless the method is marked as `@deprecated`
+3. `@Event()` usages must be documented, unless the event is marked as `@deprecated`
+4. CSS Part usages must be documented

--- a/versioned_docs/version-v4.11/config/cli.md
+++ b/versioned_docs/version-v4.11/config/cli.md
@@ -20,7 +20,7 @@ Builds a Stencil project. The flags below are the available options for the `bui
 | `--config` | Path to the `stencil.config.ts` file. This flag is not needed in most cases since Stencil will find the config. Additionally, a Stencil config is not required. | `-c` |
 | `--debug` | Adds additional runtime code to help debug, and sets the log level for more verbose output. | |
 | `--dev` | Runs a development build. | |
-| `--docs-readme` | Generate `readme.md` docs based on the component types, properties, methods, events, JSDocs, CSS Custom Properties, etc. | |
+| `--docs` | Generate all docs based on the component types, properties, methods, events, JSDocs, CSS Custom Properties, etc. | |
 | `--es5` | Creates an ES5 compatible build. By default ES5 builds are not created during development in order to improve build times. However, ES5 builds are always created during production builds. Use this flag to create ES5 builds during development. | |
 | `--log` | Write logs for the `stencil build` into `stencil-build.log`. The log file is written in the same location as the config. | |
 | `--prerender` | Prerender the application using the `www` output target after the build has completed. | |

--- a/versioned_docs/version-v4.11/documentation-generation/docs-readme.md
+++ b/versioned_docs/version-v4.11/documentation-generation/docs-readme.md
@@ -7,54 +7,478 @@ slug: /docs-readme
 
 # Docs Readme Markdown File Auto-Generation
 
-Stencil is able to auto-generate `readme.md` files in markdown. This
-feature will save the readme files as a sibling to the component's source file within the
-same directory. This can help you to maintain consistently formatted
-documentation for your components which live right next to them and render in
-GitHub.
+Stencil is able to auto-generate `readme.md` files for your components.
+This can help you to maintain consistently formatted documentation for your components which lives right next to them and renders in GitHub.
 
-To auto-generate readme files, add the `docs-readme` output target to your
-`stencil.config.ts` like so:
+## Setup
+
+To generate markdown files, it is recommended to add the `docs-readme` output target to your Stencil configuration file:
 
 ```tsx title="stencil.config.ts"
 import { Config } from '@stencil/core';
 
 export const config: Config = {
   outputTargets: [
-    { type: 'docs-readme' }
+    { 
+      type: 'docs-readme'
+    }
   ]
 };
 ```
 
-Another option would be to use the `--docs` CLI flag as a part of the [build task](../config/cli.md#stencil-build), like so:
+## Generating README Files
 
+### Using the Build Command
+
+If your project has a `docs-readme` output target configured in your Stencil configuration file, the Stencil [build command](../config/cli.md#stencil-build) is all that's needed to generate README docs:
 ```bash
-stencil build --docs
+npx stencil build
+```
+If you're running the build command with the `--watch` flag, your project's README files will automatically update without requiring multiple explicit build commands:
+```bash
+npm stencil build --watch
 ```
 
-This will cause the Stencil compiler to perform a one-time generation of README
-files as a part of the build process.
-
-:::note
-If you don't add the `docs-readme` output target to your Stencil configuration, the `--docs` flag must be applied to regenerate documentation.
+:::info
+When running the build command with the `--dev` flag, README files will not be generated.
+This is to prevent unnecessary I/O operations during the development cycle.
 :::
 
-Alternatively, the [docs task](../config/cli.md#stencil-docs) can be used to perform a one time generation of the documentation:
+If you choose not to include a `docs-readme` output target in your Stencil configuration file, use the `--docs` CLI flag as a part of the build command:
 ```bash
-stencil docs
+npx stencil build --docs
 ```
 
-## Adding Custom Markdown to Auto-Generated Files
+This will cause the Stencil compiler to perform a one-time build of your entire project, including README files.
 
-Once you've generated a `readme.md` file you can customize it with your own
-markdown content. Simply add your own markdown above the comment that reads:
-`<!-- Auto Generated Below -->`.
+### Using the Docs Command
 
-## Custom Footer
+As an alternative to the build command, the [docs command](../config/cli.md#stencil-docs) can be used to perform a one time generation of the documentation:
+```bash
+npx stencil docs
+```
+Running `stencil docs` will generate documentation for [all documentation output targets](./01-overview.md), not just `docs-readme`.
+
+## README Sections
+
+Most generated markdown content will automatically be generated without requiring any additional configuration.
+Content is generated based on its Stencil component, rather than requiring you to configure multiple flags.
+Each section below describes the different types of content Stencil recognizes and will automatically generate. 
+
+### Custom Markdown Content
+
+Once you've generated a `readme.md` file, you can add your own markdown content to the file.
+You may add any content above the following comment in a component's `readme.md`:
+```
+Custom content goes here!
+<!-- Auto Generated Below -->
+```
+
+Any custom content placed above this comment will be persisted on subsequent builds of the README file.
+
+### Deprecation Notices
+
+A Stencil component may be marked as deprecated using the [JSDoc `@deprecated` tag](https://jsdoc.app/tags-deprecated).
+By placing `@deprecated` in a component's class-level JSDoc it will cause the generated README to denote the component as deprecated.
+
+For a component with the JSDoc:
+
+```tsx title="A component with @deprecated in its JSDoc"
+/**
+ * @deprecated since v2.0.0
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent { /* omitted */ }
+```
+
+In the code block above, `@deprecated` is added to the JSDoc for `MyComponent`.
+This causes the generated README to contain:
+```
+> **[DEPRECATED]** since v2.0.0
+```
+
+The deprecation notice will always begin with `> **[DEPRECATED]**`, followed by the description provided in the JSDoc.
+In this case, that description is "since v2.0.0".
+
+The deprecation notice will be placed after the [custom content](#custom-markdown-content) in the README.
+
+If a component is not marked as deprecated, this section will be omitted from the generated README.
+
+### Component Overview
+
+A Stencil component that has a JSDoc comment on its class component like so:
+
+```tsx title="A component with an overview in its JSDoc"
+/**
+ * A simple component for formatting names
+ *
+ * This component will do some neat things!
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent { }
+```
+will generate the following section in your component's README:
+
+```
+## Overview
+
+A simple component for formatting names
+
+This component will do some neat things!
+```
+
+The overview will be placed after the [deprecation notice](#deprecation-notices) section of the README.
+
+If a component's JSDoc does not contain an overview, this section will be omitted from the generated README.
+
+### Usage Examples
+
+Usage examples are user-generated markdown files that demonstrate how another developer might use a component.
+These files are separate from a component's README file, and are placed in a `usage/` directory adjacent to a component's implementation.
+
+The content of these files will be added to a `Usage` section of the generated README. 
+This allows you to keep examples right next to the code, making it easy to include them in a documentation site or other downstream consumer(s) of your docs.
+
+The example usage file below describes how to use a component defined in `src/components/my-component/my-component.tsx`:
+
+````md title="src/components/my-component/usage/my-component-usage.md"
+# How to Use `my-component`
+
+This component is used to provide a way to greet a user using their first, middle, and last name.
+This component will properly format the provided name, even when all fields aren't provided:
+
+```html
+<my-component first="Stencil"></my-component>
+<my-component first="Stencil" last="JS"></my-component>
+```
+````
+
+When the README for `my-component` is regenerated, following will be added to the README:
+
+````md
+## Usage
+
+### My-component-usage
+
+# How to Use `my-component`
+
+This component is used to provide a way to greet a user using their first, middle, and last name.
+This component will properly format the provided name, even when all fields aren't provided:
+
+```html
+<my-component first="Stencil"></my-component>
+<my-component first="Stencil" last="JS"></my-component>
+```
+````
+
+:::caution
+Stencil does not check that your usage examples are up-to-date.
+If you make any changes to your component's API, you'll need to update your usage examples manually.
+:::
+
+The usage section will be placed after the [overview section](#component-overview) of the README.
+
+If a component's directory does not contain any usage files, this section will be omitted from the generated README.
+
+### @Prop() Details
+
+Usages of Stencil's [`@Prop()` decorator](../components/properties.md) are described in a table containing the following information for each usage of `@Prop()`:
+- **Property**: The name of the property on the TypeScript class.
+- **Attribute**: The name of the attribute associated with the property name.
+- **Description**: A description of the property, if one was given in a JSDoc comment for the property.
+- **Type**: The TypeScript type of the property.
+- **Default**: The default value of the property.
+
+For the following usages of `@Prop()` in a component:
+```ts
+export class MyComponent {
+  /**
+   * The first name
+   */
+  @Prop() first!: string; // the '!' denotes a required property
+  /**
+   * @deprecated since v2.1.0
+   */
+  @Prop() middle: string;
+  @Prop() lastName = "Smith";
+
+  // ...
+}
+```
+
+The following section will be generated:
+```md
+## Properties
+
+| Property             | Attribute   | Description                                                            | Type     | Default     |
+| -------------------- | ----------- | ---------------------------------------------------------------------- | -------- | ----------- |
+| `first` _(required)_ | `first`     | The first name                                                         | `string` | `undefined` |
+| `lastName`           | `last-name` |                                                                        | `string` | `"Smith"`   |
+| `middle`             | `middle`    | <span style="color:red">**[DEPRECATED]**</span> since v2.1.0<br/><br/> | `string` | `undefined` |
+```
+
+The properties section will be placed after the [usage examples section](#usage-examples) of the README.
+
+If a component does not use the `@Prop()` decorator, this section will be omitted from the generated README.
+
+### @Event() Details
+
+Usages of Stencil's [`@Event()` decorator](../components/events.md) are described in a table containing the following information for each usage of `@Event()`:
+- **Event**: The name of the property on the TypeScript class decorated with `@Event()`.
+- **Description**: A description of the property, if one was given in a JSDoc comment for the property.
+- **Type**: The TypeScript type of the property.
+
+For the following usages of `@Event()` in a component:
+```tsx
+export class MyComponent {
+  /**
+   * Emitted when an event is completed
+   */
+  @Event() todoCompleted: EventEmitter<number>;
+  /**
+   * @deprecated
+   */
+  @Event() todoUndo: EventEmitter<number>;
+
+  // ...
+}
+```
+
+The following section will be generated:
+
+```md
+## Events
+
+| Event           | Description                                                | Type                  |
+| --------------- | ---------------------------------------------------------- | --------------------- |
+| `todoCompleted` | Emitted when an event is completed                         | `CustomEvent<number>` |
+| `todoUndo`      | <span style="color:red">**[DEPRECATED]**</span> <br/><br/> | `CustomEvent<number>` |
+```
+
+The events section will be placed after the [@Prop() section](#prop-details) of the README.
+
+If a component does not use the `@Event()` decorator, this section will be omitted from the generated README.
+
+### @Method() Details
+
+Components that use Stencil's [`@Method()` decorator](../components/methods.md) will have a section describing each usage `@Method`.
+
+Each usage of `@Method` will be documented with its own subsection containing the following:
+- The method signature will be used as the heading for each subsection 
+- A description of the method will immediately follow, if one was provided in a JSDoc
+- A 'Parameters' section that contains a table the describes the name, TypeScript type, and description of each parameter of the method
+- A 'Returns' section that contains the return type of the method, along with a description of the returned value.
+
+For the following usages of `@Method()` in a component:
+
+```ts
+export class MyComponent {
+  /**
+   * Scroll by a specified X/Y distance in the component.
+   *
+   * @param x The amount to scroll by on the horizontal axis.
+   * @param y The amount to scroll by on the vertical axis.
+   * @param duration The amount of time to take scrolling by that amount.
+   * @returns the total distance travelled
+   */
+  @Method()
+  async scrollByPoint(x: number, y: number, duration: number): Promise<number> { /* omitted */ }
+
+  // ...
+}
+```
+
+The following section will be generated:
+
+```md
+## Methods
+
+### `scrollByPoint(x: number, y: number, duration: number) => Promise<number>`
+
+Scroll by a specified X/Y distance in the component.
+
+#### Parameters
+
+| Name       | Type     | Description                                          |
+| ---------- | -------- | ---------------------------------------------------- |
+| `x`        | `number` | The amount to scroll by on the horizontal axis.      |
+| `y`        | `number` | The amount to scroll by on the vertical axis.        |
+| `duration` | `number` | The amount of time to take scrolling by that amount. |
+
+#### Returns
+
+Type: `Promise<number>`
+
+the total distance travelled
+```
+
+The methods section will be placed after the [@Event section](#event-details) of the README.
+
+If a component does not use the `@Method()` decorator, this section will be omitted from the generated README.
+
+### @slot Details
+
+A component that uses [slots](../components/templating-and-jsx.md#slots) may describe its slots in the component's JSDoc using the Stencil-specific `@slot` JSDoc tag.
+The `@slot` tag follows the following format:
+```
+@slot [slot-name] - [description]
+```
+where `slot-name` corresponds to the name of the slot in the markup, and `description` describes the usage of the slot.
+
+For this JSDoc tag to be read properly, the following is required:
+1. Either `slot-name` or `description` must be included. Both may be included though.
+2. The '-' separating the two is required.
+
+For the default slot, omit the `slot-name`.
+
+This information is presented in a table containing the following columns:
+- **Slot**: The name of the slot. The default slot will have no name/be empty.
+- **Description**: A description of the slot, if one was given.
+
+For the following usages of `@slot()` in a component:
+```tsx
+/**
+ * @slot - Content is placed between the named slots if provided without a slot.
+ * @slot primary - Content is placed to the left of the main slotted-in text.
+ * @slot secondary - Content is placed to the right of the main slotted-in text.
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent {
+  // ...
+  
+  render() {
+    return (
+      <section>
+        <slot name="primary"></slot>
+        <div class="content">
+          <slot></slot>
+        </div>
+        <slot name="secondary"></slot>
+      </section>
+    );
+  }
+}
+```
+
+The following table is generated:
+
+```md
+## Slots
+
+| Slot          | Description                                                           |
+| ------------- | --------------------------------------------------------------------- |
+|               | Content is placed between the named slots if provided without a slot. |
+| `"primary"`   | Content is placed to the left of the main slotted-in text.            |
+| `"secondary"` | Content is placed to the right of the main slotted-in text.           |
+
+```
+
+The slots section will be placed after the [@Method section](#method-details) of the README.
+
+If a component's top-level JSDoc does not use `@slot` tags, this section will be omitted from the generated README.
+
+### Shadow Parts
+
+A component that uses [CSS shadow parts](../components/styling.md#css-parts) may describe the component's shadow parts in the component's JSDoc using the Stencil-specific `@part` JSDoc tag.
+The `@part` tag follows the following format:
+```
+@part [part-name] - [description]
+```
+where `part-name` corresponds to the name of the shadow part in the markup, and `description` describes its usage.
+
+For this tag to be read properly, the following is required:
+1. Either `part-name` or `description` must be included, although using both is strongly encouraged.
+2. The '-' separating the two is required.
+
+This information is presented in a table containing the following columns:
+- **Part**: The name of the shadow part.
+- **Description**: A description of the shadow part, if one was given.
+
+For the following usages of `@part()` in a component:
+
+```tsx
+/**
+ * @part label - The label text describing the component.
+ */
+@Component({
+  tag: 'my-component',
+  styleUrl: 'my-component.css',
+  shadow: true,
+})
+export class MyComponent {
+  // ...
+
+  render() {
+    return (
+      <div part="label">
+        <slot></slot>
+      </div>
+    );
+  }
+}
+```
+
+The following table will be generated:
+```md
+## Shadow Parts
+
+| Part                                                        | Description                              |
+| ----------------------------------------------------------- | ---------------------------------------- |
+| `"label"`                                                   | The label text describing the component. |
+```
+
+The shadow parts section will be placed after the [@Slot Details](#slot-details) of the README.
+
+If a component's top-level JSDoc does not use `@part` tags, this section will be omitted from the generated README.
+
+### Styling Details
+
+Styling in CSS files can be documented in Stencil components as well.
+One use case for documenting styles using Stencil is to note a CSS variable that a component's styling depends on.
+Using the `@prop` JSDoc in a component's CSS file, Stencil can generate this documentation as well.
+
+This information is presented in a table containing the following columns:
+- **Name**: The name of the custom property.
+- **Description**: A description of the custom property, if one was given.
+
+For the following usages of `@prop` in a component's css file:
+
+```css
+:host {
+  /**
+   * @prop --border-radius: Border radius of the avatar and inner image
+   */
+  border-radius: var(--border-radius);
+}
+```
+The following table will be generated:
+
+```md
+## CSS Custom Properties
+
+| Name              | Description                                 |
+| ----------------- | ------------------------------------------- |
+| `--border-radius` | Border radius of the avatar and inner image |
+```
+
+The styling details section will be placed after the [Shadow Parts Details](#shadow-parts) of the README.
+
+If a component's styles does not include styling details, this section will be omitted from the generated README.
+
+### Custom Footers
 
 Removing or customizing the footer can be done by adding a `footer` property to
 the output target. This string is added to the generated Markdown files without
-modification, so you can use Markdown syntax in it for rich formatting.
+modification, so you can use Markdown syntax in it for rich formatting:
 
 ```tsx title="stencil.config.ts"
 import { Config } from '@stencil/core';
@@ -69,10 +493,16 @@ export const config: Config = {
 };
 ```
 
-## Generating to a Directory
+The following footer will be placed at the bottom of your component's README file:
+```
+*Built with love!*
+```
 
-By default, a readme file will be generated in the same directory as the
-component corresponds to. This behavior can be changed by setting the `dir`
+## Configuration
+### Specifying the Output Directory
+
+By default, a README file will be generated in the same directory as the
+component it corresponds to. This behavior can be changed by setting the `dir`
 property on the output target configuration. Specifying a directory will create
 the structure `{dir}/{component}/readme.md`.
 
@@ -89,10 +519,9 @@ export const config: Config = {
 };
 ```
 
-## Strict Mode
+### Strict Mode
 
-Adding `strict: true` to the output target configuration will cause Stencil to
-output a warning whenever the project is built with missing documentation.
+Adding `strict: true` to the output target configuration will cause Stencil to output a warning whenever the project is built with missing documentation.
 
 ```tsx title="stencil.config.ts"
 import { Config } from '@stencil/core';
@@ -106,3 +535,9 @@ export const config: Config = {
   ]
 };
 ```
+
+When strict mode is enabled, the following items are checked:
+1. `@Prop()` usages must be documented, unless the property is marked as `@deprecated`
+2. `@Method()` usages must be documented, unless the method is marked as `@deprecated`
+3. `@Event()` usages must be documented, unless the event is marked as `@deprecated`
+4. CSS Part usages must be documented

--- a/versioned_docs/version-v4.12/config/cli.md
+++ b/versioned_docs/version-v4.12/config/cli.md
@@ -20,7 +20,7 @@ Builds a Stencil project. The flags below are the available options for the `bui
 | `--config` | Path to the `stencil.config.ts` file. This flag is not needed in most cases since Stencil will find the config. Additionally, a Stencil config is not required. | `-c` |
 | `--debug` | Adds additional runtime code to help debug, and sets the log level for more verbose output. | |
 | `--dev` | Runs a development build. | |
-| `--docs-readme` | Generate `readme.md` docs based on the component types, properties, methods, events, JSDocs, CSS Custom Properties, etc. | |
+| `--docs` | Generate all docs based on the component types, properties, methods, events, JSDocs, CSS Custom Properties, etc. | |
 | `--es5` | Creates an ES5 compatible build. By default ES5 builds are not created during development in order to improve build times. However, ES5 builds are always created during production builds. Use this flag to create ES5 builds during development. | |
 | `--log` | Write logs for the `stencil build` into `stencil-build.log`. The log file is written in the same location as the config. | |
 | `--prerender` | Prerender the application using the `www` output target after the build has completed. | |

--- a/versioned_docs/version-v4.12/documentation-generation/docs-readme.md
+++ b/versioned_docs/version-v4.12/documentation-generation/docs-readme.md
@@ -7,54 +7,478 @@ slug: /docs-readme
 
 # Docs Readme Markdown File Auto-Generation
 
-Stencil is able to auto-generate `readme.md` files in markdown. This
-feature will save the readme files as a sibling to the component's source file within the
-same directory. This can help you to maintain consistently formatted
-documentation for your components which live right next to them and render in
-GitHub.
+Stencil is able to auto-generate `readme.md` files for your components.
+This can help you to maintain consistently formatted documentation for your components which lives right next to them and renders in GitHub.
 
-To auto-generate readme files, add the `docs-readme` output target to your
-`stencil.config.ts` like so:
+## Setup
+
+To generate markdown files, it is recommended to add the `docs-readme` output target to your Stencil configuration file:
 
 ```tsx title="stencil.config.ts"
 import { Config } from '@stencil/core';
 
 export const config: Config = {
   outputTargets: [
-    { type: 'docs-readme' }
+    { 
+      type: 'docs-readme'
+    }
   ]
 };
 ```
 
-Another option would be to use the `--docs` CLI flag as a part of the [build task](../config/cli.md#stencil-build), like so:
+## Generating README Files
 
+### Using the Build Command
+
+If your project has a `docs-readme` output target configured in your Stencil configuration file, the Stencil [build command](../config/cli.md#stencil-build) is all that's needed to generate README docs:
 ```bash
-stencil build --docs
+npx stencil build
+```
+If you're running the build command with the `--watch` flag, your project's README files will automatically update without requiring multiple explicit build commands:
+```bash
+npm stencil build --watch
 ```
 
-This will cause the Stencil compiler to perform a one-time generation of README
-files as a part of the build process.
-
-:::note
-If you don't add the `docs-readme` output target to your Stencil configuration, the `--docs` flag must be applied to regenerate documentation.
+:::info
+When running the build command with the `--dev` flag, README files will not be generated.
+This is to prevent unnecessary I/O operations during the development cycle.
 :::
 
-Alternatively, the [docs task](../config/cli.md#stencil-docs) can be used to perform a one time generation of the documentation:
+If you choose not to include a `docs-readme` output target in your Stencil configuration file, use the `--docs` CLI flag as a part of the build command:
 ```bash
-stencil docs
+npx stencil build --docs
 ```
 
-## Adding Custom Markdown to Auto-Generated Files
+This will cause the Stencil compiler to perform a one-time build of your entire project, including README files.
 
-Once you've generated a `readme.md` file you can customize it with your own
-markdown content. Simply add your own markdown above the comment that reads:
-`<!-- Auto Generated Below -->`.
+### Using the Docs Command
 
-## Custom Footer
+As an alternative to the build command, the [docs command](../config/cli.md#stencil-docs) can be used to perform a one time generation of the documentation:
+```bash
+npx stencil docs
+```
+Running `stencil docs` will generate documentation for [all documentation output targets](./01-overview.md), not just `docs-readme`.
+
+## README Sections
+
+Most generated markdown content will automatically be generated without requiring any additional configuration.
+Content is generated based on its Stencil component, rather than requiring you to configure multiple flags.
+Each section below describes the different types of content Stencil recognizes and will automatically generate. 
+
+### Custom Markdown Content
+
+Once you've generated a `readme.md` file, you can add your own markdown content to the file.
+You may add any content above the following comment in a component's `readme.md`:
+```
+Custom content goes here!
+<!-- Auto Generated Below -->
+```
+
+Any custom content placed above this comment will be persisted on subsequent builds of the README file.
+
+### Deprecation Notices
+
+A Stencil component may be marked as deprecated using the [JSDoc `@deprecated` tag](https://jsdoc.app/tags-deprecated).
+By placing `@deprecated` in a component's class-level JSDoc it will cause the generated README to denote the component as deprecated.
+
+For a component with the JSDoc:
+
+```tsx title="A component with @deprecated in its JSDoc"
+/**
+ * @deprecated since v2.0.0
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent { /* omitted */ }
+```
+
+In the code block above, `@deprecated` is added to the JSDoc for `MyComponent`.
+This causes the generated README to contain:
+```
+> **[DEPRECATED]** since v2.0.0
+```
+
+The deprecation notice will always begin with `> **[DEPRECATED]**`, followed by the description provided in the JSDoc.
+In this case, that description is "since v2.0.0".
+
+The deprecation notice will be placed after the [custom content](#custom-markdown-content) in the README.
+
+If a component is not marked as deprecated, this section will be omitted from the generated README.
+
+### Component Overview
+
+A Stencil component that has a JSDoc comment on its class component like so:
+
+```tsx title="A component with an overview in its JSDoc"
+/**
+ * A simple component for formatting names
+ *
+ * This component will do some neat things!
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent { }
+```
+will generate the following section in your component's README:
+
+```
+## Overview
+
+A simple component for formatting names
+
+This component will do some neat things!
+```
+
+The overview will be placed after the [deprecation notice](#deprecation-notices) section of the README.
+
+If a component's JSDoc does not contain an overview, this section will be omitted from the generated README.
+
+### Usage Examples
+
+Usage examples are user-generated markdown files that demonstrate how another developer might use a component.
+These files are separate from a component's README file, and are placed in a `usage/` directory adjacent to a component's implementation.
+
+The content of these files will be added to a `Usage` section of the generated README. 
+This allows you to keep examples right next to the code, making it easy to include them in a documentation site or other downstream consumer(s) of your docs.
+
+The example usage file below describes how to use a component defined in `src/components/my-component/my-component.tsx`:
+
+````md title="src/components/my-component/usage/my-component-usage.md"
+# How to Use `my-component`
+
+This component is used to provide a way to greet a user using their first, middle, and last name.
+This component will properly format the provided name, even when all fields aren't provided:
+
+```html
+<my-component first="Stencil"></my-component>
+<my-component first="Stencil" last="JS"></my-component>
+```
+````
+
+When the README for `my-component` is regenerated, following will be added to the README:
+
+````md
+## Usage
+
+### My-component-usage
+
+# How to Use `my-component`
+
+This component is used to provide a way to greet a user using their first, middle, and last name.
+This component will properly format the provided name, even when all fields aren't provided:
+
+```html
+<my-component first="Stencil"></my-component>
+<my-component first="Stencil" last="JS"></my-component>
+```
+````
+
+:::caution
+Stencil does not check that your usage examples are up-to-date.
+If you make any changes to your component's API, you'll need to update your usage examples manually.
+:::
+
+The usage section will be placed after the [overview section](#component-overview) of the README.
+
+If a component's directory does not contain any usage files, this section will be omitted from the generated README.
+
+### @Prop() Details
+
+Usages of Stencil's [`@Prop()` decorator](../components/properties.md) are described in a table containing the following information for each usage of `@Prop()`:
+- **Property**: The name of the property on the TypeScript class.
+- **Attribute**: The name of the attribute associated with the property name.
+- **Description**: A description of the property, if one was given in a JSDoc comment for the property.
+- **Type**: The TypeScript type of the property.
+- **Default**: The default value of the property.
+
+For the following usages of `@Prop()` in a component:
+```ts
+export class MyComponent {
+  /**
+   * The first name
+   */
+  @Prop() first!: string; // the '!' denotes a required property
+  /**
+   * @deprecated since v2.1.0
+   */
+  @Prop() middle: string;
+  @Prop() lastName = "Smith";
+
+  // ...
+}
+```
+
+The following section will be generated:
+```md
+## Properties
+
+| Property             | Attribute   | Description                                                            | Type     | Default     |
+| -------------------- | ----------- | ---------------------------------------------------------------------- | -------- | ----------- |
+| `first` _(required)_ | `first`     | The first name                                                         | `string` | `undefined` |
+| `lastName`           | `last-name` |                                                                        | `string` | `"Smith"`   |
+| `middle`             | `middle`    | <span style="color:red">**[DEPRECATED]**</span> since v2.1.0<br/><br/> | `string` | `undefined` |
+```
+
+The properties section will be placed after the [usage examples section](#usage-examples) of the README.
+
+If a component does not use the `@Prop()` decorator, this section will be omitted from the generated README.
+
+### @Event() Details
+
+Usages of Stencil's [`@Event()` decorator](../components/events.md) are described in a table containing the following information for each usage of `@Event()`:
+- **Event**: The name of the property on the TypeScript class decorated with `@Event()`.
+- **Description**: A description of the property, if one was given in a JSDoc comment for the property.
+- **Type**: The TypeScript type of the property.
+
+For the following usages of `@Event()` in a component:
+```tsx
+export class MyComponent {
+  /**
+   * Emitted when an event is completed
+   */
+  @Event() todoCompleted: EventEmitter<number>;
+  /**
+   * @deprecated
+   */
+  @Event() todoUndo: EventEmitter<number>;
+
+  // ...
+}
+```
+
+The following section will be generated:
+
+```md
+## Events
+
+| Event           | Description                                                | Type                  |
+| --------------- | ---------------------------------------------------------- | --------------------- |
+| `todoCompleted` | Emitted when an event is completed                         | `CustomEvent<number>` |
+| `todoUndo`      | <span style="color:red">**[DEPRECATED]**</span> <br/><br/> | `CustomEvent<number>` |
+```
+
+The events section will be placed after the [@Prop() section](#prop-details) of the README.
+
+If a component does not use the `@Event()` decorator, this section will be omitted from the generated README.
+
+### @Method() Details
+
+Components that use Stencil's [`@Method()` decorator](../components/methods.md) will have a section describing each usage `@Method`.
+
+Each usage of `@Method` will be documented with its own subsection containing the following:
+- The method signature will be used as the heading for each subsection 
+- A description of the method will immediately follow, if one was provided in a JSDoc
+- A 'Parameters' section that contains a table the describes the name, TypeScript type, and description of each parameter of the method
+- A 'Returns' section that contains the return type of the method, along with a description of the returned value.
+
+For the following usages of `@Method()` in a component:
+
+```ts
+export class MyComponent {
+  /**
+   * Scroll by a specified X/Y distance in the component.
+   *
+   * @param x The amount to scroll by on the horizontal axis.
+   * @param y The amount to scroll by on the vertical axis.
+   * @param duration The amount of time to take scrolling by that amount.
+   * @returns the total distance travelled
+   */
+  @Method()
+  async scrollByPoint(x: number, y: number, duration: number): Promise<number> { /* omitted */ }
+
+  // ...
+}
+```
+
+The following section will be generated:
+
+```md
+## Methods
+
+### `scrollByPoint(x: number, y: number, duration: number) => Promise<number>`
+
+Scroll by a specified X/Y distance in the component.
+
+#### Parameters
+
+| Name       | Type     | Description                                          |
+| ---------- | -------- | ---------------------------------------------------- |
+| `x`        | `number` | The amount to scroll by on the horizontal axis.      |
+| `y`        | `number` | The amount to scroll by on the vertical axis.        |
+| `duration` | `number` | The amount of time to take scrolling by that amount. |
+
+#### Returns
+
+Type: `Promise<number>`
+
+the total distance travelled
+```
+
+The methods section will be placed after the [@Event section](#event-details) of the README.
+
+If a component does not use the `@Method()` decorator, this section will be omitted from the generated README.
+
+### @slot Details
+
+A component that uses [slots](../components/templating-and-jsx.md#slots) may describe its slots in the component's JSDoc using the Stencil-specific `@slot` JSDoc tag.
+The `@slot` tag follows the following format:
+```
+@slot [slot-name] - [description]
+```
+where `slot-name` corresponds to the name of the slot in the markup, and `description` describes the usage of the slot.
+
+For this JSDoc tag to be read properly, the following is required:
+1. Either `slot-name` or `description` must be included. Both may be included though.
+2. The '-' separating the two is required.
+
+For the default slot, omit the `slot-name`.
+
+This information is presented in a table containing the following columns:
+- **Slot**: The name of the slot. The default slot will have no name/be empty.
+- **Description**: A description of the slot, if one was given.
+
+For the following usages of `@slot()` in a component:
+```tsx
+/**
+ * @slot - Content is placed between the named slots if provided without a slot.
+ * @slot primary - Content is placed to the left of the main slotted-in text.
+ * @slot secondary - Content is placed to the right of the main slotted-in text.
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent {
+  // ...
+  
+  render() {
+    return (
+      <section>
+        <slot name="primary"></slot>
+        <div class="content">
+          <slot></slot>
+        </div>
+        <slot name="secondary"></slot>
+      </section>
+    );
+  }
+}
+```
+
+The following table is generated:
+
+```md
+## Slots
+
+| Slot          | Description                                                           |
+| ------------- | --------------------------------------------------------------------- |
+|               | Content is placed between the named slots if provided without a slot. |
+| `"primary"`   | Content is placed to the left of the main slotted-in text.            |
+| `"secondary"` | Content is placed to the right of the main slotted-in text.           |
+
+```
+
+The slots section will be placed after the [@Method section](#method-details) of the README.
+
+If a component's top-level JSDoc does not use `@slot` tags, this section will be omitted from the generated README.
+
+### Shadow Parts
+
+A component that uses [CSS shadow parts](../components/styling.md#css-parts) may describe the component's shadow parts in the component's JSDoc using the Stencil-specific `@part` JSDoc tag.
+The `@part` tag follows the following format:
+```
+@part [part-name] - [description]
+```
+where `part-name` corresponds to the name of the shadow part in the markup, and `description` describes its usage.
+
+For this tag to be read properly, the following is required:
+1. Either `part-name` or `description` must be included, although using both is strongly encouraged.
+2. The '-' separating the two is required.
+
+This information is presented in a table containing the following columns:
+- **Part**: The name of the shadow part.
+- **Description**: A description of the shadow part, if one was given.
+
+For the following usages of `@part()` in a component:
+
+```tsx
+/**
+ * @part label - The label text describing the component.
+ */
+@Component({
+  tag: 'my-component',
+  styleUrl: 'my-component.css',
+  shadow: true,
+})
+export class MyComponent {
+  // ...
+
+  render() {
+    return (
+      <div part="label">
+        <slot></slot>
+      </div>
+    );
+  }
+}
+```
+
+The following table will be generated:
+```md
+## Shadow Parts
+
+| Part                                                        | Description                              |
+| ----------------------------------------------------------- | ---------------------------------------- |
+| `"label"`                                                   | The label text describing the component. |
+```
+
+The shadow parts section will be placed after the [@Slot Details](#slot-details) of the README.
+
+If a component's top-level JSDoc does not use `@part` tags, this section will be omitted from the generated README.
+
+### Styling Details
+
+Styling in CSS files can be documented in Stencil components as well.
+One use case for documenting styles using Stencil is to note a CSS variable that a component's styling depends on.
+Using the `@prop` JSDoc in a component's CSS file, Stencil can generate this documentation as well.
+
+This information is presented in a table containing the following columns:
+- **Name**: The name of the custom property.
+- **Description**: A description of the custom property, if one was given.
+
+For the following usages of `@prop` in a component's css file:
+
+```css
+:host {
+  /**
+   * @prop --border-radius: Border radius of the avatar and inner image
+   */
+  border-radius: var(--border-radius);
+}
+```
+The following table will be generated:
+
+```md
+## CSS Custom Properties
+
+| Name              | Description                                 |
+| ----------------- | ------------------------------------------- |
+| `--border-radius` | Border radius of the avatar and inner image |
+```
+
+The styling details section will be placed after the [Shadow Parts Details](#shadow-parts) of the README.
+
+If a component's styles does not include styling details, this section will be omitted from the generated README.
+
+### Custom Footers
 
 Removing or customizing the footer can be done by adding a `footer` property to
 the output target. This string is added to the generated Markdown files without
-modification, so you can use Markdown syntax in it for rich formatting.
+modification, so you can use Markdown syntax in it for rich formatting:
 
 ```tsx title="stencil.config.ts"
 import { Config } from '@stencil/core';
@@ -69,10 +493,16 @@ export const config: Config = {
 };
 ```
 
-## Generating to a Directory
+The following footer will be placed at the bottom of your component's README file:
+```
+*Built with love!*
+```
 
-By default, a readme file will be generated in the same directory as the
-component corresponds to. This behavior can be changed by setting the `dir`
+## Configuration
+### Specifying the Output Directory
+
+By default, a README file will be generated in the same directory as the
+component it corresponds to. This behavior can be changed by setting the `dir`
 property on the output target configuration. Specifying a directory will create
 the structure `{dir}/{component}/readme.md`.
 
@@ -89,10 +519,9 @@ export const config: Config = {
 };
 ```
 
-## Strict Mode
+### Strict Mode
 
-Adding `strict: true` to the output target configuration will cause Stencil to
-output a warning whenever the project is built with missing documentation.
+Adding `strict: true` to the output target configuration will cause Stencil to output a warning whenever the project is built with missing documentation.
 
 ```tsx title="stencil.config.ts"
 import { Config } from '@stencil/core';
@@ -106,3 +535,9 @@ export const config: Config = {
   ]
 };
 ```
+
+When strict mode is enabled, the following items are checked:
+1. `@Prop()` usages must be documented, unless the property is marked as `@deprecated`
+2. `@Method()` usages must be documented, unless the method is marked as `@deprecated`
+3. `@Event()` usages must be documented, unless the event is marked as `@deprecated`
+4. CSS Part usages must be documented

--- a/versioned_docs/version-v4.2/config/cli.md
+++ b/versioned_docs/version-v4.2/config/cli.md
@@ -20,7 +20,7 @@ Builds a Stencil project. The flags below are the available options for the `bui
 | `--config` | Path to the `stencil.config.ts` file. This flag is not needed in most cases since Stencil will find the config. Additionally, a Stencil config is not required. | `-c` |
 | `--debug` | Adds additional runtime code to help debug, and sets the log level for more verbose output. | |
 | `--dev` | Runs a development build. | |
-| `--docs-readme` | Generate `readme.md` docs based on the component types, properties, methods, events, JSDocs, CSS Custom Properties, etc. | |
+| `--docs` | Generate all docs based on the component types, properties, methods, events, JSDocs, CSS Custom Properties, etc. | |
 | `--es5` | Creates an ES5 compatible build. By default ES5 builds are not created during development in order to improve build times. However, ES5 builds are always created during production builds. Use this flag to create ES5 builds during development. | |
 | `--log` | Write logs for the `stencil build` into `stencil-build.log`. The log file is written in the same location as the config. | |
 | `--prerender` | Prerender the application using the `www` output target after the build has completed. | |

--- a/versioned_docs/version-v4.2/documentation-generation/docs-readme.md
+++ b/versioned_docs/version-v4.2/documentation-generation/docs-readme.md
@@ -7,54 +7,12 @@ slug: /docs-readme
 
 # Docs Readme Markdown File Auto-Generation
 
-Stencil is able to auto-generate `readme.md` files in markdown. This
-feature will save the readme files as a sibling to the component's source file within the
-same directory. This can help you to maintain consistently formatted
-documentation for your components which live right next to them and render in
-GitHub.
+Stencil is able to auto-generate `readme.md` files for your components.
+This can help you to maintain consistently formatted documentation for your components which lives right next to them and renders in GitHub.
 
-To auto-generate readme files, add the `docs-readme` output target to your
-`stencil.config.ts` like so:
+## Setup
 
-```tsx title="stencil.config.ts"
-import { Config } from '@stencil/core';
-
-export const config: Config = {
-  outputTargets: [
-    { type: 'docs-readme' }
-  ]
-};
-```
-
-Another option would be to use the `--docs` CLI flag as a part of the [build task](../config/cli.md#stencil-build), like so:
-
-```bash
-stencil build --docs
-```
-
-This will cause the Stencil compiler to perform a one-time generation of README
-files as a part of the build process.
-
-:::note
-If you don't add the `docs-readme` output target to your Stencil configuration, the `--docs` flag must be applied to regenerate documentation.
-:::
-
-Alternatively, the [docs task](../config/cli.md#stencil-docs) can be used to perform a one time generation of the documentation:
-```bash
-stencil docs
-```
-
-## Adding Custom Markdown to Auto-Generated Files
-
-Once you've generated a `readme.md` file you can customize it with your own
-markdown content. Simply add your own markdown above the comment that reads:
-`<!-- Auto Generated Below -->`.
-
-## Custom Footer
-
-Removing or customizing the footer can be done by adding a `footer` property to
-the output target. This string is added to the generated Markdown files without
-modification, so you can use Markdown syntax in it for rich formatting.
+To generate markdown files, it is recommended to add the `docs-readme` output target to your Stencil configuration file:
 
 ```tsx title="stencil.config.ts"
 import { Config } from '@stencil/core';
@@ -62,6 +20,472 @@ import { Config } from '@stencil/core';
 export const config: Config = {
   outputTargets: [
     { 
+      type: 'docs-readme'
+    }
+  ]
+};
+```
+
+## Generating README Files
+
+### Using the Build Command
+
+If your project has a `docs-readme` output target configured in your Stencil configuration file, the Stencil [build command](../config/cli.md#stencil-build) is all that's needed to generate README docs:
+```bash
+npx stencil build
+```
+If you're running the build command with the `--watch` flag, your project's README files will automatically update without requiring multiple explicit build commands:
+```bash
+npm stencil build --watch
+```
+
+:::info
+When running the build command with the `--dev` flag, README files will not be generated.
+This is to prevent unnecessary I/O operations during the development cycle.
+:::
+
+If you choose not to include a `docs-readme` output target in your Stencil configuration file, use the `--docs` CLI flag as a part of the build command:
+```bash
+npx stencil build --docs
+```
+
+This will cause the Stencil compiler to perform a one-time build of your entire project, including README files.
+
+### Using the Docs Command
+
+As an alternative to the build command, the [docs command](../config/cli.md#stencil-docs) can be used to perform a one time generation of the documentation:
+```bash
+npx stencil docs
+```
+Running `stencil docs` will generate documentation for [all documentation output targets](./01-overview.md), not just `docs-readme`.
+
+## README Sections
+
+Most generated markdown content will automatically be generated without requiring any additional configuration.
+Content is generated based on its Stencil component, rather than requiring you to configure multiple flags.
+Each section below describes the different types of content Stencil recognizes and will automatically generate. 
+
+### Custom Markdown Content
+
+Once you've generated a `readme.md` file, you can add your own markdown content to the file.
+You may add any content above the following comment in a component's `readme.md`:
+```
+Custom content goes here!
+<!-- Auto Generated Below -->
+```
+
+Any custom content placed above this comment will be persisted on subsequent builds of the README file.
+
+### Deprecation Notices
+
+A Stencil component may be marked as deprecated using the [JSDoc `@deprecated` tag](https://jsdoc.app/tags-deprecated).
+By placing `@deprecated` in a component's class-level JSDoc it will cause the generated README to denote the component as deprecated.
+
+For a component with the JSDoc:
+
+```tsx title="A component with @deprecated in its JSDoc"
+/**
+ * @deprecated since v2.0.0
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent { /* omitted */ }
+```
+
+In the code block above, `@deprecated` is added to the JSDoc for `MyComponent`.
+This causes the generated README to contain:
+```
+> **[DEPRECATED]** since v2.0.0
+```
+
+The deprecation notice will always begin with `> **[DEPRECATED]**`, followed by the description provided in the JSDoc.
+In this case, that description is "since v2.0.0".
+
+The deprecation notice will be placed after the [custom content](#custom-markdown-content) in the README.
+
+If a component is not marked as deprecated, this section will be omitted from the generated README.
+
+### Component Overview
+
+A Stencil component that has a JSDoc comment on its class component like so:
+
+```tsx title="A component with an overview in its JSDoc"
+/**
+ * A simple component for formatting names
+ *
+ * This component will do some neat things!
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent { }
+```
+will generate the following section in your component's README:
+
+```
+## Overview
+
+A simple component for formatting names
+
+This component will do some neat things!
+```
+
+The overview will be placed after the [deprecation notice](#deprecation-notices) section of the README.
+
+If a component's JSDoc does not contain an overview, this section will be omitted from the generated README.
+
+### Usage Examples
+
+Usage examples are user-generated markdown files that demonstrate how another developer might use a component.
+These files are separate from a component's README file, and are placed in a `usage/` directory adjacent to a component's implementation.
+
+The content of these files will be added to a `Usage` section of the generated README. 
+This allows you to keep examples right next to the code, making it easy to include them in a documentation site or other downstream consumer(s) of your docs.
+
+The example usage file below describes how to use a component defined in `src/components/my-component/my-component.tsx`:
+
+````md title="src/components/my-component/usage/my-component-usage.md"
+# How to Use `my-component`
+
+This component is used to provide a way to greet a user using their first, middle, and last name.
+This component will properly format the provided name, even when all fields aren't provided:
+
+```html
+<my-component first="Stencil"></my-component>
+<my-component first="Stencil" last="JS"></my-component>
+```
+````
+
+When the README for `my-component` is regenerated, following will be added to the README:
+
+````md
+## Usage
+
+### My-component-usage
+
+# How to Use `my-component`
+
+This component is used to provide a way to greet a user using their first, middle, and last name.
+This component will properly format the provided name, even when all fields aren't provided:
+
+```html
+<my-component first="Stencil"></my-component>
+<my-component first="Stencil" last="JS"></my-component>
+```
+````
+
+:::caution
+Stencil does not check that your usage examples are up-to-date.
+If you make any changes to your component's API, you'll need to update your usage examples manually.
+:::
+
+The usage section will be placed after the [overview section](#component-overview) of the README.
+
+If a component's directory does not contain any usage files, this section will be omitted from the generated README.
+
+### @Prop() Details
+
+Usages of Stencil's [`@Prop()` decorator](../components/properties.md) are described in a table containing the following information for each usage of `@Prop()`:
+- **Property**: The name of the property on the TypeScript class.
+- **Attribute**: The name of the attribute associated with the property name.
+- **Description**: A description of the property, if one was given in a JSDoc comment for the property.
+- **Type**: The TypeScript type of the property.
+- **Default**: The default value of the property.
+
+For the following usages of `@Prop()` in a component:
+```ts
+export class MyComponent {
+  /**
+   * The first name
+   */
+  @Prop() first!: string; // the '!' denotes a required property
+  /**
+   * @deprecated since v2.1.0
+   */
+  @Prop() middle: string;
+  @Prop() lastName = "Smith";
+
+  // ...
+}
+```
+
+The following section will be generated:
+```md
+## Properties
+
+| Property             | Attribute   | Description                                                            | Type     | Default     |
+| -------------------- | ----------- | ---------------------------------------------------------------------- | -------- | ----------- |
+| `first` _(required)_ | `first`     | The first name                                                         | `string` | `undefined` |
+| `lastName`           | `last-name` |                                                                        | `string` | `"Smith"`   |
+| `middle`             | `middle`    | <span style="color:red">**[DEPRECATED]**</span> since v2.1.0<br/><br/> | `string` | `undefined` |
+```
+
+The properties section will be placed after the [usage examples section](#usage-examples) of the README.
+
+If a component does not use the `@Prop()` decorator, this section will be omitted from the generated README.
+
+### @Event() Details
+
+Usages of Stencil's [`@Event()` decorator](../components/events.md) are described in a table containing the following information for each usage of `@Event()`:
+- **Event**: The name of the property on the TypeScript class decorated with `@Event()`.
+- **Description**: A description of the property, if one was given in a JSDoc comment for the property.
+- **Type**: The TypeScript type of the property.
+
+For the following usages of `@Event()` in a component:
+```tsx
+export class MyComponent {
+  /**
+   * Emitted when an event is completed
+   */
+  @Event() todoCompleted: EventEmitter<number>;
+  /**
+   * @deprecated
+   */
+  @Event() todoUndo: EventEmitter<number>;
+
+  // ...
+}
+```
+
+The following section will be generated:
+
+```md
+## Events
+
+| Event           | Description                                                | Type                  |
+| --------------- | ---------------------------------------------------------- | --------------------- |
+| `todoCompleted` | Emitted when an event is completed                         | `CustomEvent<number>` |
+| `todoUndo`      | <span style="color:red">**[DEPRECATED]**</span> <br/><br/> | `CustomEvent<number>` |
+```
+
+The events section will be placed after the [@Prop() section](#prop-details) of the README.
+
+If a component does not use the `@Event()` decorator, this section will be omitted from the generated README.
+
+### @Method() Details
+
+Components that use Stencil's [`@Method()` decorator](../components/methods.md) will have a section describing each usage `@Method`.
+
+Each usage of `@Method` will be documented with its own subsection containing the following:
+- The method signature will be used as the heading for each subsection 
+- A description of the method will immediately follow, if one was provided in a JSDoc
+- A 'Parameters' section that contains a table the describes the name, TypeScript type, and description of each parameter of the method
+- A 'Returns' section that contains the return type of the method, along with a description of the returned value.
+
+For the following usages of `@Method()` in a component:
+
+```ts
+export class MyComponent {
+  /**
+   * Scroll by a specified X/Y distance in the component.
+   *
+   * @param x The amount to scroll by on the horizontal axis.
+   * @param y The amount to scroll by on the vertical axis.
+   * @param duration The amount of time to take scrolling by that amount.
+   * @returns the total distance travelled
+   */
+  @Method()
+  async scrollByPoint(x: number, y: number, duration: number): Promise<number> { /* omitted */ }
+
+  // ...
+}
+```
+
+The following section will be generated:
+
+```md
+## Methods
+
+### `scrollByPoint(x: number, y: number, duration: number) => Promise<number>`
+
+Scroll by a specified X/Y distance in the component.
+
+#### Parameters
+
+| Name       | Type     | Description                                          |
+| ---------- | -------- | ---------------------------------------------------- |
+| `x`        | `number` | The amount to scroll by on the horizontal axis.      |
+| `y`        | `number` | The amount to scroll by on the vertical axis.        |
+| `duration` | `number` | The amount of time to take scrolling by that amount. |
+
+#### Returns
+
+Type: `Promise<number>`
+
+the total distance travelled
+```
+
+The methods section will be placed after the [@Event section](#event-details) of the README.
+
+If a component does not use the `@Method()` decorator, this section will be omitted from the generated README.
+
+### @slot Details
+
+A component that uses [slots](../components/templating-and-jsx.md#slots) may describe its slots in the component's JSDoc using the Stencil-specific `@slot` JSDoc tag.
+The `@slot` tag follows the following format:
+```
+@slot [slot-name] - [description]
+```
+where `slot-name` corresponds to the name of the slot in the markup, and `description` describes the usage of the slot.
+
+For this JSDoc tag to be read properly, the following is required:
+1. Either `slot-name` or `description` must be included. Both may be included though.
+2. The '-' separating the two is required.
+
+For the default slot, omit the `slot-name`.
+
+This information is presented in a table containing the following columns:
+- **Slot**: The name of the slot. The default slot will have no name/be empty.
+- **Description**: A description of the slot, if one was given.
+
+For the following usages of `@slot()` in a component:
+```tsx
+/**
+ * @slot - Content is placed between the named slots if provided without a slot.
+ * @slot primary - Content is placed to the left of the main slotted-in text.
+ * @slot secondary - Content is placed to the right of the main slotted-in text.
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent {
+  // ...
+  
+  render() {
+    return (
+      <section>
+        <slot name="primary"></slot>
+        <div class="content">
+          <slot></slot>
+        </div>
+        <slot name="secondary"></slot>
+      </section>
+    );
+  }
+}
+```
+
+The following table is generated:
+
+```md
+## Slots
+
+| Slot          | Description                                                           |
+| ------------- | --------------------------------------------------------------------- |
+|               | Content is placed between the named slots if provided without a slot. |
+| `"primary"`   | Content is placed to the left of the main slotted-in text.            |
+| `"secondary"` | Content is placed to the right of the main slotted-in text.           |
+
+```
+
+The slots section will be placed after the [@Method section](#method-details) of the README.
+
+If a component's top-level JSDoc does not use `@slot` tags, this section will be omitted from the generated README.
+
+### Shadow Parts
+
+A component that uses [CSS shadow parts](../components/styling.md#css-parts) may describe the component's shadow parts in the component's JSDoc using the Stencil-specific `@part` JSDoc tag.
+The `@part` tag follows the following format:
+```
+@part [part-name] - [description]
+```
+where `part-name` corresponds to the name of the shadow part in the markup, and `description` describes its usage.
+
+For this tag to be read properly, the following is required:
+1. Either `part-name` or `description` must be included, although using both is strongly encouraged.
+2. The '-' separating the two is required.
+
+This information is presented in a table containing the following columns:
+- **Part**: The name of the shadow part.
+- **Description**: A description of the shadow part, if one was given.
+
+For the following usages of `@part()` in a component:
+
+```tsx
+/**
+ * @part label - The label text describing the component.
+ */
+@Component({
+  tag: 'my-component',
+  styleUrl: 'my-component.css',
+  shadow: true,
+})
+export class MyComponent {
+  // ...
+
+  render() {
+    return (
+      <div part="label">
+        <slot></slot>
+      </div>
+    );
+  }
+}
+```
+
+The following table will be generated:
+```md
+## Shadow Parts
+
+| Part                                                        | Description                              |
+| ----------------------------------------------------------- | ---------------------------------------- |
+| `"label"`                                                   | The label text describing the component. |
+```
+
+The shadow parts section will be placed after the [@Slot Details](#slot-details) of the README.
+
+If a component's top-level JSDoc does not use `@part` tags, this section will be omitted from the generated README.
+
+### Styling Details
+
+Styling in CSS files can be documented in Stencil components as well.
+One use case for documenting styles using Stencil is to note a CSS variable that a component's styling depends on.
+Using the `@prop` JSDoc in a component's CSS file, Stencil can generate this documentation as well.
+
+This information is presented in a table containing the following columns:
+- **Name**: The name of the custom property.
+- **Description**: A description of the custom property, if one was given.
+
+For the following usages of `@prop` in a component's css file:
+
+```css
+:host {
+  /**
+   * @prop --border-radius: Border radius of the avatar and inner image
+   */
+  border-radius: var(--border-radius);
+}
+```
+The following table will be generated:
+
+```md
+## CSS Custom Properties
+
+| Name              | Description                                 |
+| ----------------- | ------------------------------------------- |
+| `--border-radius` | Border radius of the avatar and inner image |
+```
+
+The styling details section will be placed after the [Shadow Parts Details](#shadow-parts) of the README.
+
+If a component's styles does not include styling details, this section will be omitted from the generated README.
+
+### Custom Footers
+
+Removing or customizing the footer can be done by adding a `footer` property to
+the output target. This string is added to the generated Markdown files without
+modification, so you can use Markdown syntax in it for rich formatting:
+
+```tsx title="stencil.config.ts"
+import { Config } from '@stencil/core';
+
+export const config: Config = {
+  outputTargets: [
+    {
       type: 'docs-readme',
       footer: '*Built with love!*',
     }
@@ -69,10 +493,16 @@ export const config: Config = {
 };
 ```
 
-## Generating to a Directory
+The following footer will be placed at the bottom of your component's README file:
+```
+*Built with love!*
+```
 
-By default, a readme file will be generated in the same directory as the
-component corresponds to. This behavior can be changed by setting the `dir`
+## Configuration
+### Specifying the Output Directory
+
+By default, a README file will be generated in the same directory as the
+component it corresponds to. This behavior can be changed by setting the `dir`
 property on the output target configuration. Specifying a directory will create
 the structure `{dir}/{component}/readme.md`.
 
@@ -89,10 +519,9 @@ export const config: Config = {
 };
 ```
 
-## Strict Mode
+### Strict Mode
 
-Adding `strict: true` to the output target configuration will cause Stencil to
-output a warning whenever the project is built with missing documentation.
+Adding `strict: true` to the output target configuration will cause Stencil to output a warning whenever the project is built with missing documentation.
 
 ```tsx title="stencil.config.ts"
 import { Config } from '@stencil/core';
@@ -106,3 +535,9 @@ export const config: Config = {
   ]
 };
 ```
+
+When strict mode is enabled, the following items are checked:
+1. `@Prop()` usages must be documented, unless the property is marked as `@deprecated`
+2. `@Method()` usages must be documented, unless the method is marked as `@deprecated`
+3. `@Event()` usages must be documented, unless the event is marked as `@deprecated`
+4. CSS Part usages must be documented

--- a/versioned_docs/version-v4.3/config/cli.md
+++ b/versioned_docs/version-v4.3/config/cli.md
@@ -20,7 +20,7 @@ Builds a Stencil project. The flags below are the available options for the `bui
 | `--config` | Path to the `stencil.config.ts` file. This flag is not needed in most cases since Stencil will find the config. Additionally, a Stencil config is not required. | `-c` |
 | `--debug` | Adds additional runtime code to help debug, and sets the log level for more verbose output. | |
 | `--dev` | Runs a development build. | |
-| `--docs-readme` | Generate `readme.md` docs based on the component types, properties, methods, events, JSDocs, CSS Custom Properties, etc. | |
+| `--docs` | Generate all docs based on the component types, properties, methods, events, JSDocs, CSS Custom Properties, etc. | |
 | `--es5` | Creates an ES5 compatible build. By default ES5 builds are not created during development in order to improve build times. However, ES5 builds are always created during production builds. Use this flag to create ES5 builds during development. | |
 | `--log` | Write logs for the `stencil build` into `stencil-build.log`. The log file is written in the same location as the config. | |
 | `--prerender` | Prerender the application using the `www` output target after the build has completed. | |

--- a/versioned_docs/version-v4.3/documentation-generation/docs-readme.md
+++ b/versioned_docs/version-v4.3/documentation-generation/docs-readme.md
@@ -7,54 +7,12 @@ slug: /docs-readme
 
 # Docs Readme Markdown File Auto-Generation
 
-Stencil is able to auto-generate `readme.md` files in markdown. This
-feature will save the readme files as a sibling to the component's source file within the
-same directory. This can help you to maintain consistently formatted
-documentation for your components which live right next to them and render in
-GitHub.
+Stencil is able to auto-generate `readme.md` files for your components.
+This can help you to maintain consistently formatted documentation for your components which lives right next to them and renders in GitHub.
 
-To auto-generate readme files, add the `docs-readme` output target to your
-`stencil.config.ts` like so:
+## Setup
 
-```tsx title="stencil.config.ts"
-import { Config } from '@stencil/core';
-
-export const config: Config = {
-  outputTargets: [
-    { type: 'docs-readme' }
-  ]
-};
-```
-
-Another option would be to use the `--docs` CLI flag as a part of the [build task](../config/cli.md#stencil-build), like so:
-
-```bash
-stencil build --docs
-```
-
-This will cause the Stencil compiler to perform a one-time generation of README
-files as a part of the build process.
-
-:::note
-If you don't add the `docs-readme` output target to your Stencil configuration, the `--docs` flag must be applied to regenerate documentation.
-:::
-
-Alternatively, the [docs task](../config/cli.md#stencil-docs) can be used to perform a one time generation of the documentation:
-```bash
-stencil docs
-```
-
-## Adding Custom Markdown to Auto-Generated Files
-
-Once you've generated a `readme.md` file you can customize it with your own
-markdown content. Simply add your own markdown above the comment that reads:
-`<!-- Auto Generated Below -->`.
-
-## Custom Footer
-
-Removing or customizing the footer can be done by adding a `footer` property to
-the output target. This string is added to the generated Markdown files without
-modification, so you can use Markdown syntax in it for rich formatting.
+To generate markdown files, it is recommended to add the `docs-readme` output target to your Stencil configuration file:
 
 ```tsx title="stencil.config.ts"
 import { Config } from '@stencil/core';
@@ -62,6 +20,472 @@ import { Config } from '@stencil/core';
 export const config: Config = {
   outputTargets: [
     { 
+      type: 'docs-readme'
+    }
+  ]
+};
+```
+
+## Generating README Files
+
+### Using the Build Command
+
+If your project has a `docs-readme` output target configured in your Stencil configuration file, the Stencil [build command](../config/cli.md#stencil-build) is all that's needed to generate README docs:
+```bash
+npx stencil build
+```
+If you're running the build command with the `--watch` flag, your project's README files will automatically update without requiring multiple explicit build commands:
+```bash
+npm stencil build --watch
+```
+
+:::info
+When running the build command with the `--dev` flag, README files will not be generated.
+This is to prevent unnecessary I/O operations during the development cycle.
+:::
+
+If you choose not to include a `docs-readme` output target in your Stencil configuration file, use the `--docs` CLI flag as a part of the build command:
+```bash
+npx stencil build --docs
+```
+
+This will cause the Stencil compiler to perform a one-time build of your entire project, including README files.
+
+### Using the Docs Command
+
+As an alternative to the build command, the [docs command](../config/cli.md#stencil-docs) can be used to perform a one time generation of the documentation:
+```bash
+npx stencil docs
+```
+Running `stencil docs` will generate documentation for [all documentation output targets](./01-overview.md), not just `docs-readme`.
+
+## README Sections
+
+Most generated markdown content will automatically be generated without requiring any additional configuration.
+Content is generated based on its Stencil component, rather than requiring you to configure multiple flags.
+Each section below describes the different types of content Stencil recognizes and will automatically generate. 
+
+### Custom Markdown Content
+
+Once you've generated a `readme.md` file, you can add your own markdown content to the file.
+You may add any content above the following comment in a component's `readme.md`:
+```
+Custom content goes here!
+<!-- Auto Generated Below -->
+```
+
+Any custom content placed above this comment will be persisted on subsequent builds of the README file.
+
+### Deprecation Notices
+
+A Stencil component may be marked as deprecated using the [JSDoc `@deprecated` tag](https://jsdoc.app/tags-deprecated).
+By placing `@deprecated` in a component's class-level JSDoc it will cause the generated README to denote the component as deprecated.
+
+For a component with the JSDoc:
+
+```tsx title="A component with @deprecated in its JSDoc"
+/**
+ * @deprecated since v2.0.0
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent { /* omitted */ }
+```
+
+In the code block above, `@deprecated` is added to the JSDoc for `MyComponent`.
+This causes the generated README to contain:
+```
+> **[DEPRECATED]** since v2.0.0
+```
+
+The deprecation notice will always begin with `> **[DEPRECATED]**`, followed by the description provided in the JSDoc.
+In this case, that description is "since v2.0.0".
+
+The deprecation notice will be placed after the [custom content](#custom-markdown-content) in the README.
+
+If a component is not marked as deprecated, this section will be omitted from the generated README.
+
+### Component Overview
+
+A Stencil component that has a JSDoc comment on its class component like so:
+
+```tsx title="A component with an overview in its JSDoc"
+/**
+ * A simple component for formatting names
+ *
+ * This component will do some neat things!
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent { }
+```
+will generate the following section in your component's README:
+
+```
+## Overview
+
+A simple component for formatting names
+
+This component will do some neat things!
+```
+
+The overview will be placed after the [deprecation notice](#deprecation-notices) section of the README.
+
+If a component's JSDoc does not contain an overview, this section will be omitted from the generated README.
+
+### Usage Examples
+
+Usage examples are user-generated markdown files that demonstrate how another developer might use a component.
+These files are separate from a component's README file, and are placed in a `usage/` directory adjacent to a component's implementation.
+
+The content of these files will be added to a `Usage` section of the generated README. 
+This allows you to keep examples right next to the code, making it easy to include them in a documentation site or other downstream consumer(s) of your docs.
+
+The example usage file below describes how to use a component defined in `src/components/my-component/my-component.tsx`:
+
+````md title="src/components/my-component/usage/my-component-usage.md"
+# How to Use `my-component`
+
+This component is used to provide a way to greet a user using their first, middle, and last name.
+This component will properly format the provided name, even when all fields aren't provided:
+
+```html
+<my-component first="Stencil"></my-component>
+<my-component first="Stencil" last="JS"></my-component>
+```
+````
+
+When the README for `my-component` is regenerated, following will be added to the README:
+
+````md
+## Usage
+
+### My-component-usage
+
+# How to Use `my-component`
+
+This component is used to provide a way to greet a user using their first, middle, and last name.
+This component will properly format the provided name, even when all fields aren't provided:
+
+```html
+<my-component first="Stencil"></my-component>
+<my-component first="Stencil" last="JS"></my-component>
+```
+````
+
+:::caution
+Stencil does not check that your usage examples are up-to-date.
+If you make any changes to your component's API, you'll need to update your usage examples manually.
+:::
+
+The usage section will be placed after the [overview section](#component-overview) of the README.
+
+If a component's directory does not contain any usage files, this section will be omitted from the generated README.
+
+### @Prop() Details
+
+Usages of Stencil's [`@Prop()` decorator](../components/properties.md) are described in a table containing the following information for each usage of `@Prop()`:
+- **Property**: The name of the property on the TypeScript class.
+- **Attribute**: The name of the attribute associated with the property name.
+- **Description**: A description of the property, if one was given in a JSDoc comment for the property.
+- **Type**: The TypeScript type of the property.
+- **Default**: The default value of the property.
+
+For the following usages of `@Prop()` in a component:
+```ts
+export class MyComponent {
+  /**
+   * The first name
+   */
+  @Prop() first!: string; // the '!' denotes a required property
+  /**
+   * @deprecated since v2.1.0
+   */
+  @Prop() middle: string;
+  @Prop() lastName = "Smith";
+
+  // ...
+}
+```
+
+The following section will be generated:
+```md
+## Properties
+
+| Property             | Attribute   | Description                                                            | Type     | Default     |
+| -------------------- | ----------- | ---------------------------------------------------------------------- | -------- | ----------- |
+| `first` _(required)_ | `first`     | The first name                                                         | `string` | `undefined` |
+| `lastName`           | `last-name` |                                                                        | `string` | `"Smith"`   |
+| `middle`             | `middle`    | <span style="color:red">**[DEPRECATED]**</span> since v2.1.0<br/><br/> | `string` | `undefined` |
+```
+
+The properties section will be placed after the [usage examples section](#usage-examples) of the README.
+
+If a component does not use the `@Prop()` decorator, this section will be omitted from the generated README.
+
+### @Event() Details
+
+Usages of Stencil's [`@Event()` decorator](../components/events.md) are described in a table containing the following information for each usage of `@Event()`:
+- **Event**: The name of the property on the TypeScript class decorated with `@Event()`.
+- **Description**: A description of the property, if one was given in a JSDoc comment for the property.
+- **Type**: The TypeScript type of the property.
+
+For the following usages of `@Event()` in a component:
+```tsx
+export class MyComponent {
+  /**
+   * Emitted when an event is completed
+   */
+  @Event() todoCompleted: EventEmitter<number>;
+  /**
+   * @deprecated
+   */
+  @Event() todoUndo: EventEmitter<number>;
+
+  // ...
+}
+```
+
+The following section will be generated:
+
+```md
+## Events
+
+| Event           | Description                                                | Type                  |
+| --------------- | ---------------------------------------------------------- | --------------------- |
+| `todoCompleted` | Emitted when an event is completed                         | `CustomEvent<number>` |
+| `todoUndo`      | <span style="color:red">**[DEPRECATED]**</span> <br/><br/> | `CustomEvent<number>` |
+```
+
+The events section will be placed after the [@Prop() section](#prop-details) of the README.
+
+If a component does not use the `@Event()` decorator, this section will be omitted from the generated README.
+
+### @Method() Details
+
+Components that use Stencil's [`@Method()` decorator](../components/methods.md) will have a section describing each usage `@Method`.
+
+Each usage of `@Method` will be documented with its own subsection containing the following:
+- The method signature will be used as the heading for each subsection 
+- A description of the method will immediately follow, if one was provided in a JSDoc
+- A 'Parameters' section that contains a table the describes the name, TypeScript type, and description of each parameter of the method
+- A 'Returns' section that contains the return type of the method, along with a description of the returned value.
+
+For the following usages of `@Method()` in a component:
+
+```ts
+export class MyComponent {
+  /**
+   * Scroll by a specified X/Y distance in the component.
+   *
+   * @param x The amount to scroll by on the horizontal axis.
+   * @param y The amount to scroll by on the vertical axis.
+   * @param duration The amount of time to take scrolling by that amount.
+   * @returns the total distance travelled
+   */
+  @Method()
+  async scrollByPoint(x: number, y: number, duration: number): Promise<number> { /* omitted */ }
+
+  // ...
+}
+```
+
+The following section will be generated:
+
+```md
+## Methods
+
+### `scrollByPoint(x: number, y: number, duration: number) => Promise<number>`
+
+Scroll by a specified X/Y distance in the component.
+
+#### Parameters
+
+| Name       | Type     | Description                                          |
+| ---------- | -------- | ---------------------------------------------------- |
+| `x`        | `number` | The amount to scroll by on the horizontal axis.      |
+| `y`        | `number` | The amount to scroll by on the vertical axis.        |
+| `duration` | `number` | The amount of time to take scrolling by that amount. |
+
+#### Returns
+
+Type: `Promise<number>`
+
+the total distance travelled
+```
+
+The methods section will be placed after the [@Event section](#event-details) of the README.
+
+If a component does not use the `@Method()` decorator, this section will be omitted from the generated README.
+
+### @slot Details
+
+A component that uses [slots](../components/templating-and-jsx.md#slots) may describe its slots in the component's JSDoc using the Stencil-specific `@slot` JSDoc tag.
+The `@slot` tag follows the following format:
+```
+@slot [slot-name] - [description]
+```
+where `slot-name` corresponds to the name of the slot in the markup, and `description` describes the usage of the slot.
+
+For this JSDoc tag to be read properly, the following is required:
+1. Either `slot-name` or `description` must be included. Both may be included though.
+2. The '-' separating the two is required.
+
+For the default slot, omit the `slot-name`.
+
+This information is presented in a table containing the following columns:
+- **Slot**: The name of the slot. The default slot will have no name/be empty.
+- **Description**: A description of the slot, if one was given.
+
+For the following usages of `@slot()` in a component:
+```tsx
+/**
+ * @slot - Content is placed between the named slots if provided without a slot.
+ * @slot primary - Content is placed to the left of the main slotted-in text.
+ * @slot secondary - Content is placed to the right of the main slotted-in text.
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent {
+  // ...
+  
+  render() {
+    return (
+      <section>
+        <slot name="primary"></slot>
+        <div class="content">
+          <slot></slot>
+        </div>
+        <slot name="secondary"></slot>
+      </section>
+    );
+  }
+}
+```
+
+The following table is generated:
+
+```md
+## Slots
+
+| Slot          | Description                                                           |
+| ------------- | --------------------------------------------------------------------- |
+|               | Content is placed between the named slots if provided without a slot. |
+| `"primary"`   | Content is placed to the left of the main slotted-in text.            |
+| `"secondary"` | Content is placed to the right of the main slotted-in text.           |
+
+```
+
+The slots section will be placed after the [@Method section](#method-details) of the README.
+
+If a component's top-level JSDoc does not use `@slot` tags, this section will be omitted from the generated README.
+
+### Shadow Parts
+
+A component that uses [CSS shadow parts](../components/styling.md#css-parts) may describe the component's shadow parts in the component's JSDoc using the Stencil-specific `@part` JSDoc tag.
+The `@part` tag follows the following format:
+```
+@part [part-name] - [description]
+```
+where `part-name` corresponds to the name of the shadow part in the markup, and `description` describes its usage.
+
+For this tag to be read properly, the following is required:
+1. Either `part-name` or `description` must be included, although using both is strongly encouraged.
+2. The '-' separating the two is required.
+
+This information is presented in a table containing the following columns:
+- **Part**: The name of the shadow part.
+- **Description**: A description of the shadow part, if one was given.
+
+For the following usages of `@part()` in a component:
+
+```tsx
+/**
+ * @part label - The label text describing the component.
+ */
+@Component({
+  tag: 'my-component',
+  styleUrl: 'my-component.css',
+  shadow: true,
+})
+export class MyComponent {
+  // ...
+
+  render() {
+    return (
+      <div part="label">
+        <slot></slot>
+      </div>
+    );
+  }
+}
+```
+
+The following table will be generated:
+```md
+## Shadow Parts
+
+| Part                                                        | Description                              |
+| ----------------------------------------------------------- | ---------------------------------------- |
+| `"label"`                                                   | The label text describing the component. |
+```
+
+The shadow parts section will be placed after the [@Slot Details](#slot-details) of the README.
+
+If a component's top-level JSDoc does not use `@part` tags, this section will be omitted from the generated README.
+
+### Styling Details
+
+Styling in CSS files can be documented in Stencil components as well.
+One use case for documenting styles using Stencil is to note a CSS variable that a component's styling depends on.
+Using the `@prop` JSDoc in a component's CSS file, Stencil can generate this documentation as well.
+
+This information is presented in a table containing the following columns:
+- **Name**: The name of the custom property.
+- **Description**: A description of the custom property, if one was given.
+
+For the following usages of `@prop` in a component's css file:
+
+```css
+:host {
+  /**
+   * @prop --border-radius: Border radius of the avatar and inner image
+   */
+  border-radius: var(--border-radius);
+}
+```
+The following table will be generated:
+
+```md
+## CSS Custom Properties
+
+| Name              | Description                                 |
+| ----------------- | ------------------------------------------- |
+| `--border-radius` | Border radius of the avatar and inner image |
+```
+
+The styling details section will be placed after the [Shadow Parts Details](#shadow-parts) of the README.
+
+If a component's styles does not include styling details, this section will be omitted from the generated README.
+
+### Custom Footers
+
+Removing or customizing the footer can be done by adding a `footer` property to
+the output target. This string is added to the generated Markdown files without
+modification, so you can use Markdown syntax in it for rich formatting:
+
+```tsx title="stencil.config.ts"
+import { Config } from '@stencil/core';
+
+export const config: Config = {
+  outputTargets: [
+    {
       type: 'docs-readme',
       footer: '*Built with love!*',
     }
@@ -69,10 +493,16 @@ export const config: Config = {
 };
 ```
 
-## Generating to a Directory
+The following footer will be placed at the bottom of your component's README file:
+```
+*Built with love!*
+```
 
-By default, a readme file will be generated in the same directory as the
-component corresponds to. This behavior can be changed by setting the `dir`
+## Configuration
+### Specifying the Output Directory
+
+By default, a README file will be generated in the same directory as the
+component it corresponds to. This behavior can be changed by setting the `dir`
 property on the output target configuration. Specifying a directory will create
 the structure `{dir}/{component}/readme.md`.
 
@@ -89,10 +519,9 @@ export const config: Config = {
 };
 ```
 
-## Strict Mode
+### Strict Mode
 
-Adding `strict: true` to the output target configuration will cause Stencil to
-output a warning whenever the project is built with missing documentation.
+Adding `strict: true` to the output target configuration will cause Stencil to output a warning whenever the project is built with missing documentation.
 
 ```tsx title="stencil.config.ts"
 import { Config } from '@stencil/core';
@@ -106,3 +535,9 @@ export const config: Config = {
   ]
 };
 ```
+
+When strict mode is enabled, the following items are checked:
+1. `@Prop()` usages must be documented, unless the property is marked as `@deprecated`
+2. `@Method()` usages must be documented, unless the method is marked as `@deprecated`
+3. `@Event()` usages must be documented, unless the event is marked as `@deprecated`
+4. CSS Part usages must be documented

--- a/versioned_docs/version-v4.4/config/cli.md
+++ b/versioned_docs/version-v4.4/config/cli.md
@@ -20,7 +20,7 @@ Builds a Stencil project. The flags below are the available options for the `bui
 | `--config` | Path to the `stencil.config.ts` file. This flag is not needed in most cases since Stencil will find the config. Additionally, a Stencil config is not required. | `-c` |
 | `--debug` | Adds additional runtime code to help debug, and sets the log level for more verbose output. | |
 | `--dev` | Runs a development build. | |
-| `--docs-readme` | Generate `readme.md` docs based on the component types, properties, methods, events, JSDocs, CSS Custom Properties, etc. | |
+| `--docs` | Generate all docs based on the component types, properties, methods, events, JSDocs, CSS Custom Properties, etc. | |
 | `--es5` | Creates an ES5 compatible build. By default ES5 builds are not created during development in order to improve build times. However, ES5 builds are always created during production builds. Use this flag to create ES5 builds during development. | |
 | `--log` | Write logs for the `stencil build` into `stencil-build.log`. The log file is written in the same location as the config. | |
 | `--prerender` | Prerender the application using the `www` output target after the build has completed. | |

--- a/versioned_docs/version-v4.4/documentation-generation/docs-readme.md
+++ b/versioned_docs/version-v4.4/documentation-generation/docs-readme.md
@@ -7,54 +7,12 @@ slug: /docs-readme
 
 # Docs Readme Markdown File Auto-Generation
 
-Stencil is able to auto-generate `readme.md` files in markdown. This
-feature will save the readme files as a sibling to the component's source file within the
-same directory. This can help you to maintain consistently formatted
-documentation for your components which live right next to them and render in
-GitHub.
+Stencil is able to auto-generate `readme.md` files for your components.
+This can help you to maintain consistently formatted documentation for your components which lives right next to them and renders in GitHub.
 
-To auto-generate readme files, add the `docs-readme` output target to your
-`stencil.config.ts` like so:
+## Setup
 
-```tsx title="stencil.config.ts"
-import { Config } from '@stencil/core';
-
-export const config: Config = {
-  outputTargets: [
-    { type: 'docs-readme' }
-  ]
-};
-```
-
-Another option would be to use the `--docs` CLI flag as a part of the [build task](../config/cli.md#stencil-build), like so:
-
-```bash
-stencil build --docs
-```
-
-This will cause the Stencil compiler to perform a one-time generation of README
-files as a part of the build process.
-
-:::note
-If you don't add the `docs-readme` output target to your Stencil configuration, the `--docs` flag must be applied to regenerate documentation.
-:::
-
-Alternatively, the [docs task](../config/cli.md#stencil-docs) can be used to perform a one time generation of the documentation:
-```bash
-stencil docs
-```
-
-## Adding Custom Markdown to Auto-Generated Files
-
-Once you've generated a `readme.md` file you can customize it with your own
-markdown content. Simply add your own markdown above the comment that reads:
-`<!-- Auto Generated Below -->`.
-
-## Custom Footer
-
-Removing or customizing the footer can be done by adding a `footer` property to
-the output target. This string is added to the generated Markdown files without
-modification, so you can use Markdown syntax in it for rich formatting.
+To generate markdown files, it is recommended to add the `docs-readme` output target to your Stencil configuration file:
 
 ```tsx title="stencil.config.ts"
 import { Config } from '@stencil/core';
@@ -62,6 +20,472 @@ import { Config } from '@stencil/core';
 export const config: Config = {
   outputTargets: [
     { 
+      type: 'docs-readme'
+    }
+  ]
+};
+```
+
+## Generating README Files
+
+### Using the Build Command
+
+If your project has a `docs-readme` output target configured in your Stencil configuration file, the Stencil [build command](../config/cli.md#stencil-build) is all that's needed to generate README docs:
+```bash
+npx stencil build
+```
+If you're running the build command with the `--watch` flag, your project's README files will automatically update without requiring multiple explicit build commands:
+```bash
+npm stencil build --watch
+```
+
+:::info
+When running the build command with the `--dev` flag, README files will not be generated.
+This is to prevent unnecessary I/O operations during the development cycle.
+:::
+
+If you choose not to include a `docs-readme` output target in your Stencil configuration file, use the `--docs` CLI flag as a part of the build command:
+```bash
+npx stencil build --docs
+```
+
+This will cause the Stencil compiler to perform a one-time build of your entire project, including README files.
+
+### Using the Docs Command
+
+As an alternative to the build command, the [docs command](../config/cli.md#stencil-docs) can be used to perform a one time generation of the documentation:
+```bash
+npx stencil docs
+```
+Running `stencil docs` will generate documentation for [all documentation output targets](./01-overview.md), not just `docs-readme`.
+
+## README Sections
+
+Most generated markdown content will automatically be generated without requiring any additional configuration.
+Content is generated based on its Stencil component, rather than requiring you to configure multiple flags.
+Each section below describes the different types of content Stencil recognizes and will automatically generate. 
+
+### Custom Markdown Content
+
+Once you've generated a `readme.md` file, you can add your own markdown content to the file.
+You may add any content above the following comment in a component's `readme.md`:
+```
+Custom content goes here!
+<!-- Auto Generated Below -->
+```
+
+Any custom content placed above this comment will be persisted on subsequent builds of the README file.
+
+### Deprecation Notices
+
+A Stencil component may be marked as deprecated using the [JSDoc `@deprecated` tag](https://jsdoc.app/tags-deprecated).
+By placing `@deprecated` in a component's class-level JSDoc it will cause the generated README to denote the component as deprecated.
+
+For a component with the JSDoc:
+
+```tsx title="A component with @deprecated in its JSDoc"
+/**
+ * @deprecated since v2.0.0
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent { /* omitted */ }
+```
+
+In the code block above, `@deprecated` is added to the JSDoc for `MyComponent`.
+This causes the generated README to contain:
+```
+> **[DEPRECATED]** since v2.0.0
+```
+
+The deprecation notice will always begin with `> **[DEPRECATED]**`, followed by the description provided in the JSDoc.
+In this case, that description is "since v2.0.0".
+
+The deprecation notice will be placed after the [custom content](#custom-markdown-content) in the README.
+
+If a component is not marked as deprecated, this section will be omitted from the generated README.
+
+### Component Overview
+
+A Stencil component that has a JSDoc comment on its class component like so:
+
+```tsx title="A component with an overview in its JSDoc"
+/**
+ * A simple component for formatting names
+ *
+ * This component will do some neat things!
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent { }
+```
+will generate the following section in your component's README:
+
+```
+## Overview
+
+A simple component for formatting names
+
+This component will do some neat things!
+```
+
+The overview will be placed after the [deprecation notice](#deprecation-notices) section of the README.
+
+If a component's JSDoc does not contain an overview, this section will be omitted from the generated README.
+
+### Usage Examples
+
+Usage examples are user-generated markdown files that demonstrate how another developer might use a component.
+These files are separate from a component's README file, and are placed in a `usage/` directory adjacent to a component's implementation.
+
+The content of these files will be added to a `Usage` section of the generated README. 
+This allows you to keep examples right next to the code, making it easy to include them in a documentation site or other downstream consumer(s) of your docs.
+
+The example usage file below describes how to use a component defined in `src/components/my-component/my-component.tsx`:
+
+````md title="src/components/my-component/usage/my-component-usage.md"
+# How to Use `my-component`
+
+This component is used to provide a way to greet a user using their first, middle, and last name.
+This component will properly format the provided name, even when all fields aren't provided:
+
+```html
+<my-component first="Stencil"></my-component>
+<my-component first="Stencil" last="JS"></my-component>
+```
+````
+
+When the README for `my-component` is regenerated, following will be added to the README:
+
+````md
+## Usage
+
+### My-component-usage
+
+# How to Use `my-component`
+
+This component is used to provide a way to greet a user using their first, middle, and last name.
+This component will properly format the provided name, even when all fields aren't provided:
+
+```html
+<my-component first="Stencil"></my-component>
+<my-component first="Stencil" last="JS"></my-component>
+```
+````
+
+:::caution
+Stencil does not check that your usage examples are up-to-date.
+If you make any changes to your component's API, you'll need to update your usage examples manually.
+:::
+
+The usage section will be placed after the [overview section](#component-overview) of the README.
+
+If a component's directory does not contain any usage files, this section will be omitted from the generated README.
+
+### @Prop() Details
+
+Usages of Stencil's [`@Prop()` decorator](../components/properties.md) are described in a table containing the following information for each usage of `@Prop()`:
+- **Property**: The name of the property on the TypeScript class.
+- **Attribute**: The name of the attribute associated with the property name.
+- **Description**: A description of the property, if one was given in a JSDoc comment for the property.
+- **Type**: The TypeScript type of the property.
+- **Default**: The default value of the property.
+
+For the following usages of `@Prop()` in a component:
+```ts
+export class MyComponent {
+  /**
+   * The first name
+   */
+  @Prop() first!: string; // the '!' denotes a required property
+  /**
+   * @deprecated since v2.1.0
+   */
+  @Prop() middle: string;
+  @Prop() lastName = "Smith";
+
+  // ...
+}
+```
+
+The following section will be generated:
+```md
+## Properties
+
+| Property             | Attribute   | Description                                                            | Type     | Default     |
+| -------------------- | ----------- | ---------------------------------------------------------------------- | -------- | ----------- |
+| `first` _(required)_ | `first`     | The first name                                                         | `string` | `undefined` |
+| `lastName`           | `last-name` |                                                                        | `string` | `"Smith"`   |
+| `middle`             | `middle`    | <span style="color:red">**[DEPRECATED]**</span> since v2.1.0<br/><br/> | `string` | `undefined` |
+```
+
+The properties section will be placed after the [usage examples section](#usage-examples) of the README.
+
+If a component does not use the `@Prop()` decorator, this section will be omitted from the generated README.
+
+### @Event() Details
+
+Usages of Stencil's [`@Event()` decorator](../components/events.md) are described in a table containing the following information for each usage of `@Event()`:
+- **Event**: The name of the property on the TypeScript class decorated with `@Event()`.
+- **Description**: A description of the property, if one was given in a JSDoc comment for the property.
+- **Type**: The TypeScript type of the property.
+
+For the following usages of `@Event()` in a component:
+```tsx
+export class MyComponent {
+  /**
+   * Emitted when an event is completed
+   */
+  @Event() todoCompleted: EventEmitter<number>;
+  /**
+   * @deprecated
+   */
+  @Event() todoUndo: EventEmitter<number>;
+
+  // ...
+}
+```
+
+The following section will be generated:
+
+```md
+## Events
+
+| Event           | Description                                                | Type                  |
+| --------------- | ---------------------------------------------------------- | --------------------- |
+| `todoCompleted` | Emitted when an event is completed                         | `CustomEvent<number>` |
+| `todoUndo`      | <span style="color:red">**[DEPRECATED]**</span> <br/><br/> | `CustomEvent<number>` |
+```
+
+The events section will be placed after the [@Prop() section](#prop-details) of the README.
+
+If a component does not use the `@Event()` decorator, this section will be omitted from the generated README.
+
+### @Method() Details
+
+Components that use Stencil's [`@Method()` decorator](../components/methods.md) will have a section describing each usage `@Method`.
+
+Each usage of `@Method` will be documented with its own subsection containing the following:
+- The method signature will be used as the heading for each subsection 
+- A description of the method will immediately follow, if one was provided in a JSDoc
+- A 'Parameters' section that contains a table the describes the name, TypeScript type, and description of each parameter of the method
+- A 'Returns' section that contains the return type of the method, along with a description of the returned value.
+
+For the following usages of `@Method()` in a component:
+
+```ts
+export class MyComponent {
+  /**
+   * Scroll by a specified X/Y distance in the component.
+   *
+   * @param x The amount to scroll by on the horizontal axis.
+   * @param y The amount to scroll by on the vertical axis.
+   * @param duration The amount of time to take scrolling by that amount.
+   * @returns the total distance travelled
+   */
+  @Method()
+  async scrollByPoint(x: number, y: number, duration: number): Promise<number> { /* omitted */ }
+
+  // ...
+}
+```
+
+The following section will be generated:
+
+```md
+## Methods
+
+### `scrollByPoint(x: number, y: number, duration: number) => Promise<number>`
+
+Scroll by a specified X/Y distance in the component.
+
+#### Parameters
+
+| Name       | Type     | Description                                          |
+| ---------- | -------- | ---------------------------------------------------- |
+| `x`        | `number` | The amount to scroll by on the horizontal axis.      |
+| `y`        | `number` | The amount to scroll by on the vertical axis.        |
+| `duration` | `number` | The amount of time to take scrolling by that amount. |
+
+#### Returns
+
+Type: `Promise<number>`
+
+the total distance travelled
+```
+
+The methods section will be placed after the [@Event section](#event-details) of the README.
+
+If a component does not use the `@Method()` decorator, this section will be omitted from the generated README.
+
+### @slot Details
+
+A component that uses [slots](../components/templating-and-jsx.md#slots) may describe its slots in the component's JSDoc using the Stencil-specific `@slot` JSDoc tag.
+The `@slot` tag follows the following format:
+```
+@slot [slot-name] - [description]
+```
+where `slot-name` corresponds to the name of the slot in the markup, and `description` describes the usage of the slot.
+
+For this JSDoc tag to be read properly, the following is required:
+1. Either `slot-name` or `description` must be included. Both may be included though.
+2. The '-' separating the two is required.
+
+For the default slot, omit the `slot-name`.
+
+This information is presented in a table containing the following columns:
+- **Slot**: The name of the slot. The default slot will have no name/be empty.
+- **Description**: A description of the slot, if one was given.
+
+For the following usages of `@slot()` in a component:
+```tsx
+/**
+ * @slot - Content is placed between the named slots if provided without a slot.
+ * @slot primary - Content is placed to the left of the main slotted-in text.
+ * @slot secondary - Content is placed to the right of the main slotted-in text.
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent {
+  // ...
+  
+  render() {
+    return (
+      <section>
+        <slot name="primary"></slot>
+        <div class="content">
+          <slot></slot>
+        </div>
+        <slot name="secondary"></slot>
+      </section>
+    );
+  }
+}
+```
+
+The following table is generated:
+
+```md
+## Slots
+
+| Slot          | Description                                                           |
+| ------------- | --------------------------------------------------------------------- |
+|               | Content is placed between the named slots if provided without a slot. |
+| `"primary"`   | Content is placed to the left of the main slotted-in text.            |
+| `"secondary"` | Content is placed to the right of the main slotted-in text.           |
+
+```
+
+The slots section will be placed after the [@Method section](#method-details) of the README.
+
+If a component's top-level JSDoc does not use `@slot` tags, this section will be omitted from the generated README.
+
+### Shadow Parts
+
+A component that uses [CSS shadow parts](../components/styling.md#css-parts) may describe the component's shadow parts in the component's JSDoc using the Stencil-specific `@part` JSDoc tag.
+The `@part` tag follows the following format:
+```
+@part [part-name] - [description]
+```
+where `part-name` corresponds to the name of the shadow part in the markup, and `description` describes its usage.
+
+For this tag to be read properly, the following is required:
+1. Either `part-name` or `description` must be included, although using both is strongly encouraged.
+2. The '-' separating the two is required.
+
+This information is presented in a table containing the following columns:
+- **Part**: The name of the shadow part.
+- **Description**: A description of the shadow part, if one was given.
+
+For the following usages of `@part()` in a component:
+
+```tsx
+/**
+ * @part label - The label text describing the component.
+ */
+@Component({
+  tag: 'my-component',
+  styleUrl: 'my-component.css',
+  shadow: true,
+})
+export class MyComponent {
+  // ...
+
+  render() {
+    return (
+      <div part="label">
+        <slot></slot>
+      </div>
+    );
+  }
+}
+```
+
+The following table will be generated:
+```md
+## Shadow Parts
+
+| Part                                                        | Description                              |
+| ----------------------------------------------------------- | ---------------------------------------- |
+| `"label"`                                                   | The label text describing the component. |
+```
+
+The shadow parts section will be placed after the [@Slot Details](#slot-details) of the README.
+
+If a component's top-level JSDoc does not use `@part` tags, this section will be omitted from the generated README.
+
+### Styling Details
+
+Styling in CSS files can be documented in Stencil components as well.
+One use case for documenting styles using Stencil is to note a CSS variable that a component's styling depends on.
+Using the `@prop` JSDoc in a component's CSS file, Stencil can generate this documentation as well.
+
+This information is presented in a table containing the following columns:
+- **Name**: The name of the custom property.
+- **Description**: A description of the custom property, if one was given.
+
+For the following usages of `@prop` in a component's css file:
+
+```css
+:host {
+  /**
+   * @prop --border-radius: Border radius of the avatar and inner image
+   */
+  border-radius: var(--border-radius);
+}
+```
+The following table will be generated:
+
+```md
+## CSS Custom Properties
+
+| Name              | Description                                 |
+| ----------------- | ------------------------------------------- |
+| `--border-radius` | Border radius of the avatar and inner image |
+```
+
+The styling details section will be placed after the [Shadow Parts Details](#shadow-parts) of the README.
+
+If a component's styles does not include styling details, this section will be omitted from the generated README.
+
+### Custom Footers
+
+Removing or customizing the footer can be done by adding a `footer` property to
+the output target. This string is added to the generated Markdown files without
+modification, so you can use Markdown syntax in it for rich formatting:
+
+```tsx title="stencil.config.ts"
+import { Config } from '@stencil/core';
+
+export const config: Config = {
+  outputTargets: [
+    {
       type: 'docs-readme',
       footer: '*Built with love!*',
     }
@@ -69,10 +493,16 @@ export const config: Config = {
 };
 ```
 
-## Generating to a Directory
+The following footer will be placed at the bottom of your component's README file:
+```
+*Built with love!*
+```
 
-By default, a readme file will be generated in the same directory as the
-component corresponds to. This behavior can be changed by setting the `dir`
+## Configuration
+### Specifying the Output Directory
+
+By default, a README file will be generated in the same directory as the
+component it corresponds to. This behavior can be changed by setting the `dir`
 property on the output target configuration. Specifying a directory will create
 the structure `{dir}/{component}/readme.md`.
 
@@ -89,10 +519,9 @@ export const config: Config = {
 };
 ```
 
-## Strict Mode
+### Strict Mode
 
-Adding `strict: true` to the output target configuration will cause Stencil to
-output a warning whenever the project is built with missing documentation.
+Adding `strict: true` to the output target configuration will cause Stencil to output a warning whenever the project is built with missing documentation.
 
 ```tsx title="stencil.config.ts"
 import { Config } from '@stencil/core';
@@ -106,3 +535,9 @@ export const config: Config = {
   ]
 };
 ```
+
+When strict mode is enabled, the following items are checked:
+1. `@Prop()` usages must be documented, unless the property is marked as `@deprecated`
+2. `@Method()` usages must be documented, unless the method is marked as `@deprecated`
+3. `@Event()` usages must be documented, unless the event is marked as `@deprecated`
+4. CSS Part usages must be documented

--- a/versioned_docs/version-v4.5/config/cli.md
+++ b/versioned_docs/version-v4.5/config/cli.md
@@ -20,7 +20,7 @@ Builds a Stencil project. The flags below are the available options for the `bui
 | `--config` | Path to the `stencil.config.ts` file. This flag is not needed in most cases since Stencil will find the config. Additionally, a Stencil config is not required. | `-c` |
 | `--debug` | Adds additional runtime code to help debug, and sets the log level for more verbose output. | |
 | `--dev` | Runs a development build. | |
-| `--docs-readme` | Generate `readme.md` docs based on the component types, properties, methods, events, JSDocs, CSS Custom Properties, etc. | |
+| `--docs` | Generate all docs based on the component types, properties, methods, events, JSDocs, CSS Custom Properties, etc. | |
 | `--es5` | Creates an ES5 compatible build. By default ES5 builds are not created during development in order to improve build times. However, ES5 builds are always created during production builds. Use this flag to create ES5 builds during development. | |
 | `--log` | Write logs for the `stencil build` into `stencil-build.log`. The log file is written in the same location as the config. | |
 | `--prerender` | Prerender the application using the `www` output target after the build has completed. | |

--- a/versioned_docs/version-v4.5/documentation-generation/docs-readme.md
+++ b/versioned_docs/version-v4.5/documentation-generation/docs-readme.md
@@ -7,54 +7,12 @@ slug: /docs-readme
 
 # Docs Readme Markdown File Auto-Generation
 
-Stencil is able to auto-generate `readme.md` files in markdown. This
-feature will save the readme files as a sibling to the component's source file within the
-same directory. This can help you to maintain consistently formatted
-documentation for your components which live right next to them and render in
-GitHub.
+Stencil is able to auto-generate `readme.md` files for your components.
+This can help you to maintain consistently formatted documentation for your components which lives right next to them and renders in GitHub.
 
-To auto-generate readme files, add the `docs-readme` output target to your
-`stencil.config.ts` like so:
+## Setup
 
-```tsx title="stencil.config.ts"
-import { Config } from '@stencil/core';
-
-export const config: Config = {
-  outputTargets: [
-    { type: 'docs-readme' }
-  ]
-};
-```
-
-Another option would be to use the `--docs` CLI flag as a part of the [build task](../config/cli.md#stencil-build), like so:
-
-```bash
-stencil build --docs
-```
-
-This will cause the Stencil compiler to perform a one-time generation of README
-files as a part of the build process.
-
-:::note
-If you don't add the `docs-readme` output target to your Stencil configuration, the `--docs` flag must be applied to regenerate documentation.
-:::
-
-Alternatively, the [docs task](../config/cli.md#stencil-docs) can be used to perform a one time generation of the documentation:
-```bash
-stencil docs
-```
-
-## Adding Custom Markdown to Auto-Generated Files
-
-Once you've generated a `readme.md` file you can customize it with your own
-markdown content. Simply add your own markdown above the comment that reads:
-`<!-- Auto Generated Below -->`.
-
-## Custom Footer
-
-Removing or customizing the footer can be done by adding a `footer` property to
-the output target. This string is added to the generated Markdown files without
-modification, so you can use Markdown syntax in it for rich formatting.
+To generate markdown files, it is recommended to add the `docs-readme` output target to your Stencil configuration file:
 
 ```tsx title="stencil.config.ts"
 import { Config } from '@stencil/core';
@@ -62,6 +20,472 @@ import { Config } from '@stencil/core';
 export const config: Config = {
   outputTargets: [
     { 
+      type: 'docs-readme'
+    }
+  ]
+};
+```
+
+## Generating README Files
+
+### Using the Build Command
+
+If your project has a `docs-readme` output target configured in your Stencil configuration file, the Stencil [build command](../config/cli.md#stencil-build) is all that's needed to generate README docs:
+```bash
+npx stencil build
+```
+If you're running the build command with the `--watch` flag, your project's README files will automatically update without requiring multiple explicit build commands:
+```bash
+npm stencil build --watch
+```
+
+:::info
+When running the build command with the `--dev` flag, README files will not be generated.
+This is to prevent unnecessary I/O operations during the development cycle.
+:::
+
+If you choose not to include a `docs-readme` output target in your Stencil configuration file, use the `--docs` CLI flag as a part of the build command:
+```bash
+npx stencil build --docs
+```
+
+This will cause the Stencil compiler to perform a one-time build of your entire project, including README files.
+
+### Using the Docs Command
+
+As an alternative to the build command, the [docs command](../config/cli.md#stencil-docs) can be used to perform a one time generation of the documentation:
+```bash
+npx stencil docs
+```
+Running `stencil docs` will generate documentation for [all documentation output targets](./01-overview.md), not just `docs-readme`.
+
+## README Sections
+
+Most generated markdown content will automatically be generated without requiring any additional configuration.
+Content is generated based on its Stencil component, rather than requiring you to configure multiple flags.
+Each section below describes the different types of content Stencil recognizes and will automatically generate. 
+
+### Custom Markdown Content
+
+Once you've generated a `readme.md` file, you can add your own markdown content to the file.
+You may add any content above the following comment in a component's `readme.md`:
+```
+Custom content goes here!
+<!-- Auto Generated Below -->
+```
+
+Any custom content placed above this comment will be persisted on subsequent builds of the README file.
+
+### Deprecation Notices
+
+A Stencil component may be marked as deprecated using the [JSDoc `@deprecated` tag](https://jsdoc.app/tags-deprecated).
+By placing `@deprecated` in a component's class-level JSDoc it will cause the generated README to denote the component as deprecated.
+
+For a component with the JSDoc:
+
+```tsx title="A component with @deprecated in its JSDoc"
+/**
+ * @deprecated since v2.0.0
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent { /* omitted */ }
+```
+
+In the code block above, `@deprecated` is added to the JSDoc for `MyComponent`.
+This causes the generated README to contain:
+```
+> **[DEPRECATED]** since v2.0.0
+```
+
+The deprecation notice will always begin with `> **[DEPRECATED]**`, followed by the description provided in the JSDoc.
+In this case, that description is "since v2.0.0".
+
+The deprecation notice will be placed after the [custom content](#custom-markdown-content) in the README.
+
+If a component is not marked as deprecated, this section will be omitted from the generated README.
+
+### Component Overview
+
+A Stencil component that has a JSDoc comment on its class component like so:
+
+```tsx title="A component with an overview in its JSDoc"
+/**
+ * A simple component for formatting names
+ *
+ * This component will do some neat things!
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent { }
+```
+will generate the following section in your component's README:
+
+```
+## Overview
+
+A simple component for formatting names
+
+This component will do some neat things!
+```
+
+The overview will be placed after the [deprecation notice](#deprecation-notices) section of the README.
+
+If a component's JSDoc does not contain an overview, this section will be omitted from the generated README.
+
+### Usage Examples
+
+Usage examples are user-generated markdown files that demonstrate how another developer might use a component.
+These files are separate from a component's README file, and are placed in a `usage/` directory adjacent to a component's implementation.
+
+The content of these files will be added to a `Usage` section of the generated README. 
+This allows you to keep examples right next to the code, making it easy to include them in a documentation site or other downstream consumer(s) of your docs.
+
+The example usage file below describes how to use a component defined in `src/components/my-component/my-component.tsx`:
+
+````md title="src/components/my-component/usage/my-component-usage.md"
+# How to Use `my-component`
+
+This component is used to provide a way to greet a user using their first, middle, and last name.
+This component will properly format the provided name, even when all fields aren't provided:
+
+```html
+<my-component first="Stencil"></my-component>
+<my-component first="Stencil" last="JS"></my-component>
+```
+````
+
+When the README for `my-component` is regenerated, following will be added to the README:
+
+````md
+## Usage
+
+### My-component-usage
+
+# How to Use `my-component`
+
+This component is used to provide a way to greet a user using their first, middle, and last name.
+This component will properly format the provided name, even when all fields aren't provided:
+
+```html
+<my-component first="Stencil"></my-component>
+<my-component first="Stencil" last="JS"></my-component>
+```
+````
+
+:::caution
+Stencil does not check that your usage examples are up-to-date.
+If you make any changes to your component's API, you'll need to update your usage examples manually.
+:::
+
+The usage section will be placed after the [overview section](#component-overview) of the README.
+
+If a component's directory does not contain any usage files, this section will be omitted from the generated README.
+
+### @Prop() Details
+
+Usages of Stencil's [`@Prop()` decorator](../components/properties.md) are described in a table containing the following information for each usage of `@Prop()`:
+- **Property**: The name of the property on the TypeScript class.
+- **Attribute**: The name of the attribute associated with the property name.
+- **Description**: A description of the property, if one was given in a JSDoc comment for the property.
+- **Type**: The TypeScript type of the property.
+- **Default**: The default value of the property.
+
+For the following usages of `@Prop()` in a component:
+```ts
+export class MyComponent {
+  /**
+   * The first name
+   */
+  @Prop() first!: string; // the '!' denotes a required property
+  /**
+   * @deprecated since v2.1.0
+   */
+  @Prop() middle: string;
+  @Prop() lastName = "Smith";
+
+  // ...
+}
+```
+
+The following section will be generated:
+```md
+## Properties
+
+| Property             | Attribute   | Description                                                            | Type     | Default     |
+| -------------------- | ----------- | ---------------------------------------------------------------------- | -------- | ----------- |
+| `first` _(required)_ | `first`     | The first name                                                         | `string` | `undefined` |
+| `lastName`           | `last-name` |                                                                        | `string` | `"Smith"`   |
+| `middle`             | `middle`    | <span style="color:red">**[DEPRECATED]**</span> since v2.1.0<br/><br/> | `string` | `undefined` |
+```
+
+The properties section will be placed after the [usage examples section](#usage-examples) of the README.
+
+If a component does not use the `@Prop()` decorator, this section will be omitted from the generated README.
+
+### @Event() Details
+
+Usages of Stencil's [`@Event()` decorator](../components/events.md) are described in a table containing the following information for each usage of `@Event()`:
+- **Event**: The name of the property on the TypeScript class decorated with `@Event()`.
+- **Description**: A description of the property, if one was given in a JSDoc comment for the property.
+- **Type**: The TypeScript type of the property.
+
+For the following usages of `@Event()` in a component:
+```tsx
+export class MyComponent {
+  /**
+   * Emitted when an event is completed
+   */
+  @Event() todoCompleted: EventEmitter<number>;
+  /**
+   * @deprecated
+   */
+  @Event() todoUndo: EventEmitter<number>;
+
+  // ...
+}
+```
+
+The following section will be generated:
+
+```md
+## Events
+
+| Event           | Description                                                | Type                  |
+| --------------- | ---------------------------------------------------------- | --------------------- |
+| `todoCompleted` | Emitted when an event is completed                         | `CustomEvent<number>` |
+| `todoUndo`      | <span style="color:red">**[DEPRECATED]**</span> <br/><br/> | `CustomEvent<number>` |
+```
+
+The events section will be placed after the [@Prop() section](#prop-details) of the README.
+
+If a component does not use the `@Event()` decorator, this section will be omitted from the generated README.
+
+### @Method() Details
+
+Components that use Stencil's [`@Method()` decorator](../components/methods.md) will have a section describing each usage `@Method`.
+
+Each usage of `@Method` will be documented with its own subsection containing the following:
+- The method signature will be used as the heading for each subsection 
+- A description of the method will immediately follow, if one was provided in a JSDoc
+- A 'Parameters' section that contains a table the describes the name, TypeScript type, and description of each parameter of the method
+- A 'Returns' section that contains the return type of the method, along with a description of the returned value.
+
+For the following usages of `@Method()` in a component:
+
+```ts
+export class MyComponent {
+  /**
+   * Scroll by a specified X/Y distance in the component.
+   *
+   * @param x The amount to scroll by on the horizontal axis.
+   * @param y The amount to scroll by on the vertical axis.
+   * @param duration The amount of time to take scrolling by that amount.
+   * @returns the total distance travelled
+   */
+  @Method()
+  async scrollByPoint(x: number, y: number, duration: number): Promise<number> { /* omitted */ }
+
+  // ...
+}
+```
+
+The following section will be generated:
+
+```md
+## Methods
+
+### `scrollByPoint(x: number, y: number, duration: number) => Promise<number>`
+
+Scroll by a specified X/Y distance in the component.
+
+#### Parameters
+
+| Name       | Type     | Description                                          |
+| ---------- | -------- | ---------------------------------------------------- |
+| `x`        | `number` | The amount to scroll by on the horizontal axis.      |
+| `y`        | `number` | The amount to scroll by on the vertical axis.        |
+| `duration` | `number` | The amount of time to take scrolling by that amount. |
+
+#### Returns
+
+Type: `Promise<number>`
+
+the total distance travelled
+```
+
+The methods section will be placed after the [@Event section](#event-details) of the README.
+
+If a component does not use the `@Method()` decorator, this section will be omitted from the generated README.
+
+### @slot Details
+
+A component that uses [slots](../components/templating-and-jsx.md#slots) may describe its slots in the component's JSDoc using the Stencil-specific `@slot` JSDoc tag.
+The `@slot` tag follows the following format:
+```
+@slot [slot-name] - [description]
+```
+where `slot-name` corresponds to the name of the slot in the markup, and `description` describes the usage of the slot.
+
+For this JSDoc tag to be read properly, the following is required:
+1. Either `slot-name` or `description` must be included. Both may be included though.
+2. The '-' separating the two is required.
+
+For the default slot, omit the `slot-name`.
+
+This information is presented in a table containing the following columns:
+- **Slot**: The name of the slot. The default slot will have no name/be empty.
+- **Description**: A description of the slot, if one was given.
+
+For the following usages of `@slot()` in a component:
+```tsx
+/**
+ * @slot - Content is placed between the named slots if provided without a slot.
+ * @slot primary - Content is placed to the left of the main slotted-in text.
+ * @slot secondary - Content is placed to the right of the main slotted-in text.
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent {
+  // ...
+  
+  render() {
+    return (
+      <section>
+        <slot name="primary"></slot>
+        <div class="content">
+          <slot></slot>
+        </div>
+        <slot name="secondary"></slot>
+      </section>
+    );
+  }
+}
+```
+
+The following table is generated:
+
+```md
+## Slots
+
+| Slot          | Description                                                           |
+| ------------- | --------------------------------------------------------------------- |
+|               | Content is placed between the named slots if provided without a slot. |
+| `"primary"`   | Content is placed to the left of the main slotted-in text.            |
+| `"secondary"` | Content is placed to the right of the main slotted-in text.           |
+
+```
+
+The slots section will be placed after the [@Method section](#method-details) of the README.
+
+If a component's top-level JSDoc does not use `@slot` tags, this section will be omitted from the generated README.
+
+### Shadow Parts
+
+A component that uses [CSS shadow parts](../components/styling.md#css-parts) may describe the component's shadow parts in the component's JSDoc using the Stencil-specific `@part` JSDoc tag.
+The `@part` tag follows the following format:
+```
+@part [part-name] - [description]
+```
+where `part-name` corresponds to the name of the shadow part in the markup, and `description` describes its usage.
+
+For this tag to be read properly, the following is required:
+1. Either `part-name` or `description` must be included, although using both is strongly encouraged.
+2. The '-' separating the two is required.
+
+This information is presented in a table containing the following columns:
+- **Part**: The name of the shadow part.
+- **Description**: A description of the shadow part, if one was given.
+
+For the following usages of `@part()` in a component:
+
+```tsx
+/**
+ * @part label - The label text describing the component.
+ */
+@Component({
+  tag: 'my-component',
+  styleUrl: 'my-component.css',
+  shadow: true,
+})
+export class MyComponent {
+  // ...
+
+  render() {
+    return (
+      <div part="label">
+        <slot></slot>
+      </div>
+    );
+  }
+}
+```
+
+The following table will be generated:
+```md
+## Shadow Parts
+
+| Part                                                        | Description                              |
+| ----------------------------------------------------------- | ---------------------------------------- |
+| `"label"`                                                   | The label text describing the component. |
+```
+
+The shadow parts section will be placed after the [@Slot Details](#slot-details) of the README.
+
+If a component's top-level JSDoc does not use `@part` tags, this section will be omitted from the generated README.
+
+### Styling Details
+
+Styling in CSS files can be documented in Stencil components as well.
+One use case for documenting styles using Stencil is to note a CSS variable that a component's styling depends on.
+Using the `@prop` JSDoc in a component's CSS file, Stencil can generate this documentation as well.
+
+This information is presented in a table containing the following columns:
+- **Name**: The name of the custom property.
+- **Description**: A description of the custom property, if one was given.
+
+For the following usages of `@prop` in a component's css file:
+
+```css
+:host {
+  /**
+   * @prop --border-radius: Border radius of the avatar and inner image
+   */
+  border-radius: var(--border-radius);
+}
+```
+The following table will be generated:
+
+```md
+## CSS Custom Properties
+
+| Name              | Description                                 |
+| ----------------- | ------------------------------------------- |
+| `--border-radius` | Border radius of the avatar and inner image |
+```
+
+The styling details section will be placed after the [Shadow Parts Details](#shadow-parts) of the README.
+
+If a component's styles does not include styling details, this section will be omitted from the generated README.
+
+### Custom Footers
+
+Removing or customizing the footer can be done by adding a `footer` property to
+the output target. This string is added to the generated Markdown files without
+modification, so you can use Markdown syntax in it for rich formatting:
+
+```tsx title="stencil.config.ts"
+import { Config } from '@stencil/core';
+
+export const config: Config = {
+  outputTargets: [
+    {
       type: 'docs-readme',
       footer: '*Built with love!*',
     }
@@ -69,10 +493,16 @@ export const config: Config = {
 };
 ```
 
-## Generating to a Directory
+The following footer will be placed at the bottom of your component's README file:
+```
+*Built with love!*
+```
 
-By default, a readme file will be generated in the same directory as the
-component corresponds to. This behavior can be changed by setting the `dir`
+## Configuration
+### Specifying the Output Directory
+
+By default, a README file will be generated in the same directory as the
+component it corresponds to. This behavior can be changed by setting the `dir`
 property on the output target configuration. Specifying a directory will create
 the structure `{dir}/{component}/readme.md`.
 
@@ -89,10 +519,9 @@ export const config: Config = {
 };
 ```
 
-## Strict Mode
+### Strict Mode
 
-Adding `strict: true` to the output target configuration will cause Stencil to
-output a warning whenever the project is built with missing documentation.
+Adding `strict: true` to the output target configuration will cause Stencil to output a warning whenever the project is built with missing documentation.
 
 ```tsx title="stencil.config.ts"
 import { Config } from '@stencil/core';
@@ -106,3 +535,9 @@ export const config: Config = {
   ]
 };
 ```
+
+When strict mode is enabled, the following items are checked:
+1. `@Prop()` usages must be documented, unless the property is marked as `@deprecated`
+2. `@Method()` usages must be documented, unless the method is marked as `@deprecated`
+3. `@Event()` usages must be documented, unless the event is marked as `@deprecated`
+4. CSS Part usages must be documented

--- a/versioned_docs/version-v4.6/config/cli.md
+++ b/versioned_docs/version-v4.6/config/cli.md
@@ -20,7 +20,7 @@ Builds a Stencil project. The flags below are the available options for the `bui
 | `--config` | Path to the `stencil.config.ts` file. This flag is not needed in most cases since Stencil will find the config. Additionally, a Stencil config is not required. | `-c` |
 | `--debug` | Adds additional runtime code to help debug, and sets the log level for more verbose output. | |
 | `--dev` | Runs a development build. | |
-| `--docs-readme` | Generate `readme.md` docs based on the component types, properties, methods, events, JSDocs, CSS Custom Properties, etc. | |
+| `--docs` | Generate all docs based on the component types, properties, methods, events, JSDocs, CSS Custom Properties, etc. | |
 | `--es5` | Creates an ES5 compatible build. By default ES5 builds are not created during development in order to improve build times. However, ES5 builds are always created during production builds. Use this flag to create ES5 builds during development. | |
 | `--log` | Write logs for the `stencil build` into `stencil-build.log`. The log file is written in the same location as the config. | |
 | `--prerender` | Prerender the application using the `www` output target after the build has completed. | |

--- a/versioned_docs/version-v4.6/documentation-generation/docs-readme.md
+++ b/versioned_docs/version-v4.6/documentation-generation/docs-readme.md
@@ -7,54 +7,12 @@ slug: /docs-readme
 
 # Docs Readme Markdown File Auto-Generation
 
-Stencil is able to auto-generate `readme.md` files in markdown. This
-feature will save the readme files as a sibling to the component's source file within the
-same directory. This can help you to maintain consistently formatted
-documentation for your components which live right next to them and render in
-GitHub.
+Stencil is able to auto-generate `readme.md` files for your components.
+This can help you to maintain consistently formatted documentation for your components which lives right next to them and renders in GitHub.
 
-To auto-generate readme files, add the `docs-readme` output target to your
-`stencil.config.ts` like so:
+## Setup
 
-```tsx title="stencil.config.ts"
-import { Config } from '@stencil/core';
-
-export const config: Config = {
-  outputTargets: [
-    { type: 'docs-readme' }
-  ]
-};
-```
-
-Another option would be to use the `--docs` CLI flag as a part of the [build task](../config/cli.md#stencil-build), like so:
-
-```bash
-stencil build --docs
-```
-
-This will cause the Stencil compiler to perform a one-time generation of README
-files as a part of the build process.
-
-:::note
-If you don't add the `docs-readme` output target to your Stencil configuration, the `--docs` flag must be applied to regenerate documentation.
-:::
-
-Alternatively, the [docs task](../config/cli.md#stencil-docs) can be used to perform a one time generation of the documentation:
-```bash
-stencil docs
-```
-
-## Adding Custom Markdown to Auto-Generated Files
-
-Once you've generated a `readme.md` file you can customize it with your own
-markdown content. Simply add your own markdown above the comment that reads:
-`<!-- Auto Generated Below -->`.
-
-## Custom Footer
-
-Removing or customizing the footer can be done by adding a `footer` property to
-the output target. This string is added to the generated Markdown files without
-modification, so you can use Markdown syntax in it for rich formatting.
+To generate markdown files, it is recommended to add the `docs-readme` output target to your Stencil configuration file:
 
 ```tsx title="stencil.config.ts"
 import { Config } from '@stencil/core';
@@ -62,6 +20,472 @@ import { Config } from '@stencil/core';
 export const config: Config = {
   outputTargets: [
     { 
+      type: 'docs-readme'
+    }
+  ]
+};
+```
+
+## Generating README Files
+
+### Using the Build Command
+
+If your project has a `docs-readme` output target configured in your Stencil configuration file, the Stencil [build command](../config/cli.md#stencil-build) is all that's needed to generate README docs:
+```bash
+npx stencil build
+```
+If you're running the build command with the `--watch` flag, your project's README files will automatically update without requiring multiple explicit build commands:
+```bash
+npm stencil build --watch
+```
+
+:::info
+When running the build command with the `--dev` flag, README files will not be generated.
+This is to prevent unnecessary I/O operations during the development cycle.
+:::
+
+If you choose not to include a `docs-readme` output target in your Stencil configuration file, use the `--docs` CLI flag as a part of the build command:
+```bash
+npx stencil build --docs
+```
+
+This will cause the Stencil compiler to perform a one-time build of your entire project, including README files.
+
+### Using the Docs Command
+
+As an alternative to the build command, the [docs command](../config/cli.md#stencil-docs) can be used to perform a one time generation of the documentation:
+```bash
+npx stencil docs
+```
+Running `stencil docs` will generate documentation for [all documentation output targets](./01-overview.md), not just `docs-readme`.
+
+## README Sections
+
+Most generated markdown content will automatically be generated without requiring any additional configuration.
+Content is generated based on its Stencil component, rather than requiring you to configure multiple flags.
+Each section below describes the different types of content Stencil recognizes and will automatically generate. 
+
+### Custom Markdown Content
+
+Once you've generated a `readme.md` file, you can add your own markdown content to the file.
+You may add any content above the following comment in a component's `readme.md`:
+```
+Custom content goes here!
+<!-- Auto Generated Below -->
+```
+
+Any custom content placed above this comment will be persisted on subsequent builds of the README file.
+
+### Deprecation Notices
+
+A Stencil component may be marked as deprecated using the [JSDoc `@deprecated` tag](https://jsdoc.app/tags-deprecated).
+By placing `@deprecated` in a component's class-level JSDoc it will cause the generated README to denote the component as deprecated.
+
+For a component with the JSDoc:
+
+```tsx title="A component with @deprecated in its JSDoc"
+/**
+ * @deprecated since v2.0.0
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent { /* omitted */ }
+```
+
+In the code block above, `@deprecated` is added to the JSDoc for `MyComponent`.
+This causes the generated README to contain:
+```
+> **[DEPRECATED]** since v2.0.0
+```
+
+The deprecation notice will always begin with `> **[DEPRECATED]**`, followed by the description provided in the JSDoc.
+In this case, that description is "since v2.0.0".
+
+The deprecation notice will be placed after the [custom content](#custom-markdown-content) in the README.
+
+If a component is not marked as deprecated, this section will be omitted from the generated README.
+
+### Component Overview
+
+A Stencil component that has a JSDoc comment on its class component like so:
+
+```tsx title="A component with an overview in its JSDoc"
+/**
+ * A simple component for formatting names
+ *
+ * This component will do some neat things!
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent { }
+```
+will generate the following section in your component's README:
+
+```
+## Overview
+
+A simple component for formatting names
+
+This component will do some neat things!
+```
+
+The overview will be placed after the [deprecation notice](#deprecation-notices) section of the README.
+
+If a component's JSDoc does not contain an overview, this section will be omitted from the generated README.
+
+### Usage Examples
+
+Usage examples are user-generated markdown files that demonstrate how another developer might use a component.
+These files are separate from a component's README file, and are placed in a `usage/` directory adjacent to a component's implementation.
+
+The content of these files will be added to a `Usage` section of the generated README. 
+This allows you to keep examples right next to the code, making it easy to include them in a documentation site or other downstream consumer(s) of your docs.
+
+The example usage file below describes how to use a component defined in `src/components/my-component/my-component.tsx`:
+
+````md title="src/components/my-component/usage/my-component-usage.md"
+# How to Use `my-component`
+
+This component is used to provide a way to greet a user using their first, middle, and last name.
+This component will properly format the provided name, even when all fields aren't provided:
+
+```html
+<my-component first="Stencil"></my-component>
+<my-component first="Stencil" last="JS"></my-component>
+```
+````
+
+When the README for `my-component` is regenerated, following will be added to the README:
+
+````md
+## Usage
+
+### My-component-usage
+
+# How to Use `my-component`
+
+This component is used to provide a way to greet a user using their first, middle, and last name.
+This component will properly format the provided name, even when all fields aren't provided:
+
+```html
+<my-component first="Stencil"></my-component>
+<my-component first="Stencil" last="JS"></my-component>
+```
+````
+
+:::caution
+Stencil does not check that your usage examples are up-to-date.
+If you make any changes to your component's API, you'll need to update your usage examples manually.
+:::
+
+The usage section will be placed after the [overview section](#component-overview) of the README.
+
+If a component's directory does not contain any usage files, this section will be omitted from the generated README.
+
+### @Prop() Details
+
+Usages of Stencil's [`@Prop()` decorator](../components/properties.md) are described in a table containing the following information for each usage of `@Prop()`:
+- **Property**: The name of the property on the TypeScript class.
+- **Attribute**: The name of the attribute associated with the property name.
+- **Description**: A description of the property, if one was given in a JSDoc comment for the property.
+- **Type**: The TypeScript type of the property.
+- **Default**: The default value of the property.
+
+For the following usages of `@Prop()` in a component:
+```ts
+export class MyComponent {
+  /**
+   * The first name
+   */
+  @Prop() first!: string; // the '!' denotes a required property
+  /**
+   * @deprecated since v2.1.0
+   */
+  @Prop() middle: string;
+  @Prop() lastName = "Smith";
+
+  // ...
+}
+```
+
+The following section will be generated:
+```md
+## Properties
+
+| Property             | Attribute   | Description                                                            | Type     | Default     |
+| -------------------- | ----------- | ---------------------------------------------------------------------- | -------- | ----------- |
+| `first` _(required)_ | `first`     | The first name                                                         | `string` | `undefined` |
+| `lastName`           | `last-name` |                                                                        | `string` | `"Smith"`   |
+| `middle`             | `middle`    | <span style="color:red">**[DEPRECATED]**</span> since v2.1.0<br/><br/> | `string` | `undefined` |
+```
+
+The properties section will be placed after the [usage examples section](#usage-examples) of the README.
+
+If a component does not use the `@Prop()` decorator, this section will be omitted from the generated README.
+
+### @Event() Details
+
+Usages of Stencil's [`@Event()` decorator](../components/events.md) are described in a table containing the following information for each usage of `@Event()`:
+- **Event**: The name of the property on the TypeScript class decorated with `@Event()`.
+- **Description**: A description of the property, if one was given in a JSDoc comment for the property.
+- **Type**: The TypeScript type of the property.
+
+For the following usages of `@Event()` in a component:
+```tsx
+export class MyComponent {
+  /**
+   * Emitted when an event is completed
+   */
+  @Event() todoCompleted: EventEmitter<number>;
+  /**
+   * @deprecated
+   */
+  @Event() todoUndo: EventEmitter<number>;
+
+  // ...
+}
+```
+
+The following section will be generated:
+
+```md
+## Events
+
+| Event           | Description                                                | Type                  |
+| --------------- | ---------------------------------------------------------- | --------------------- |
+| `todoCompleted` | Emitted when an event is completed                         | `CustomEvent<number>` |
+| `todoUndo`      | <span style="color:red">**[DEPRECATED]**</span> <br/><br/> | `CustomEvent<number>` |
+```
+
+The events section will be placed after the [@Prop() section](#prop-details) of the README.
+
+If a component does not use the `@Event()` decorator, this section will be omitted from the generated README.
+
+### @Method() Details
+
+Components that use Stencil's [`@Method()` decorator](../components/methods.md) will have a section describing each usage `@Method`.
+
+Each usage of `@Method` will be documented with its own subsection containing the following:
+- The method signature will be used as the heading for each subsection 
+- A description of the method will immediately follow, if one was provided in a JSDoc
+- A 'Parameters' section that contains a table the describes the name, TypeScript type, and description of each parameter of the method
+- A 'Returns' section that contains the return type of the method, along with a description of the returned value.
+
+For the following usages of `@Method()` in a component:
+
+```ts
+export class MyComponent {
+  /**
+   * Scroll by a specified X/Y distance in the component.
+   *
+   * @param x The amount to scroll by on the horizontal axis.
+   * @param y The amount to scroll by on the vertical axis.
+   * @param duration The amount of time to take scrolling by that amount.
+   * @returns the total distance travelled
+   */
+  @Method()
+  async scrollByPoint(x: number, y: number, duration: number): Promise<number> { /* omitted */ }
+
+  // ...
+}
+```
+
+The following section will be generated:
+
+```md
+## Methods
+
+### `scrollByPoint(x: number, y: number, duration: number) => Promise<number>`
+
+Scroll by a specified X/Y distance in the component.
+
+#### Parameters
+
+| Name       | Type     | Description                                          |
+| ---------- | -------- | ---------------------------------------------------- |
+| `x`        | `number` | The amount to scroll by on the horizontal axis.      |
+| `y`        | `number` | The amount to scroll by on the vertical axis.        |
+| `duration` | `number` | The amount of time to take scrolling by that amount. |
+
+#### Returns
+
+Type: `Promise<number>`
+
+the total distance travelled
+```
+
+The methods section will be placed after the [@Event section](#event-details) of the README.
+
+If a component does not use the `@Method()` decorator, this section will be omitted from the generated README.
+
+### @slot Details
+
+A component that uses [slots](../components/templating-and-jsx.md#slots) may describe its slots in the component's JSDoc using the Stencil-specific `@slot` JSDoc tag.
+The `@slot` tag follows the following format:
+```
+@slot [slot-name] - [description]
+```
+where `slot-name` corresponds to the name of the slot in the markup, and `description` describes the usage of the slot.
+
+For this JSDoc tag to be read properly, the following is required:
+1. Either `slot-name` or `description` must be included. Both may be included though.
+2. The '-' separating the two is required.
+
+For the default slot, omit the `slot-name`.
+
+This information is presented in a table containing the following columns:
+- **Slot**: The name of the slot. The default slot will have no name/be empty.
+- **Description**: A description of the slot, if one was given.
+
+For the following usages of `@slot()` in a component:
+```tsx
+/**
+ * @slot - Content is placed between the named slots if provided without a slot.
+ * @slot primary - Content is placed to the left of the main slotted-in text.
+ * @slot secondary - Content is placed to the right of the main slotted-in text.
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent {
+  // ...
+  
+  render() {
+    return (
+      <section>
+        <slot name="primary"></slot>
+        <div class="content">
+          <slot></slot>
+        </div>
+        <slot name="secondary"></slot>
+      </section>
+    );
+  }
+}
+```
+
+The following table is generated:
+
+```md
+## Slots
+
+| Slot          | Description                                                           |
+| ------------- | --------------------------------------------------------------------- |
+|               | Content is placed between the named slots if provided without a slot. |
+| `"primary"`   | Content is placed to the left of the main slotted-in text.            |
+| `"secondary"` | Content is placed to the right of the main slotted-in text.           |
+
+```
+
+The slots section will be placed after the [@Method section](#method-details) of the README.
+
+If a component's top-level JSDoc does not use `@slot` tags, this section will be omitted from the generated README.
+
+### Shadow Parts
+
+A component that uses [CSS shadow parts](../components/styling.md#css-parts) may describe the component's shadow parts in the component's JSDoc using the Stencil-specific `@part` JSDoc tag.
+The `@part` tag follows the following format:
+```
+@part [part-name] - [description]
+```
+where `part-name` corresponds to the name of the shadow part in the markup, and `description` describes its usage.
+
+For this tag to be read properly, the following is required:
+1. Either `part-name` or `description` must be included, although using both is strongly encouraged.
+2. The '-' separating the two is required.
+
+This information is presented in a table containing the following columns:
+- **Part**: The name of the shadow part.
+- **Description**: A description of the shadow part, if one was given.
+
+For the following usages of `@part()` in a component:
+
+```tsx
+/**
+ * @part label - The label text describing the component.
+ */
+@Component({
+  tag: 'my-component',
+  styleUrl: 'my-component.css',
+  shadow: true,
+})
+export class MyComponent {
+  // ...
+
+  render() {
+    return (
+      <div part="label">
+        <slot></slot>
+      </div>
+    );
+  }
+}
+```
+
+The following table will be generated:
+```md
+## Shadow Parts
+
+| Part                                                        | Description                              |
+| ----------------------------------------------------------- | ---------------------------------------- |
+| `"label"`                                                   | The label text describing the component. |
+```
+
+The shadow parts section will be placed after the [@Slot Details](#slot-details) of the README.
+
+If a component's top-level JSDoc does not use `@part` tags, this section will be omitted from the generated README.
+
+### Styling Details
+
+Styling in CSS files can be documented in Stencil components as well.
+One use case for documenting styles using Stencil is to note a CSS variable that a component's styling depends on.
+Using the `@prop` JSDoc in a component's CSS file, Stencil can generate this documentation as well.
+
+This information is presented in a table containing the following columns:
+- **Name**: The name of the custom property.
+- **Description**: A description of the custom property, if one was given.
+
+For the following usages of `@prop` in a component's css file:
+
+```css
+:host {
+  /**
+   * @prop --border-radius: Border radius of the avatar and inner image
+   */
+  border-radius: var(--border-radius);
+}
+```
+The following table will be generated:
+
+```md
+## CSS Custom Properties
+
+| Name              | Description                                 |
+| ----------------- | ------------------------------------------- |
+| `--border-radius` | Border radius of the avatar and inner image |
+```
+
+The styling details section will be placed after the [Shadow Parts Details](#shadow-parts) of the README.
+
+If a component's styles does not include styling details, this section will be omitted from the generated README.
+
+### Custom Footers
+
+Removing or customizing the footer can be done by adding a `footer` property to
+the output target. This string is added to the generated Markdown files without
+modification, so you can use Markdown syntax in it for rich formatting:
+
+```tsx title="stencil.config.ts"
+import { Config } from '@stencil/core';
+
+export const config: Config = {
+  outputTargets: [
+    {
       type: 'docs-readme',
       footer: '*Built with love!*',
     }
@@ -69,10 +493,16 @@ export const config: Config = {
 };
 ```
 
-## Generating to a Directory
+The following footer will be placed at the bottom of your component's README file:
+```
+*Built with love!*
+```
 
-By default, a readme file will be generated in the same directory as the
-component corresponds to. This behavior can be changed by setting the `dir`
+## Configuration
+### Specifying the Output Directory
+
+By default, a README file will be generated in the same directory as the
+component it corresponds to. This behavior can be changed by setting the `dir`
 property on the output target configuration. Specifying a directory will create
 the structure `{dir}/{component}/readme.md`.
 
@@ -89,10 +519,9 @@ export const config: Config = {
 };
 ```
 
-## Strict Mode
+### Strict Mode
 
-Adding `strict: true` to the output target configuration will cause Stencil to
-output a warning whenever the project is built with missing documentation.
+Adding `strict: true` to the output target configuration will cause Stencil to output a warning whenever the project is built with missing documentation.
 
 ```tsx title="stencil.config.ts"
 import { Config } from '@stencil/core';
@@ -106,3 +535,9 @@ export const config: Config = {
   ]
 };
 ```
+
+When strict mode is enabled, the following items are checked:
+1. `@Prop()` usages must be documented, unless the property is marked as `@deprecated`
+2. `@Method()` usages must be documented, unless the method is marked as `@deprecated`
+3. `@Event()` usages must be documented, unless the event is marked as `@deprecated`
+4. CSS Part usages must be documented

--- a/versioned_docs/version-v4.7/config/cli.md
+++ b/versioned_docs/version-v4.7/config/cli.md
@@ -20,7 +20,7 @@ Builds a Stencil project. The flags below are the available options for the `bui
 | `--config` | Path to the `stencil.config.ts` file. This flag is not needed in most cases since Stencil will find the config. Additionally, a Stencil config is not required. | `-c` |
 | `--debug` | Adds additional runtime code to help debug, and sets the log level for more verbose output. | |
 | `--dev` | Runs a development build. | |
-| `--docs-readme` | Generate `readme.md` docs based on the component types, properties, methods, events, JSDocs, CSS Custom Properties, etc. | |
+| `--docs` | Generate all docs based on the component types, properties, methods, events, JSDocs, CSS Custom Properties, etc. | |
 | `--es5` | Creates an ES5 compatible build. By default ES5 builds are not created during development in order to improve build times. However, ES5 builds are always created during production builds. Use this flag to create ES5 builds during development. | |
 | `--log` | Write logs for the `stencil build` into `stencil-build.log`. The log file is written in the same location as the config. | |
 | `--prerender` | Prerender the application using the `www` output target after the build has completed. | |

--- a/versioned_docs/version-v4.7/documentation-generation/docs-readme.md
+++ b/versioned_docs/version-v4.7/documentation-generation/docs-readme.md
@@ -7,54 +7,12 @@ slug: /docs-readme
 
 # Docs Readme Markdown File Auto-Generation
 
-Stencil is able to auto-generate `readme.md` files in markdown. This
-feature will save the readme files as a sibling to the component's source file within the
-same directory. This can help you to maintain consistently formatted
-documentation for your components which live right next to them and render in
-GitHub.
+Stencil is able to auto-generate `readme.md` files for your components.
+This can help you to maintain consistently formatted documentation for your components which lives right next to them and renders in GitHub.
 
-To auto-generate readme files, add the `docs-readme` output target to your
-`stencil.config.ts` like so:
+## Setup
 
-```tsx title="stencil.config.ts"
-import { Config } from '@stencil/core';
-
-export const config: Config = {
-  outputTargets: [
-    { type: 'docs-readme' }
-  ]
-};
-```
-
-Another option would be to use the `--docs` CLI flag as a part of the [build task](../config/cli.md#stencil-build), like so:
-
-```bash
-stencil build --docs
-```
-
-This will cause the Stencil compiler to perform a one-time generation of README
-files as a part of the build process.
-
-:::note
-If you don't add the `docs-readme` output target to your Stencil configuration, the `--docs` flag must be applied to regenerate documentation.
-:::
-
-Alternatively, the [docs task](../config/cli.md#stencil-docs) can be used to perform a one time generation of the documentation:
-```bash
-stencil docs
-```
-
-## Adding Custom Markdown to Auto-Generated Files
-
-Once you've generated a `readme.md` file you can customize it with your own
-markdown content. Simply add your own markdown above the comment that reads:
-`<!-- Auto Generated Below -->`.
-
-## Custom Footer
-
-Removing or customizing the footer can be done by adding a `footer` property to
-the output target. This string is added to the generated Markdown files without
-modification, so you can use Markdown syntax in it for rich formatting.
+To generate markdown files, it is recommended to add the `docs-readme` output target to your Stencil configuration file:
 
 ```tsx title="stencil.config.ts"
 import { Config } from '@stencil/core';
@@ -62,6 +20,472 @@ import { Config } from '@stencil/core';
 export const config: Config = {
   outputTargets: [
     { 
+      type: 'docs-readme'
+    }
+  ]
+};
+```
+
+## Generating README Files
+
+### Using the Build Command
+
+If your project has a `docs-readme` output target configured in your Stencil configuration file, the Stencil [build command](../config/cli.md#stencil-build) is all that's needed to generate README docs:
+```bash
+npx stencil build
+```
+If you're running the build command with the `--watch` flag, your project's README files will automatically update without requiring multiple explicit build commands:
+```bash
+npm stencil build --watch
+```
+
+:::info
+When running the build command with the `--dev` flag, README files will not be generated.
+This is to prevent unnecessary I/O operations during the development cycle.
+:::
+
+If you choose not to include a `docs-readme` output target in your Stencil configuration file, use the `--docs` CLI flag as a part of the build command:
+```bash
+npx stencil build --docs
+```
+
+This will cause the Stencil compiler to perform a one-time build of your entire project, including README files.
+
+### Using the Docs Command
+
+As an alternative to the build command, the [docs command](../config/cli.md#stencil-docs) can be used to perform a one time generation of the documentation:
+```bash
+npx stencil docs
+```
+Running `stencil docs` will generate documentation for [all documentation output targets](./01-overview.md), not just `docs-readme`.
+
+## README Sections
+
+Most generated markdown content will automatically be generated without requiring any additional configuration.
+Content is generated based on its Stencil component, rather than requiring you to configure multiple flags.
+Each section below describes the different types of content Stencil recognizes and will automatically generate. 
+
+### Custom Markdown Content
+
+Once you've generated a `readme.md` file, you can add your own markdown content to the file.
+You may add any content above the following comment in a component's `readme.md`:
+```
+Custom content goes here!
+<!-- Auto Generated Below -->
+```
+
+Any custom content placed above this comment will be persisted on subsequent builds of the README file.
+
+### Deprecation Notices
+
+A Stencil component may be marked as deprecated using the [JSDoc `@deprecated` tag](https://jsdoc.app/tags-deprecated).
+By placing `@deprecated` in a component's class-level JSDoc it will cause the generated README to denote the component as deprecated.
+
+For a component with the JSDoc:
+
+```tsx title="A component with @deprecated in its JSDoc"
+/**
+ * @deprecated since v2.0.0
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent { /* omitted */ }
+```
+
+In the code block above, `@deprecated` is added to the JSDoc for `MyComponent`.
+This causes the generated README to contain:
+```
+> **[DEPRECATED]** since v2.0.0
+```
+
+The deprecation notice will always begin with `> **[DEPRECATED]**`, followed by the description provided in the JSDoc.
+In this case, that description is "since v2.0.0".
+
+The deprecation notice will be placed after the [custom content](#custom-markdown-content) in the README.
+
+If a component is not marked as deprecated, this section will be omitted from the generated README.
+
+### Component Overview
+
+A Stencil component that has a JSDoc comment on its class component like so:
+
+```tsx title="A component with an overview in its JSDoc"
+/**
+ * A simple component for formatting names
+ *
+ * This component will do some neat things!
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent { }
+```
+will generate the following section in your component's README:
+
+```
+## Overview
+
+A simple component for formatting names
+
+This component will do some neat things!
+```
+
+The overview will be placed after the [deprecation notice](#deprecation-notices) section of the README.
+
+If a component's JSDoc does not contain an overview, this section will be omitted from the generated README.
+
+### Usage Examples
+
+Usage examples are user-generated markdown files that demonstrate how another developer might use a component.
+These files are separate from a component's README file, and are placed in a `usage/` directory adjacent to a component's implementation.
+
+The content of these files will be added to a `Usage` section of the generated README. 
+This allows you to keep examples right next to the code, making it easy to include them in a documentation site or other downstream consumer(s) of your docs.
+
+The example usage file below describes how to use a component defined in `src/components/my-component/my-component.tsx`:
+
+````md title="src/components/my-component/usage/my-component-usage.md"
+# How to Use `my-component`
+
+This component is used to provide a way to greet a user using their first, middle, and last name.
+This component will properly format the provided name, even when all fields aren't provided:
+
+```html
+<my-component first="Stencil"></my-component>
+<my-component first="Stencil" last="JS"></my-component>
+```
+````
+
+When the README for `my-component` is regenerated, following will be added to the README:
+
+````md
+## Usage
+
+### My-component-usage
+
+# How to Use `my-component`
+
+This component is used to provide a way to greet a user using their first, middle, and last name.
+This component will properly format the provided name, even when all fields aren't provided:
+
+```html
+<my-component first="Stencil"></my-component>
+<my-component first="Stencil" last="JS"></my-component>
+```
+````
+
+:::caution
+Stencil does not check that your usage examples are up-to-date.
+If you make any changes to your component's API, you'll need to update your usage examples manually.
+:::
+
+The usage section will be placed after the [overview section](#component-overview) of the README.
+
+If a component's directory does not contain any usage files, this section will be omitted from the generated README.
+
+### @Prop() Details
+
+Usages of Stencil's [`@Prop()` decorator](../components/properties.md) are described in a table containing the following information for each usage of `@Prop()`:
+- **Property**: The name of the property on the TypeScript class.
+- **Attribute**: The name of the attribute associated with the property name.
+- **Description**: A description of the property, if one was given in a JSDoc comment for the property.
+- **Type**: The TypeScript type of the property.
+- **Default**: The default value of the property.
+
+For the following usages of `@Prop()` in a component:
+```ts
+export class MyComponent {
+  /**
+   * The first name
+   */
+  @Prop() first!: string; // the '!' denotes a required property
+  /**
+   * @deprecated since v2.1.0
+   */
+  @Prop() middle: string;
+  @Prop() lastName = "Smith";
+
+  // ...
+}
+```
+
+The following section will be generated:
+```md
+## Properties
+
+| Property             | Attribute   | Description                                                            | Type     | Default     |
+| -------------------- | ----------- | ---------------------------------------------------------------------- | -------- | ----------- |
+| `first` _(required)_ | `first`     | The first name                                                         | `string` | `undefined` |
+| `lastName`           | `last-name` |                                                                        | `string` | `"Smith"`   |
+| `middle`             | `middle`    | <span style="color:red">**[DEPRECATED]**</span> since v2.1.0<br/><br/> | `string` | `undefined` |
+```
+
+The properties section will be placed after the [usage examples section](#usage-examples) of the README.
+
+If a component does not use the `@Prop()` decorator, this section will be omitted from the generated README.
+
+### @Event() Details
+
+Usages of Stencil's [`@Event()` decorator](../components/events.md) are described in a table containing the following information for each usage of `@Event()`:
+- **Event**: The name of the property on the TypeScript class decorated with `@Event()`.
+- **Description**: A description of the property, if one was given in a JSDoc comment for the property.
+- **Type**: The TypeScript type of the property.
+
+For the following usages of `@Event()` in a component:
+```tsx
+export class MyComponent {
+  /**
+   * Emitted when an event is completed
+   */
+  @Event() todoCompleted: EventEmitter<number>;
+  /**
+   * @deprecated
+   */
+  @Event() todoUndo: EventEmitter<number>;
+
+  // ...
+}
+```
+
+The following section will be generated:
+
+```md
+## Events
+
+| Event           | Description                                                | Type                  |
+| --------------- | ---------------------------------------------------------- | --------------------- |
+| `todoCompleted` | Emitted when an event is completed                         | `CustomEvent<number>` |
+| `todoUndo`      | <span style="color:red">**[DEPRECATED]**</span> <br/><br/> | `CustomEvent<number>` |
+```
+
+The events section will be placed after the [@Prop() section](#prop-details) of the README.
+
+If a component does not use the `@Event()` decorator, this section will be omitted from the generated README.
+
+### @Method() Details
+
+Components that use Stencil's [`@Method()` decorator](../components/methods.md) will have a section describing each usage `@Method`.
+
+Each usage of `@Method` will be documented with its own subsection containing the following:
+- The method signature will be used as the heading for each subsection 
+- A description of the method will immediately follow, if one was provided in a JSDoc
+- A 'Parameters' section that contains a table the describes the name, TypeScript type, and description of each parameter of the method
+- A 'Returns' section that contains the return type of the method, along with a description of the returned value.
+
+For the following usages of `@Method()` in a component:
+
+```ts
+export class MyComponent {
+  /**
+   * Scroll by a specified X/Y distance in the component.
+   *
+   * @param x The amount to scroll by on the horizontal axis.
+   * @param y The amount to scroll by on the vertical axis.
+   * @param duration The amount of time to take scrolling by that amount.
+   * @returns the total distance travelled
+   */
+  @Method()
+  async scrollByPoint(x: number, y: number, duration: number): Promise<number> { /* omitted */ }
+
+  // ...
+}
+```
+
+The following section will be generated:
+
+```md
+## Methods
+
+### `scrollByPoint(x: number, y: number, duration: number) => Promise<number>`
+
+Scroll by a specified X/Y distance in the component.
+
+#### Parameters
+
+| Name       | Type     | Description                                          |
+| ---------- | -------- | ---------------------------------------------------- |
+| `x`        | `number` | The amount to scroll by on the horizontal axis.      |
+| `y`        | `number` | The amount to scroll by on the vertical axis.        |
+| `duration` | `number` | The amount of time to take scrolling by that amount. |
+
+#### Returns
+
+Type: `Promise<number>`
+
+the total distance travelled
+```
+
+The methods section will be placed after the [@Event section](#event-details) of the README.
+
+If a component does not use the `@Method()` decorator, this section will be omitted from the generated README.
+
+### @slot Details
+
+A component that uses [slots](../components/templating-and-jsx.md#slots) may describe its slots in the component's JSDoc using the Stencil-specific `@slot` JSDoc tag.
+The `@slot` tag follows the following format:
+```
+@slot [slot-name] - [description]
+```
+where `slot-name` corresponds to the name of the slot in the markup, and `description` describes the usage of the slot.
+
+For this JSDoc tag to be read properly, the following is required:
+1. Either `slot-name` or `description` must be included. Both may be included though.
+2. The '-' separating the two is required.
+
+For the default slot, omit the `slot-name`.
+
+This information is presented in a table containing the following columns:
+- **Slot**: The name of the slot. The default slot will have no name/be empty.
+- **Description**: A description of the slot, if one was given.
+
+For the following usages of `@slot()` in a component:
+```tsx
+/**
+ * @slot - Content is placed between the named slots if provided without a slot.
+ * @slot primary - Content is placed to the left of the main slotted-in text.
+ * @slot secondary - Content is placed to the right of the main slotted-in text.
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent {
+  // ...
+  
+  render() {
+    return (
+      <section>
+        <slot name="primary"></slot>
+        <div class="content">
+          <slot></slot>
+        </div>
+        <slot name="secondary"></slot>
+      </section>
+    );
+  }
+}
+```
+
+The following table is generated:
+
+```md
+## Slots
+
+| Slot          | Description                                                           |
+| ------------- | --------------------------------------------------------------------- |
+|               | Content is placed between the named slots if provided without a slot. |
+| `"primary"`   | Content is placed to the left of the main slotted-in text.            |
+| `"secondary"` | Content is placed to the right of the main slotted-in text.           |
+
+```
+
+The slots section will be placed after the [@Method section](#method-details) of the README.
+
+If a component's top-level JSDoc does not use `@slot` tags, this section will be omitted from the generated README.
+
+### Shadow Parts
+
+A component that uses [CSS shadow parts](../components/styling.md#css-parts) may describe the component's shadow parts in the component's JSDoc using the Stencil-specific `@part` JSDoc tag.
+The `@part` tag follows the following format:
+```
+@part [part-name] - [description]
+```
+where `part-name` corresponds to the name of the shadow part in the markup, and `description` describes its usage.
+
+For this tag to be read properly, the following is required:
+1. Either `part-name` or `description` must be included, although using both is strongly encouraged.
+2. The '-' separating the two is required.
+
+This information is presented in a table containing the following columns:
+- **Part**: The name of the shadow part.
+- **Description**: A description of the shadow part, if one was given.
+
+For the following usages of `@part()` in a component:
+
+```tsx
+/**
+ * @part label - The label text describing the component.
+ */
+@Component({
+  tag: 'my-component',
+  styleUrl: 'my-component.css',
+  shadow: true,
+})
+export class MyComponent {
+  // ...
+
+  render() {
+    return (
+      <div part="label">
+        <slot></slot>
+      </div>
+    );
+  }
+}
+```
+
+The following table will be generated:
+```md
+## Shadow Parts
+
+| Part                                                        | Description                              |
+| ----------------------------------------------------------- | ---------------------------------------- |
+| `"label"`                                                   | The label text describing the component. |
+```
+
+The shadow parts section will be placed after the [@Slot Details](#slot-details) of the README.
+
+If a component's top-level JSDoc does not use `@part` tags, this section will be omitted from the generated README.
+
+### Styling Details
+
+Styling in CSS files can be documented in Stencil components as well.
+One use case for documenting styles using Stencil is to note a CSS variable that a component's styling depends on.
+Using the `@prop` JSDoc in a component's CSS file, Stencil can generate this documentation as well.
+
+This information is presented in a table containing the following columns:
+- **Name**: The name of the custom property.
+- **Description**: A description of the custom property, if one was given.
+
+For the following usages of `@prop` in a component's css file:
+
+```css
+:host {
+  /**
+   * @prop --border-radius: Border radius of the avatar and inner image
+   */
+  border-radius: var(--border-radius);
+}
+```
+The following table will be generated:
+
+```md
+## CSS Custom Properties
+
+| Name              | Description                                 |
+| ----------------- | ------------------------------------------- |
+| `--border-radius` | Border radius of the avatar and inner image |
+```
+
+The styling details section will be placed after the [Shadow Parts Details](#shadow-parts) of the README.
+
+If a component's styles does not include styling details, this section will be omitted from the generated README.
+
+### Custom Footers
+
+Removing or customizing the footer can be done by adding a `footer` property to
+the output target. This string is added to the generated Markdown files without
+modification, so you can use Markdown syntax in it for rich formatting:
+
+```tsx title="stencil.config.ts"
+import { Config } from '@stencil/core';
+
+export const config: Config = {
+  outputTargets: [
+    {
       type: 'docs-readme',
       footer: '*Built with love!*',
     }
@@ -69,10 +493,16 @@ export const config: Config = {
 };
 ```
 
-## Generating to a Directory
+The following footer will be placed at the bottom of your component's README file:
+```
+*Built with love!*
+```
 
-By default, a readme file will be generated in the same directory as the
-component corresponds to. This behavior can be changed by setting the `dir`
+## Configuration
+### Specifying the Output Directory
+
+By default, a README file will be generated in the same directory as the
+component it corresponds to. This behavior can be changed by setting the `dir`
 property on the output target configuration. Specifying a directory will create
 the structure `{dir}/{component}/readme.md`.
 
@@ -89,10 +519,9 @@ export const config: Config = {
 };
 ```
 
-## Strict Mode
+### Strict Mode
 
-Adding `strict: true` to the output target configuration will cause Stencil to
-output a warning whenever the project is built with missing documentation.
+Adding `strict: true` to the output target configuration will cause Stencil to output a warning whenever the project is built with missing documentation.
 
 ```tsx title="stencil.config.ts"
 import { Config } from '@stencil/core';
@@ -106,3 +535,9 @@ export const config: Config = {
   ]
 };
 ```
+
+When strict mode is enabled, the following items are checked:
+1. `@Prop()` usages must be documented, unless the property is marked as `@deprecated`
+2. `@Method()` usages must be documented, unless the method is marked as `@deprecated`
+3. `@Event()` usages must be documented, unless the event is marked as `@deprecated`
+4. CSS Part usages must be documented

--- a/versioned_docs/version-v4.8/config/cli.md
+++ b/versioned_docs/version-v4.8/config/cli.md
@@ -20,7 +20,7 @@ Builds a Stencil project. The flags below are the available options for the `bui
 | `--config` | Path to the `stencil.config.ts` file. This flag is not needed in most cases since Stencil will find the config. Additionally, a Stencil config is not required. | `-c` |
 | `--debug` | Adds additional runtime code to help debug, and sets the log level for more verbose output. | |
 | `--dev` | Runs a development build. | |
-| `--docs-readme` | Generate `readme.md` docs based on the component types, properties, methods, events, JSDocs, CSS Custom Properties, etc. | |
+| `--docs` | Generate all docs based on the component types, properties, methods, events, JSDocs, CSS Custom Properties, etc. | |
 | `--es5` | Creates an ES5 compatible build. By default ES5 builds are not created during development in order to improve build times. However, ES5 builds are always created during production builds. Use this flag to create ES5 builds during development. | |
 | `--log` | Write logs for the `stencil build` into `stencil-build.log`. The log file is written in the same location as the config. | |
 | `--prerender` | Prerender the application using the `www` output target after the build has completed. | |

--- a/versioned_docs/version-v4.8/documentation-generation/docs-readme.md
+++ b/versioned_docs/version-v4.8/documentation-generation/docs-readme.md
@@ -7,54 +7,478 @@ slug: /docs-readme
 
 # Docs Readme Markdown File Auto-Generation
 
-Stencil is able to auto-generate `readme.md` files in markdown. This
-feature will save the readme files as a sibling to the component's source file within the
-same directory. This can help you to maintain consistently formatted
-documentation for your components which live right next to them and render in
-GitHub.
+Stencil is able to auto-generate `readme.md` files for your components.
+This can help you to maintain consistently formatted documentation for your components which lives right next to them and renders in GitHub.
 
-To auto-generate readme files, add the `docs-readme` output target to your
-`stencil.config.ts` like so:
+## Setup
+
+To generate markdown files, it is recommended to add the `docs-readme` output target to your Stencil configuration file:
 
 ```tsx title="stencil.config.ts"
 import { Config } from '@stencil/core';
 
 export const config: Config = {
   outputTargets: [
-    { type: 'docs-readme' }
+    { 
+      type: 'docs-readme'
+    }
   ]
 };
 ```
 
-Another option would be to use the `--docs` CLI flag as a part of the [build task](../config/cli.md#stencil-build), like so:
+## Generating README Files
 
+### Using the Build Command
+
+If your project has a `docs-readme` output target configured in your Stencil configuration file, the Stencil [build command](../config/cli.md#stencil-build) is all that's needed to generate README docs:
 ```bash
-stencil build --docs
+npx stencil build
+```
+If you're running the build command with the `--watch` flag, your project's README files will automatically update without requiring multiple explicit build commands:
+```bash
+npm stencil build --watch
 ```
 
-This will cause the Stencil compiler to perform a one-time generation of README
-files as a part of the build process.
-
-:::note
-If you don't add the `docs-readme` output target to your Stencil configuration, the `--docs` flag must be applied to regenerate documentation.
+:::info
+When running the build command with the `--dev` flag, README files will not be generated.
+This is to prevent unnecessary I/O operations during the development cycle.
 :::
 
-Alternatively, the [docs task](../config/cli.md#stencil-docs) can be used to perform a one time generation of the documentation:
+If you choose not to include a `docs-readme` output target in your Stencil configuration file, use the `--docs` CLI flag as a part of the build command:
 ```bash
-stencil docs
+npx stencil build --docs
 ```
 
-## Adding Custom Markdown to Auto-Generated Files
+This will cause the Stencil compiler to perform a one-time build of your entire project, including README files.
 
-Once you've generated a `readme.md` file you can customize it with your own
-markdown content. Simply add your own markdown above the comment that reads:
-`<!-- Auto Generated Below -->`.
+### Using the Docs Command
 
-## Custom Footer
+As an alternative to the build command, the [docs command](../config/cli.md#stencil-docs) can be used to perform a one time generation of the documentation:
+```bash
+npx stencil docs
+```
+Running `stencil docs` will generate documentation for [all documentation output targets](./01-overview.md), not just `docs-readme`.
+
+## README Sections
+
+Most generated markdown content will automatically be generated without requiring any additional configuration.
+Content is generated based on its Stencil component, rather than requiring you to configure multiple flags.
+Each section below describes the different types of content Stencil recognizes and will automatically generate. 
+
+### Custom Markdown Content
+
+Once you've generated a `readme.md` file, you can add your own markdown content to the file.
+You may add any content above the following comment in a component's `readme.md`:
+```
+Custom content goes here!
+<!-- Auto Generated Below -->
+```
+
+Any custom content placed above this comment will be persisted on subsequent builds of the README file.
+
+### Deprecation Notices
+
+A Stencil component may be marked as deprecated using the [JSDoc `@deprecated` tag](https://jsdoc.app/tags-deprecated).
+By placing `@deprecated` in a component's class-level JSDoc it will cause the generated README to denote the component as deprecated.
+
+For a component with the JSDoc:
+
+```tsx title="A component with @deprecated in its JSDoc"
+/**
+ * @deprecated since v2.0.0
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent { /* omitted */ }
+```
+
+In the code block above, `@deprecated` is added to the JSDoc for `MyComponent`.
+This causes the generated README to contain:
+```
+> **[DEPRECATED]** since v2.0.0
+```
+
+The deprecation notice will always begin with `> **[DEPRECATED]**`, followed by the description provided in the JSDoc.
+In this case, that description is "since v2.0.0".
+
+The deprecation notice will be placed after the [custom content](#custom-markdown-content) in the README.
+
+If a component is not marked as deprecated, this section will be omitted from the generated README.
+
+### Component Overview
+
+A Stencil component that has a JSDoc comment on its class component like so:
+
+```tsx title="A component with an overview in its JSDoc"
+/**
+ * A simple component for formatting names
+ *
+ * This component will do some neat things!
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent { }
+```
+will generate the following section in your component's README:
+
+```
+## Overview
+
+A simple component for formatting names
+
+This component will do some neat things!
+```
+
+The overview will be placed after the [deprecation notice](#deprecation-notices) section of the README.
+
+If a component's JSDoc does not contain an overview, this section will be omitted from the generated README.
+
+### Usage Examples
+
+Usage examples are user-generated markdown files that demonstrate how another developer might use a component.
+These files are separate from a component's README file, and are placed in a `usage/` directory adjacent to a component's implementation.
+
+The content of these files will be added to a `Usage` section of the generated README. 
+This allows you to keep examples right next to the code, making it easy to include them in a documentation site or other downstream consumer(s) of your docs.
+
+The example usage file below describes how to use a component defined in `src/components/my-component/my-component.tsx`:
+
+````md title="src/components/my-component/usage/my-component-usage.md"
+# How to Use `my-component`
+
+This component is used to provide a way to greet a user using their first, middle, and last name.
+This component will properly format the provided name, even when all fields aren't provided:
+
+```html
+<my-component first="Stencil"></my-component>
+<my-component first="Stencil" last="JS"></my-component>
+```
+````
+
+When the README for `my-component` is regenerated, following will be added to the README:
+
+````md
+## Usage
+
+### My-component-usage
+
+# How to Use `my-component`
+
+This component is used to provide a way to greet a user using their first, middle, and last name.
+This component will properly format the provided name, even when all fields aren't provided:
+
+```html
+<my-component first="Stencil"></my-component>
+<my-component first="Stencil" last="JS"></my-component>
+```
+````
+
+:::caution
+Stencil does not check that your usage examples are up-to-date.
+If you make any changes to your component's API, you'll need to update your usage examples manually.
+:::
+
+The usage section will be placed after the [overview section](#component-overview) of the README.
+
+If a component's directory does not contain any usage files, this section will be omitted from the generated README.
+
+### @Prop() Details
+
+Usages of Stencil's [`@Prop()` decorator](../components/properties.md) are described in a table containing the following information for each usage of `@Prop()`:
+- **Property**: The name of the property on the TypeScript class.
+- **Attribute**: The name of the attribute associated with the property name.
+- **Description**: A description of the property, if one was given in a JSDoc comment for the property.
+- **Type**: The TypeScript type of the property.
+- **Default**: The default value of the property.
+
+For the following usages of `@Prop()` in a component:
+```ts
+export class MyComponent {
+  /**
+   * The first name
+   */
+  @Prop() first!: string; // the '!' denotes a required property
+  /**
+   * @deprecated since v2.1.0
+   */
+  @Prop() middle: string;
+  @Prop() lastName = "Smith";
+
+  // ...
+}
+```
+
+The following section will be generated:
+```md
+## Properties
+
+| Property             | Attribute   | Description                                                            | Type     | Default     |
+| -------------------- | ----------- | ---------------------------------------------------------------------- | -------- | ----------- |
+| `first` _(required)_ | `first`     | The first name                                                         | `string` | `undefined` |
+| `lastName`           | `last-name` |                                                                        | `string` | `"Smith"`   |
+| `middle`             | `middle`    | <span style="color:red">**[DEPRECATED]**</span> since v2.1.0<br/><br/> | `string` | `undefined` |
+```
+
+The properties section will be placed after the [usage examples section](#usage-examples) of the README.
+
+If a component does not use the `@Prop()` decorator, this section will be omitted from the generated README.
+
+### @Event() Details
+
+Usages of Stencil's [`@Event()` decorator](../components/events.md) are described in a table containing the following information for each usage of `@Event()`:
+- **Event**: The name of the property on the TypeScript class decorated with `@Event()`.
+- **Description**: A description of the property, if one was given in a JSDoc comment for the property.
+- **Type**: The TypeScript type of the property.
+
+For the following usages of `@Event()` in a component:
+```tsx
+export class MyComponent {
+  /**
+   * Emitted when an event is completed
+   */
+  @Event() todoCompleted: EventEmitter<number>;
+  /**
+   * @deprecated
+   */
+  @Event() todoUndo: EventEmitter<number>;
+
+  // ...
+}
+```
+
+The following section will be generated:
+
+```md
+## Events
+
+| Event           | Description                                                | Type                  |
+| --------------- | ---------------------------------------------------------- | --------------------- |
+| `todoCompleted` | Emitted when an event is completed                         | `CustomEvent<number>` |
+| `todoUndo`      | <span style="color:red">**[DEPRECATED]**</span> <br/><br/> | `CustomEvent<number>` |
+```
+
+The events section will be placed after the [@Prop() section](#prop-details) of the README.
+
+If a component does not use the `@Event()` decorator, this section will be omitted from the generated README.
+
+### @Method() Details
+
+Components that use Stencil's [`@Method()` decorator](../components/methods.md) will have a section describing each usage `@Method`.
+
+Each usage of `@Method` will be documented with its own subsection containing the following:
+- The method signature will be used as the heading for each subsection 
+- A description of the method will immediately follow, if one was provided in a JSDoc
+- A 'Parameters' section that contains a table the describes the name, TypeScript type, and description of each parameter of the method
+- A 'Returns' section that contains the return type of the method, along with a description of the returned value.
+
+For the following usages of `@Method()` in a component:
+
+```ts
+export class MyComponent {
+  /**
+   * Scroll by a specified X/Y distance in the component.
+   *
+   * @param x The amount to scroll by on the horizontal axis.
+   * @param y The amount to scroll by on the vertical axis.
+   * @param duration The amount of time to take scrolling by that amount.
+   * @returns the total distance travelled
+   */
+  @Method()
+  async scrollByPoint(x: number, y: number, duration: number): Promise<number> { /* omitted */ }
+
+  // ...
+}
+```
+
+The following section will be generated:
+
+```md
+## Methods
+
+### `scrollByPoint(x: number, y: number, duration: number) => Promise<number>`
+
+Scroll by a specified X/Y distance in the component.
+
+#### Parameters
+
+| Name       | Type     | Description                                          |
+| ---------- | -------- | ---------------------------------------------------- |
+| `x`        | `number` | The amount to scroll by on the horizontal axis.      |
+| `y`        | `number` | The amount to scroll by on the vertical axis.        |
+| `duration` | `number` | The amount of time to take scrolling by that amount. |
+
+#### Returns
+
+Type: `Promise<number>`
+
+the total distance travelled
+```
+
+The methods section will be placed after the [@Event section](#event-details) of the README.
+
+If a component does not use the `@Method()` decorator, this section will be omitted from the generated README.
+
+### @slot Details
+
+A component that uses [slots](../components/templating-and-jsx.md#slots) may describe its slots in the component's JSDoc using the Stencil-specific `@slot` JSDoc tag.
+The `@slot` tag follows the following format:
+```
+@slot [slot-name] - [description]
+```
+where `slot-name` corresponds to the name of the slot in the markup, and `description` describes the usage of the slot.
+
+For this JSDoc tag to be read properly, the following is required:
+1. Either `slot-name` or `description` must be included. Both may be included though.
+2. The '-' separating the two is required.
+
+For the default slot, omit the `slot-name`.
+
+This information is presented in a table containing the following columns:
+- **Slot**: The name of the slot. The default slot will have no name/be empty.
+- **Description**: A description of the slot, if one was given.
+
+For the following usages of `@slot()` in a component:
+```tsx
+/**
+ * @slot - Content is placed between the named slots if provided without a slot.
+ * @slot primary - Content is placed to the left of the main slotted-in text.
+ * @slot secondary - Content is placed to the right of the main slotted-in text.
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent {
+  // ...
+  
+  render() {
+    return (
+      <section>
+        <slot name="primary"></slot>
+        <div class="content">
+          <slot></slot>
+        </div>
+        <slot name="secondary"></slot>
+      </section>
+    );
+  }
+}
+```
+
+The following table is generated:
+
+```md
+## Slots
+
+| Slot          | Description                                                           |
+| ------------- | --------------------------------------------------------------------- |
+|               | Content is placed between the named slots if provided without a slot. |
+| `"primary"`   | Content is placed to the left of the main slotted-in text.            |
+| `"secondary"` | Content is placed to the right of the main slotted-in text.           |
+
+```
+
+The slots section will be placed after the [@Method section](#method-details) of the README.
+
+If a component's top-level JSDoc does not use `@slot` tags, this section will be omitted from the generated README.
+
+### Shadow Parts
+
+A component that uses [CSS shadow parts](../components/styling.md#css-parts) may describe the component's shadow parts in the component's JSDoc using the Stencil-specific `@part` JSDoc tag.
+The `@part` tag follows the following format:
+```
+@part [part-name] - [description]
+```
+where `part-name` corresponds to the name of the shadow part in the markup, and `description` describes its usage.
+
+For this tag to be read properly, the following is required:
+1. Either `part-name` or `description` must be included, although using both is strongly encouraged.
+2. The '-' separating the two is required.
+
+This information is presented in a table containing the following columns:
+- **Part**: The name of the shadow part.
+- **Description**: A description of the shadow part, if one was given.
+
+For the following usages of `@part()` in a component:
+
+```tsx
+/**
+ * @part label - The label text describing the component.
+ */
+@Component({
+  tag: 'my-component',
+  styleUrl: 'my-component.css',
+  shadow: true,
+})
+export class MyComponent {
+  // ...
+
+  render() {
+    return (
+      <div part="label">
+        <slot></slot>
+      </div>
+    );
+  }
+}
+```
+
+The following table will be generated:
+```md
+## Shadow Parts
+
+| Part                                                        | Description                              |
+| ----------------------------------------------------------- | ---------------------------------------- |
+| `"label"`                                                   | The label text describing the component. |
+```
+
+The shadow parts section will be placed after the [@Slot Details](#slot-details) of the README.
+
+If a component's top-level JSDoc does not use `@part` tags, this section will be omitted from the generated README.
+
+### Styling Details
+
+Styling in CSS files can be documented in Stencil components as well.
+One use case for documenting styles using Stencil is to note a CSS variable that a component's styling depends on.
+Using the `@prop` JSDoc in a component's CSS file, Stencil can generate this documentation as well.
+
+This information is presented in a table containing the following columns:
+- **Name**: The name of the custom property.
+- **Description**: A description of the custom property, if one was given.
+
+For the following usages of `@prop` in a component's css file:
+
+```css
+:host {
+  /**
+   * @prop --border-radius: Border radius of the avatar and inner image
+   */
+  border-radius: var(--border-radius);
+}
+```
+The following table will be generated:
+
+```md
+## CSS Custom Properties
+
+| Name              | Description                                 |
+| ----------------- | ------------------------------------------- |
+| `--border-radius` | Border radius of the avatar and inner image |
+```
+
+The styling details section will be placed after the [Shadow Parts Details](#shadow-parts) of the README.
+
+If a component's styles does not include styling details, this section will be omitted from the generated README.
+
+### Custom Footers
 
 Removing or customizing the footer can be done by adding a `footer` property to
 the output target. This string is added to the generated Markdown files without
-modification, so you can use Markdown syntax in it for rich formatting.
+modification, so you can use Markdown syntax in it for rich formatting:
 
 ```tsx title="stencil.config.ts"
 import { Config } from '@stencil/core';
@@ -69,10 +493,16 @@ export const config: Config = {
 };
 ```
 
-## Generating to a Directory
+The following footer will be placed at the bottom of your component's README file:
+```
+*Built with love!*
+```
 
-By default, a readme file will be generated in the same directory as the
-component corresponds to. This behavior can be changed by setting the `dir`
+## Configuration
+### Specifying the Output Directory
+
+By default, a README file will be generated in the same directory as the
+component it corresponds to. This behavior can be changed by setting the `dir`
 property on the output target configuration. Specifying a directory will create
 the structure `{dir}/{component}/readme.md`.
 
@@ -89,10 +519,9 @@ export const config: Config = {
 };
 ```
 
-## Strict Mode
+### Strict Mode
 
-Adding `strict: true` to the output target configuration will cause Stencil to
-output a warning whenever the project is built with missing documentation.
+Adding `strict: true` to the output target configuration will cause Stencil to output a warning whenever the project is built with missing documentation.
 
 ```tsx title="stencil.config.ts"
 import { Config } from '@stencil/core';
@@ -106,3 +535,9 @@ export const config: Config = {
   ]
 };
 ```
+
+When strict mode is enabled, the following items are checked:
+1. `@Prop()` usages must be documented, unless the property is marked as `@deprecated`
+2. `@Method()` usages must be documented, unless the method is marked as `@deprecated`
+3. `@Event()` usages must be documented, unless the event is marked as `@deprecated`
+4. CSS Part usages must be documented

--- a/versioned_docs/version-v4.9/config/cli.md
+++ b/versioned_docs/version-v4.9/config/cli.md
@@ -20,7 +20,7 @@ Builds a Stencil project. The flags below are the available options for the `bui
 | `--config` | Path to the `stencil.config.ts` file. This flag is not needed in most cases since Stencil will find the config. Additionally, a Stencil config is not required. | `-c` |
 | `--debug` | Adds additional runtime code to help debug, and sets the log level for more verbose output. | |
 | `--dev` | Runs a development build. | |
-| `--docs-readme` | Generate `readme.md` docs based on the component types, properties, methods, events, JSDocs, CSS Custom Properties, etc. | |
+| `--docs` | Generate all docs based on the component types, properties, methods, events, JSDocs, CSS Custom Properties, etc. | |
 | `--es5` | Creates an ES5 compatible build. By default ES5 builds are not created during development in order to improve build times. However, ES5 builds are always created during production builds. Use this flag to create ES5 builds during development. | |
 | `--log` | Write logs for the `stencil build` into `stencil-build.log`. The log file is written in the same location as the config. | |
 | `--prerender` | Prerender the application using the `www` output target after the build has completed. | |

--- a/versioned_docs/version-v4.9/documentation-generation/docs-readme.md
+++ b/versioned_docs/version-v4.9/documentation-generation/docs-readme.md
@@ -7,54 +7,478 @@ slug: /docs-readme
 
 # Docs Readme Markdown File Auto-Generation
 
-Stencil is able to auto-generate `readme.md` files in markdown. This
-feature will save the readme files as a sibling to the component's source file within the
-same directory. This can help you to maintain consistently formatted
-documentation for your components which live right next to them and render in
-GitHub.
+Stencil is able to auto-generate `readme.md` files for your components.
+This can help you to maintain consistently formatted documentation for your components which lives right next to them and renders in GitHub.
 
-To auto-generate readme files, add the `docs-readme` output target to your
-`stencil.config.ts` like so:
+## Setup
+
+To generate markdown files, it is recommended to add the `docs-readme` output target to your Stencil configuration file:
 
 ```tsx title="stencil.config.ts"
 import { Config } from '@stencil/core';
 
 export const config: Config = {
   outputTargets: [
-    { type: 'docs-readme' }
+    { 
+      type: 'docs-readme'
+    }
   ]
 };
 ```
 
-Another option would be to use the `--docs` CLI flag as a part of the [build task](../config/cli.md#stencil-build), like so:
+## Generating README Files
 
+### Using the Build Command
+
+If your project has a `docs-readme` output target configured in your Stencil configuration file, the Stencil [build command](../config/cli.md#stencil-build) is all that's needed to generate README docs:
 ```bash
-stencil build --docs
+npx stencil build
+```
+If you're running the build command with the `--watch` flag, your project's README files will automatically update without requiring multiple explicit build commands:
+```bash
+npm stencil build --watch
 ```
 
-This will cause the Stencil compiler to perform a one-time generation of README
-files as a part of the build process.
-
-:::note
-If you don't add the `docs-readme` output target to your Stencil configuration, the `--docs` flag must be applied to regenerate documentation.
+:::info
+When running the build command with the `--dev` flag, README files will not be generated.
+This is to prevent unnecessary I/O operations during the development cycle.
 :::
 
-Alternatively, the [docs task](../config/cli.md#stencil-docs) can be used to perform a one time generation of the documentation:
+If you choose not to include a `docs-readme` output target in your Stencil configuration file, use the `--docs` CLI flag as a part of the build command:
 ```bash
-stencil docs
+npx stencil build --docs
 ```
 
-## Adding Custom Markdown to Auto-Generated Files
+This will cause the Stencil compiler to perform a one-time build of your entire project, including README files.
 
-Once you've generated a `readme.md` file you can customize it with your own
-markdown content. Simply add your own markdown above the comment that reads:
-`<!-- Auto Generated Below -->`.
+### Using the Docs Command
 
-## Custom Footer
+As an alternative to the build command, the [docs command](../config/cli.md#stencil-docs) can be used to perform a one time generation of the documentation:
+```bash
+npx stencil docs
+```
+Running `stencil docs` will generate documentation for [all documentation output targets](./01-overview.md), not just `docs-readme`.
+
+## README Sections
+
+Most generated markdown content will automatically be generated without requiring any additional configuration.
+Content is generated based on its Stencil component, rather than requiring you to configure multiple flags.
+Each section below describes the different types of content Stencil recognizes and will automatically generate. 
+
+### Custom Markdown Content
+
+Once you've generated a `readme.md` file, you can add your own markdown content to the file.
+You may add any content above the following comment in a component's `readme.md`:
+```
+Custom content goes here!
+<!-- Auto Generated Below -->
+```
+
+Any custom content placed above this comment will be persisted on subsequent builds of the README file.
+
+### Deprecation Notices
+
+A Stencil component may be marked as deprecated using the [JSDoc `@deprecated` tag](https://jsdoc.app/tags-deprecated).
+By placing `@deprecated` in a component's class-level JSDoc it will cause the generated README to denote the component as deprecated.
+
+For a component with the JSDoc:
+
+```tsx title="A component with @deprecated in its JSDoc"
+/**
+ * @deprecated since v2.0.0
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent { /* omitted */ }
+```
+
+In the code block above, `@deprecated` is added to the JSDoc for `MyComponent`.
+This causes the generated README to contain:
+```
+> **[DEPRECATED]** since v2.0.0
+```
+
+The deprecation notice will always begin with `> **[DEPRECATED]**`, followed by the description provided in the JSDoc.
+In this case, that description is "since v2.0.0".
+
+The deprecation notice will be placed after the [custom content](#custom-markdown-content) in the README.
+
+If a component is not marked as deprecated, this section will be omitted from the generated README.
+
+### Component Overview
+
+A Stencil component that has a JSDoc comment on its class component like so:
+
+```tsx title="A component with an overview in its JSDoc"
+/**
+ * A simple component for formatting names
+ *
+ * This component will do some neat things!
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent { }
+```
+will generate the following section in your component's README:
+
+```
+## Overview
+
+A simple component for formatting names
+
+This component will do some neat things!
+```
+
+The overview will be placed after the [deprecation notice](#deprecation-notices) section of the README.
+
+If a component's JSDoc does not contain an overview, this section will be omitted from the generated README.
+
+### Usage Examples
+
+Usage examples are user-generated markdown files that demonstrate how another developer might use a component.
+These files are separate from a component's README file, and are placed in a `usage/` directory adjacent to a component's implementation.
+
+The content of these files will be added to a `Usage` section of the generated README. 
+This allows you to keep examples right next to the code, making it easy to include them in a documentation site or other downstream consumer(s) of your docs.
+
+The example usage file below describes how to use a component defined in `src/components/my-component/my-component.tsx`:
+
+````md title="src/components/my-component/usage/my-component-usage.md"
+# How to Use `my-component`
+
+This component is used to provide a way to greet a user using their first, middle, and last name.
+This component will properly format the provided name, even when all fields aren't provided:
+
+```html
+<my-component first="Stencil"></my-component>
+<my-component first="Stencil" last="JS"></my-component>
+```
+````
+
+When the README for `my-component` is regenerated, following will be added to the README:
+
+````md
+## Usage
+
+### My-component-usage
+
+# How to Use `my-component`
+
+This component is used to provide a way to greet a user using their first, middle, and last name.
+This component will properly format the provided name, even when all fields aren't provided:
+
+```html
+<my-component first="Stencil"></my-component>
+<my-component first="Stencil" last="JS"></my-component>
+```
+````
+
+:::caution
+Stencil does not check that your usage examples are up-to-date.
+If you make any changes to your component's API, you'll need to update your usage examples manually.
+:::
+
+The usage section will be placed after the [overview section](#component-overview) of the README.
+
+If a component's directory does not contain any usage files, this section will be omitted from the generated README.
+
+### @Prop() Details
+
+Usages of Stencil's [`@Prop()` decorator](../components/properties.md) are described in a table containing the following information for each usage of `@Prop()`:
+- **Property**: The name of the property on the TypeScript class.
+- **Attribute**: The name of the attribute associated with the property name.
+- **Description**: A description of the property, if one was given in a JSDoc comment for the property.
+- **Type**: The TypeScript type of the property.
+- **Default**: The default value of the property.
+
+For the following usages of `@Prop()` in a component:
+```ts
+export class MyComponent {
+  /**
+   * The first name
+   */
+  @Prop() first!: string; // the '!' denotes a required property
+  /**
+   * @deprecated since v2.1.0
+   */
+  @Prop() middle: string;
+  @Prop() lastName = "Smith";
+
+  // ...
+}
+```
+
+The following section will be generated:
+```md
+## Properties
+
+| Property             | Attribute   | Description                                                            | Type     | Default     |
+| -------------------- | ----------- | ---------------------------------------------------------------------- | -------- | ----------- |
+| `first` _(required)_ | `first`     | The first name                                                         | `string` | `undefined` |
+| `lastName`           | `last-name` |                                                                        | `string` | `"Smith"`   |
+| `middle`             | `middle`    | <span style="color:red">**[DEPRECATED]**</span> since v2.1.0<br/><br/> | `string` | `undefined` |
+```
+
+The properties section will be placed after the [usage examples section](#usage-examples) of the README.
+
+If a component does not use the `@Prop()` decorator, this section will be omitted from the generated README.
+
+### @Event() Details
+
+Usages of Stencil's [`@Event()` decorator](../components/events.md) are described in a table containing the following information for each usage of `@Event()`:
+- **Event**: The name of the property on the TypeScript class decorated with `@Event()`.
+- **Description**: A description of the property, if one was given in a JSDoc comment for the property.
+- **Type**: The TypeScript type of the property.
+
+For the following usages of `@Event()` in a component:
+```tsx
+export class MyComponent {
+  /**
+   * Emitted when an event is completed
+   */
+  @Event() todoCompleted: EventEmitter<number>;
+  /**
+   * @deprecated
+   */
+  @Event() todoUndo: EventEmitter<number>;
+
+  // ...
+}
+```
+
+The following section will be generated:
+
+```md
+## Events
+
+| Event           | Description                                                | Type                  |
+| --------------- | ---------------------------------------------------------- | --------------------- |
+| `todoCompleted` | Emitted when an event is completed                         | `CustomEvent<number>` |
+| `todoUndo`      | <span style="color:red">**[DEPRECATED]**</span> <br/><br/> | `CustomEvent<number>` |
+```
+
+The events section will be placed after the [@Prop() section](#prop-details) of the README.
+
+If a component does not use the `@Event()` decorator, this section will be omitted from the generated README.
+
+### @Method() Details
+
+Components that use Stencil's [`@Method()` decorator](../components/methods.md) will have a section describing each usage `@Method`.
+
+Each usage of `@Method` will be documented with its own subsection containing the following:
+- The method signature will be used as the heading for each subsection 
+- A description of the method will immediately follow, if one was provided in a JSDoc
+- A 'Parameters' section that contains a table the describes the name, TypeScript type, and description of each parameter of the method
+- A 'Returns' section that contains the return type of the method, along with a description of the returned value.
+
+For the following usages of `@Method()` in a component:
+
+```ts
+export class MyComponent {
+  /**
+   * Scroll by a specified X/Y distance in the component.
+   *
+   * @param x The amount to scroll by on the horizontal axis.
+   * @param y The amount to scroll by on the vertical axis.
+   * @param duration The amount of time to take scrolling by that amount.
+   * @returns the total distance travelled
+   */
+  @Method()
+  async scrollByPoint(x: number, y: number, duration: number): Promise<number> { /* omitted */ }
+
+  // ...
+}
+```
+
+The following section will be generated:
+
+```md
+## Methods
+
+### `scrollByPoint(x: number, y: number, duration: number) => Promise<number>`
+
+Scroll by a specified X/Y distance in the component.
+
+#### Parameters
+
+| Name       | Type     | Description                                          |
+| ---------- | -------- | ---------------------------------------------------- |
+| `x`        | `number` | The amount to scroll by on the horizontal axis.      |
+| `y`        | `number` | The amount to scroll by on the vertical axis.        |
+| `duration` | `number` | The amount of time to take scrolling by that amount. |
+
+#### Returns
+
+Type: `Promise<number>`
+
+the total distance travelled
+```
+
+The methods section will be placed after the [@Event section](#event-details) of the README.
+
+If a component does not use the `@Method()` decorator, this section will be omitted from the generated README.
+
+### @slot Details
+
+A component that uses [slots](../components/templating-and-jsx.md#slots) may describe its slots in the component's JSDoc using the Stencil-specific `@slot` JSDoc tag.
+The `@slot` tag follows the following format:
+```
+@slot [slot-name] - [description]
+```
+where `slot-name` corresponds to the name of the slot in the markup, and `description` describes the usage of the slot.
+
+For this JSDoc tag to be read properly, the following is required:
+1. Either `slot-name` or `description` must be included. Both may be included though.
+2. The '-' separating the two is required.
+
+For the default slot, omit the `slot-name`.
+
+This information is presented in a table containing the following columns:
+- **Slot**: The name of the slot. The default slot will have no name/be empty.
+- **Description**: A description of the slot, if one was given.
+
+For the following usages of `@slot()` in a component:
+```tsx
+/**
+ * @slot - Content is placed between the named slots if provided without a slot.
+ * @slot primary - Content is placed to the left of the main slotted-in text.
+ * @slot secondary - Content is placed to the right of the main slotted-in text.
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent {
+  // ...
+  
+  render() {
+    return (
+      <section>
+        <slot name="primary"></slot>
+        <div class="content">
+          <slot></slot>
+        </div>
+        <slot name="secondary"></slot>
+      </section>
+    );
+  }
+}
+```
+
+The following table is generated:
+
+```md
+## Slots
+
+| Slot          | Description                                                           |
+| ------------- | --------------------------------------------------------------------- |
+|               | Content is placed between the named slots if provided without a slot. |
+| `"primary"`   | Content is placed to the left of the main slotted-in text.            |
+| `"secondary"` | Content is placed to the right of the main slotted-in text.           |
+
+```
+
+The slots section will be placed after the [@Method section](#method-details) of the README.
+
+If a component's top-level JSDoc does not use `@slot` tags, this section will be omitted from the generated README.
+
+### Shadow Parts
+
+A component that uses [CSS shadow parts](../components/styling.md#css-parts) may describe the component's shadow parts in the component's JSDoc using the Stencil-specific `@part` JSDoc tag.
+The `@part` tag follows the following format:
+```
+@part [part-name] - [description]
+```
+where `part-name` corresponds to the name of the shadow part in the markup, and `description` describes its usage.
+
+For this tag to be read properly, the following is required:
+1. Either `part-name` or `description` must be included, although using both is strongly encouraged.
+2. The '-' separating the two is required.
+
+This information is presented in a table containing the following columns:
+- **Part**: The name of the shadow part.
+- **Description**: A description of the shadow part, if one was given.
+
+For the following usages of `@part()` in a component:
+
+```tsx
+/**
+ * @part label - The label text describing the component.
+ */
+@Component({
+  tag: 'my-component',
+  styleUrl: 'my-component.css',
+  shadow: true,
+})
+export class MyComponent {
+  // ...
+
+  render() {
+    return (
+      <div part="label">
+        <slot></slot>
+      </div>
+    );
+  }
+}
+```
+
+The following table will be generated:
+```md
+## Shadow Parts
+
+| Part                                                        | Description                              |
+| ----------------------------------------------------------- | ---------------------------------------- |
+| `"label"`                                                   | The label text describing the component. |
+```
+
+The shadow parts section will be placed after the [@Slot Details](#slot-details) of the README.
+
+If a component's top-level JSDoc does not use `@part` tags, this section will be omitted from the generated README.
+
+### Styling Details
+
+Styling in CSS files can be documented in Stencil components as well.
+One use case for documenting styles using Stencil is to note a CSS variable that a component's styling depends on.
+Using the `@prop` JSDoc in a component's CSS file, Stencil can generate this documentation as well.
+
+This information is presented in a table containing the following columns:
+- **Name**: The name of the custom property.
+- **Description**: A description of the custom property, if one was given.
+
+For the following usages of `@prop` in a component's css file:
+
+```css
+:host {
+  /**
+   * @prop --border-radius: Border radius of the avatar and inner image
+   */
+  border-radius: var(--border-radius);
+}
+```
+The following table will be generated:
+
+```md
+## CSS Custom Properties
+
+| Name              | Description                                 |
+| ----------------- | ------------------------------------------- |
+| `--border-radius` | Border radius of the avatar and inner image |
+```
+
+The styling details section will be placed after the [Shadow Parts Details](#shadow-parts) of the README.
+
+If a component's styles does not include styling details, this section will be omitted from the generated README.
+
+### Custom Footers
 
 Removing or customizing the footer can be done by adding a `footer` property to
 the output target. This string is added to the generated Markdown files without
-modification, so you can use Markdown syntax in it for rich formatting.
+modification, so you can use Markdown syntax in it for rich formatting:
 
 ```tsx title="stencil.config.ts"
 import { Config } from '@stencil/core';
@@ -69,10 +493,16 @@ export const config: Config = {
 };
 ```
 
-## Generating to a Directory
+The following footer will be placed at the bottom of your component's README file:
+```
+*Built with love!*
+```
 
-By default, a readme file will be generated in the same directory as the
-component corresponds to. This behavior can be changed by setting the `dir`
+## Configuration
+### Specifying the Output Directory
+
+By default, a README file will be generated in the same directory as the
+component it corresponds to. This behavior can be changed by setting the `dir`
 property on the output target configuration. Specifying a directory will create
 the structure `{dir}/{component}/readme.md`.
 
@@ -89,10 +519,9 @@ export const config: Config = {
 };
 ```
 
-## Strict Mode
+### Strict Mode
 
-Adding `strict: true` to the output target configuration will cause Stencil to
-output a warning whenever the project is built with missing documentation.
+Adding `strict: true` to the output target configuration will cause Stencil to output a warning whenever the project is built with missing documentation.
 
 ```tsx title="stencil.config.ts"
 import { Config } from '@stencil/core';
@@ -106,3 +535,9 @@ export const config: Config = {
   ]
 };
 ```
+
+When strict mode is enabled, the following items are checked:
+1. `@Prop()` usages must be documented, unless the property is marked as `@deprecated`
+2. `@Method()` usages must be documented, unless the method is marked as `@deprecated`
+3. `@Event()` usages must be documented, unless the event is marked as `@deprecated`
+4. CSS Part usages must be documented


### PR DESCRIPTION
add additional documentation concerning the behavior of the `docs-readme` output target. this commit is close to entire rewrite of the documentation - it looks to fill in all details concerning the output target regarding its behavior