### PR TITLE
docs(framework-integrations): add note about consuming custom elements

### DIFF
--- a/docs/framework-integration/angular.md
+++ b/docs/framework-integration/angular.md
@@ -594,6 +594,12 @@ Specifies the type of output to be generated. It can take one of the following v
 
 Both `scam` and `standalone` options are compatible with the `dist-custom-elements` output.
 
+:::note
+The configuration for the [Custom Elements](../output-targets/custom-elements.md) output target must set the
+[export behavior](../output-targets/custom-elements.md#customelementsexportbehavior) to `single-export-module` for the wrappers to generate correctly
+if using the `scam` or `standalone` output type.
+:::
+
 Note: Please choose the appropriate `outputType` based on your project's requirements and the desired output structure.
 
 ### valueAccessorConfigs

--- a/docs/framework-integration/react.md
+++ b/docs/framework-integration/react.md
@@ -427,6 +427,11 @@ If `true`, all Web Components will automatically be registered with the Custom E
 
 If `true`, the output target will import the custom element instance and register it with the Custom Elements Registry when the component is imported inside of a user's app. This can only be used with the [Custom Elements](../output-targets/custom-elements.md) output and will not work with lazy loaded components.
 
+:::note
+The configuration for the [Custom Elements](../output-targets/custom-elements.md) output target must set the
+[export behavior](../output-targets/custom-elements.md#customelementsexportbehavior) to `single-export-module` for the wrappers to generate correctly.
+:::
+
 ### includePolyfills
 
 **Optional**

--- a/docs/framework-integration/vue.md
+++ b/docs/framework-integration/vue.md
@@ -470,6 +470,11 @@ If `true`, all Web Components will automatically be registered with the Custom E
 
 If `true`, the output target will import the custom element instance and register it with the Custom Elements Registry when the component is imported inside of a user's app. This can only be used with the [Custom Elements Bundle](../output-targets/custom-elements.md) and will not work with lazy loaded components.
 
+:::note
+The configuration for the [Custom Elements](../output-targets/custom-elements.md) output target must set the
+[export behavior](../output-targets/custom-elements.md#customelementsexportbehavior) to `single-export-module` for the wrappers to generate correctly.
+:::
+
 ### includePolyfills
 
 **Optional**

--- a/versioned_docs/version-v4.0/framework-integration/react.md
+++ b/versioned_docs/version-v4.0/framework-integration/react.md
@@ -427,6 +427,11 @@ If `true`, all Web Components will automatically be registered with the Custom E
 
 If `true`, the output target will import the custom element instance and register it with the Custom Elements Registry when the component is imported inside of a user's app. This can only be used with the [Custom Elements](../output-targets/custom-elements.md) output and will not work with lazy loaded components.
 
+:::note
+The configuration for the [Custom Elements](../output-targets/custom-elements.md) output target must set the
+[export behavior](../output-targets/custom-elements.md#customelementsexportbehavior) to `single-export-module` for the wrappers to generate correctly.
+:::
+
 ### includePolyfills
 
 **Optional**

--- a/versioned_docs/version-v4.0/framework-integration/vue.md
+++ b/versioned_docs/version-v4.0/framework-integration/vue.md
@@ -470,6 +470,11 @@ If `true`, all Web Components will automatically be registered with the Custom E
 
 If `true`, the output target will import the custom element instance and register it with the Custom Elements Registry when the component is imported inside of a user's app. This can only be used with the [Custom Elements Bundle](../output-targets/custom-elements.md) and will not work with lazy loaded components.
 
+:::note
+The configuration for the [Custom Elements](../output-targets/custom-elements.md) output target must set the
+[export behavior](../output-targets/custom-elements.md#customelementsexportbehavior) to `single-export-module` for the wrappers to generate correctly.
+:::
+
 ### includePolyfills
 
 **Optional**

--- a/versioned_docs/version-v4.1/framework-integration/react.md
+++ b/versioned_docs/version-v4.1/framework-integration/react.md
@@ -427,6 +427,11 @@ If `true`, all Web Components will automatically be registered with the Custom E
 
 If `true`, the output target will import the custom element instance and register it with the Custom Elements Registry when the component is imported inside of a user's app. This can only be used with the [Custom Elements](../output-targets/custom-elements.md) output and will not work with lazy loaded components.
 
+:::note
+The configuration for the [Custom Elements](../output-targets/custom-elements.md) output target must set the
+[export behavior](../output-targets/custom-elements.md#customelementsexportbehavior) to `single-export-module` for the wrappers to generate correctly.
+:::
+
 ### includePolyfills
 
 **Optional**

--- a/versioned_docs/version-v4.1/framework-integration/vue.md
+++ b/versioned_docs/version-v4.1/framework-integration/vue.md
@@ -470,6 +470,11 @@ If `true`, all Web Components will automatically be registered with the Custom E
 
 If `true`, the output target will import the custom element instance and register it with the Custom Elements Registry when the component is imported inside of a user's app. This can only be used with the [Custom Elements Bundle](../output-targets/custom-elements.md) and will not work with lazy loaded components.
 
+:::note
+The configuration for the [Custom Elements](../output-targets/custom-elements.md) output target must set the
+[export behavior](../output-targets/custom-elements.md#customelementsexportbehavior) to `single-export-module` for the wrappers to generate correctly.
+:::
+
 ### includePolyfills
 
 **Optional**

--- a/versioned_docs/version-v4.10/framework-integration/angular.md
+++ b/versioned_docs/version-v4.10/framework-integration/angular.md
@@ -594,6 +594,12 @@ Specifies the type of output to be generated. It can take one of the following v
 
 Both `scam` and `standalone` options are compatible with the `dist-custom-elements` output.
 
+:::note
+The configuration for the [Custom Elements](../output-targets/custom-elements.md) output target must set the
+[export behavior](../output-targets/custom-elements.md#customelementsexportbehavior) to `single-export-module` for the wrappers to generate correctly
+if using the `scam` or `standalone` output type.
+:::
+
 Note: Please choose the appropriate `outputType` based on your project's requirements and the desired output structure.
 
 ### valueAccessorConfigs

--- a/versioned_docs/version-v4.10/framework-integration/react.md
+++ b/versioned_docs/version-v4.10/framework-integration/react.md
@@ -427,6 +427,11 @@ If `true`, all Web Components will automatically be registered with the Custom E
 
 If `true`, the output target will import the custom element instance and register it with the Custom Elements Registry when the component is imported inside of a user's app. This can only be used with the [Custom Elements](../output-targets/custom-elements.md) output and will not work with lazy loaded components.
 
+:::note
+The configuration for the [Custom Elements](../output-targets/custom-elements.md) output target must set the
+[export behavior](../output-targets/custom-elements.md#customelementsexportbehavior) to `single-export-module` for the wrappers to generate correctly.
+:::
+
 ### includePolyfills
 
 **Optional**

--- a/versioned_docs/version-v4.10/framework-integration/vue.md
+++ b/versioned_docs/version-v4.10/framework-integration/vue.md
@@ -470,6 +470,11 @@ If `true`, all Web Components will automatically be registered with the Custom E
 
 If `true`, the output target will import the custom element instance and register it with the Custom Elements Registry when the component is imported inside of a user's app. This can only be used with the [Custom Elements Bundle](../output-targets/custom-elements.md) and will not work with lazy loaded components.
 
+:::note
+The configuration for the [Custom Elements](../output-targets/custom-elements.md) output target must set the
+[export behavior](../output-targets/custom-elements.md#customelementsexportbehavior) to `single-export-module` for the wrappers to generate correctly.
+:::
+
 ### includePolyfills
 
 **Optional**

--- a/versioned_docs/version-v4.11/framework-integration/angular.md
+++ b/versioned_docs/version-v4.11/framework-integration/angular.md
@@ -594,6 +594,12 @@ Specifies the type of output to be generated. It can take one of the following v
 
 Both `scam` and `standalone` options are compatible with the `dist-custom-elements` output.
 
+:::note
+The configuration for the [Custom Elements](../output-targets/custom-elements.md) output target must set the
+[export behavior](../output-targets/custom-elements.md#customelementsexportbehavior) to `single-export-module` for the wrappers to generate correctly
+if using the `scam` or `standalone` output type.
+:::
+
 Note: Please choose the appropriate `outputType` based on your project's requirements and the desired output structure.
 
 ### valueAccessorConfigs

--- a/versioned_docs/version-v4.11/framework-integration/react.md
+++ b/versioned_docs/version-v4.11/framework-integration/react.md
@@ -427,6 +427,11 @@ If `true`, all Web Components will automatically be registered with the Custom E
 
 If `true`, the output target will import the custom element instance and register it with the Custom Elements Registry when the component is imported inside of a user's app. This can only be used with the [Custom Elements](../output-targets/custom-elements.md) output and will not work with lazy loaded components.
 
+:::note
+The configuration for the [Custom Elements](../output-targets/custom-elements.md) output target must set the
+[export behavior](../output-targets/custom-elements.md#customelementsexportbehavior) to `single-export-module` for the wrappers to generate correctly.
+:::
+
 ### includePolyfills
 
 **Optional**

--- a/versioned_docs/version-v4.11/framework-integration/vue.md
+++ b/versioned_docs/version-v4.11/framework-integration/vue.md
@@ -470,6 +470,11 @@ If `true`, all Web Components will automatically be registered with the Custom E
 
 If `true`, the output target will import the custom element instance and register it with the Custom Elements Registry when the component is imported inside of a user's app. This can only be used with the [Custom Elements Bundle](../output-targets/custom-elements.md) and will not work with lazy loaded components.
 
+:::note
+The configuration for the [Custom Elements](../output-targets/custom-elements.md) output target must set the
+[export behavior](../output-targets/custom-elements.md#customelementsexportbehavior) to `single-export-module` for the wrappers to generate correctly.
+:::
+
 ### includePolyfills
 
 **Optional**

--- a/versioned_docs/version-v4.12/framework-integration/angular.md
+++ b/versioned_docs/version-v4.12/framework-integration/angular.md
@@ -594,6 +594,12 @@ Specifies the type of output to be generated. It can take one of the following v
 
 Both `scam` and `standalone` options are compatible with the `dist-custom-elements` output.
 
+:::note
+The configuration for the [Custom Elements](../output-targets/custom-elements.md) output target must set the
+[export behavior](../output-targets/custom-elements.md#customelementsexportbehavior) to `single-export-module` for the wrappers to generate correctly
+if using the `scam` or `standalone` output type.
+:::
+
 Note: Please choose the appropriate `outputType` based on your project's requirements and the desired output structure.
 
 ### valueAccessorConfigs

--- a/versioned_docs/version-v4.12/framework-integration/react.md
+++ b/versioned_docs/version-v4.12/framework-integration/react.md
@@ -427,6 +427,11 @@ If `true`, all Web Components will automatically be registered with the Custom E
 
 If `true`, the output target will import the custom element instance and register it with the Custom Elements Registry when the component is imported inside of a user's app. This can only be used with the [Custom Elements](../output-targets/custom-elements.md) output and will not work with lazy loaded components.
 
+:::note
+The configuration for the [Custom Elements](../output-targets/custom-elements.md) output target must set the
+[export behavior](../output-targets/custom-elements.md#customelementsexportbehavior) to `single-export-module` for the wrappers to generate correctly.
+:::
+
 ### includePolyfills
 
 **Optional**

--- a/versioned_docs/version-v4.12/framework-integration/vue.md
+++ b/versioned_docs/version-v4.12/framework-integration/vue.md
@@ -470,6 +470,11 @@ If `true`, all Web Components will automatically be registered with the Custom E
 
 If `true`, the output target will import the custom element instance and register it with the Custom Elements Registry when the component is imported inside of a user's app. This can only be used with the [Custom Elements Bundle](../output-targets/custom-elements.md) and will not work with lazy loaded components.
 
+:::note
+The configuration for the [Custom Elements](../output-targets/custom-elements.md) output target must set the
+[export behavior](../output-targets/custom-elements.md#customelementsexportbehavior) to `single-export-module` for the wrappers to generate correctly.
+:::
+
 ### includePolyfills
 
 **Optional**

--- a/versioned_docs/version-v4.2/framework-integration/angular.md
+++ b/versioned_docs/version-v4.2/framework-integration/angular.md
@@ -417,6 +417,12 @@ Specifies the type of output to be generated. It can take one of the following v
 
 Both `scam` and `standalone` options are compatible with the `dist-custom-elements` output.
 
+:::note
+The configuration for the [Custom Elements](../output-targets/custom-elements.md) output target must set the
+[export behavior](../output-targets/custom-elements.md#customelementsexportbehavior) to `single-export-module` for the wrappers to generate correctly
+if using the `scam` or `standalone` output type.
+:::
+
 Note: Please choose the appropriate `outputType` based on your project's requirements and the desired output structure.
 
 ### valueAccessorConfigs

--- a/versioned_docs/version-v4.2/framework-integration/react.md
+++ b/versioned_docs/version-v4.2/framework-integration/react.md
@@ -427,6 +427,11 @@ If `true`, all Web Components will automatically be registered with the Custom E
 
 If `true`, the output target will import the custom element instance and register it with the Custom Elements Registry when the component is imported inside of a user's app. This can only be used with the [Custom Elements](../output-targets/custom-elements.md) output and will not work with lazy loaded components.
 
+:::note
+The configuration for the [Custom Elements](../output-targets/custom-elements.md) output target must set the
+[export behavior](../output-targets/custom-elements.md#customelementsexportbehavior) to `single-export-module` for the wrappers to generate correctly.
+:::
+
 ### includePolyfills
 
 **Optional**

--- a/versioned_docs/version-v4.2/framework-integration/vue.md
+++ b/versioned_docs/version-v4.2/framework-integration/vue.md
@@ -470,6 +470,11 @@ If `true`, all Web Components will automatically be registered with the Custom E
 
 If `true`, the output target will import the custom element instance and register it with the Custom Elements Registry when the component is imported inside of a user's app. This can only be used with the [Custom Elements Bundle](../output-targets/custom-elements.md) and will not work with lazy loaded components.
 
+:::note
+The configuration for the [Custom Elements](../output-targets/custom-elements.md) output target must set the
+[export behavior](../output-targets/custom-elements.md#customelementsexportbehavior) to `single-export-module` for the wrappers to generate correctly.
+:::
+
 ### includePolyfills
 
 **Optional**

--- a/versioned_docs/version-v4.3/framework-integration/angular.md
+++ b/versioned_docs/version-v4.3/framework-integration/angular.md
@@ -417,6 +417,12 @@ Specifies the type of output to be generated. It can take one of the following v
 
 Both `scam` and `standalone` options are compatible with the `dist-custom-elements` output.
 
+:::note
+The configuration for the [Custom Elements](../output-targets/custom-elements.md) output target must set the
+[export behavior](../output-targets/custom-elements.md#customelementsexportbehavior) to `single-export-module` for the wrappers to generate correctly
+if using the `scam` or `standalone` output type.
+:::
+
 Note: Please choose the appropriate `outputType` based on your project's requirements and the desired output structure.
 
 ### valueAccessorConfigs

--- a/versioned_docs/version-v4.3/framework-integration/react.md
+++ b/versioned_docs/version-v4.3/framework-integration/react.md
@@ -427,6 +427,11 @@ If `true`, all Web Components will automatically be registered with the Custom E
 
 If `true`, the output target will import the custom element instance and register it with the Custom Elements Registry when the component is imported inside of a user's app. This can only be used with the [Custom Elements](../output-targets/custom-elements.md) output and will not work with lazy loaded components.
 
+:::note
+The configuration for the [Custom Elements](../output-targets/custom-elements.md) output target must set the
+[export behavior](../output-targets/custom-elements.md#customelementsexportbehavior) to `single-export-module` for the wrappers to generate correctly.
+:::
+
 ### includePolyfills
 
 **Optional**

--- a/versioned_docs/version-v4.3/framework-integration/vue.md
+++ b/versioned_docs/version-v4.3/framework-integration/vue.md
@@ -470,6 +470,11 @@ If `true`, all Web Components will automatically be registered with the Custom E
 
 If `true`, the output target will import the custom element instance and register it with the Custom Elements Registry when the component is imported inside of a user's app. This can only be used with the [Custom Elements Bundle](../output-targets/custom-elements.md) and will not work with lazy loaded components.
 
+:::note
+The configuration for the [Custom Elements](../output-targets/custom-elements.md) output target must set the
+[export behavior](../output-targets/custom-elements.md#customelementsexportbehavior) to `single-export-module` for the wrappers to generate correctly.
+:::
+
 ### includePolyfills
 
 **Optional**

--- a/versioned_docs/version-v4.4/framework-integration/angular.md
+++ b/versioned_docs/version-v4.4/framework-integration/angular.md
@@ -417,6 +417,12 @@ Specifies the type of output to be generated. It can take one of the following v
 
 Both `scam` and `standalone` options are compatible with the `dist-custom-elements` output.
 
+:::note
+The configuration for the [Custom Elements](../output-targets/custom-elements.md) output target must set the
+[export behavior](../output-targets/custom-elements.md#customelementsexportbehavior) to `single-export-module` for the wrappers to generate correctly
+if using the `scam` or `standalone` output type.
+:::
+
 Note: Please choose the appropriate `outputType` based on your project's requirements and the desired output structure.
 
 ### valueAccessorConfigs

--- a/versioned_docs/version-v4.4/framework-integration/react.md
+++ b/versioned_docs/version-v4.4/framework-integration/react.md
@@ -427,6 +427,11 @@ If `true`, all Web Components will automatically be registered with the Custom E
 
 If `true`, the output target will import the custom element instance and register it with the Custom Elements Registry when the component is imported inside of a user's app. This can only be used with the [Custom Elements](../output-targets/custom-elements.md) output and will not work with lazy loaded components.
 
+:::note
+The configuration for the [Custom Elements](../output-targets/custom-elements.md) output target must set the
+[export behavior](../output-targets/custom-elements.md#customelementsexportbehavior) to `single-export-module` for the wrappers to generate correctly.
+:::
+
 ### includePolyfills
 
 **Optional**

--- a/versioned_docs/version-v4.4/framework-integration/vue.md
+++ b/versioned_docs/version-v4.4/framework-integration/vue.md
@@ -470,6 +470,11 @@ If `true`, all Web Components will automatically be registered with the Custom E
 
 If `true`, the output target will import the custom element instance and register it with the Custom Elements Registry when the component is imported inside of a user's app. This can only be used with the [Custom Elements Bundle](../output-targets/custom-elements.md) and will not work with lazy loaded components.
 
+:::note
+The configuration for the [Custom Elements](../output-targets/custom-elements.md) output target must set the
+[export behavior](../output-targets/custom-elements.md#customelementsexportbehavior) to `single-export-module` for the wrappers to generate correctly.
+:::
+
 ### includePolyfills
 
 **Optional**

--- a/versioned_docs/version-v4.5/framework-integration/angular.md
+++ b/versioned_docs/version-v4.5/framework-integration/angular.md
@@ -417,6 +417,12 @@ Specifies the type of output to be generated. It can take one of the following v
 
 Both `scam` and `standalone` options are compatible with the `dist-custom-elements` output.
 
+:::note
+The configuration for the [Custom Elements](../output-targets/custom-elements.md) output target must set the
+[export behavior](../output-targets/custom-elements.md#customelementsexportbehavior) to `single-export-module` for the wrappers to generate correctly
+if using the `scam` or `standalone` output type.
+:::
+
 Note: Please choose the appropriate `outputType` based on your project's requirements and the desired output structure.
 
 ### valueAccessorConfigs

--- a/versioned_docs/version-v4.5/framework-integration/react.md
+++ b/versioned_docs/version-v4.5/framework-integration/react.md
@@ -427,6 +427,11 @@ If `true`, all Web Components will automatically be registered with the Custom E
 
 If `true`, the output target will import the custom element instance and register it with the Custom Elements Registry when the component is imported inside of a user's app. This can only be used with the [Custom Elements](../output-targets/custom-elements.md) output and will not work with lazy loaded components.
 
+:::note
+The configuration for the [Custom Elements](../output-targets/custom-elements.md) output target must set the
+[export behavior](../output-targets/custom-elements.md#customelementsexportbehavior) to `single-export-module` for the wrappers to generate correctly.
+:::
+
 ### includePolyfills
 
 **Optional**

--- a/versioned_docs/version-v4.5/framework-integration/vue.md
+++ b/versioned_docs/version-v4.5/framework-integration/vue.md
@@ -470,6 +470,11 @@ If `true`, all Web Components will automatically be registered with the Custom E
 
 If `true`, the output target will import the custom element instance and register it with the Custom Elements Registry when the component is imported inside of a user's app. This can only be used with the [Custom Elements Bundle](../output-targets/custom-elements.md) and will not work with lazy loaded components.
 
+:::note
+The configuration for the [Custom Elements](../output-targets/custom-elements.md) output target must set the
+[export behavior](../output-targets/custom-elements.md#customelementsexportbehavior) to `single-export-module` for the wrappers to generate correctly.
+:::
+
 ### includePolyfills
 
 **Optional**

--- a/versioned_docs/version-v4.6/framework-integration/angular.md
+++ b/versioned_docs/version-v4.6/framework-integration/angular.md
@@ -417,6 +417,12 @@ Specifies the type of output to be generated. It can take one of the following v
 
 Both `scam` and `standalone` options are compatible with the `dist-custom-elements` output.
 
+:::note
+The configuration for the [Custom Elements](../output-targets/custom-elements.md) output target must set the
+[export behavior](../output-targets/custom-elements.md#customelementsexportbehavior) to `single-export-module` for the wrappers to generate correctly
+if using the `scam` or `standalone` output type.
+:::
+
 Note: Please choose the appropriate `outputType` based on your project's requirements and the desired output structure.
 
 ### valueAccessorConfigs

--- a/versioned_docs/version-v4.6/framework-integration/react.md
+++ b/versioned_docs/version-v4.6/framework-integration/react.md
@@ -427,6 +427,11 @@ If `true`, all Web Components will automatically be registered with the Custom E
 
 If `true`, the output target will import the custom element instance and register it with the Custom Elements Registry when the component is imported inside of a user's app. This can only be used with the [Custom Elements](../output-targets/custom-elements.md) output and will not work with lazy loaded components.
 
+:::note
+The configuration for the [Custom Elements](../output-targets/custom-elements.md) output target must set the
+[export behavior](../output-targets/custom-elements.md#customelementsexportbehavior) to `single-export-module` for the wrappers to generate correctly.
+:::
+
 ### includePolyfills
 
 **Optional**

--- a/versioned_docs/version-v4.6/framework-integration/vue.md
+++ b/versioned_docs/version-v4.6/framework-integration/vue.md
@@ -470,6 +470,11 @@ If `true`, all Web Components will automatically be registered with the Custom E
 
 If `true`, the output target will import the custom element instance and register it with the Custom Elements Registry when the component is imported inside of a user's app. This can only be used with the [Custom Elements Bundle](../output-targets/custom-elements.md) and will not work with lazy loaded components.
 
+:::note
+The configuration for the [Custom Elements](../output-targets/custom-elements.md) output target must set the
+[export behavior](../output-targets/custom-elements.md#customelementsexportbehavior) to `single-export-module` for the wrappers to generate correctly.
+:::
+
 ### includePolyfills
 
 **Optional**

--- a/versioned_docs/version-v4.7/framework-integration/angular.md
+++ b/versioned_docs/version-v4.7/framework-integration/angular.md
@@ -417,6 +417,12 @@ Specifies the type of output to be generated. It can take one of the following v
 
 Both `scam` and `standalone` options are compatible with the `dist-custom-elements` output.
 
+:::note
+The configuration for the [Custom Elements](../output-targets/custom-elements.md) output target must set the
+[export behavior](../output-targets/custom-elements.md#customelementsexportbehavior) to `single-export-module` for the wrappers to generate correctly
+if using the `scam` or `standalone` output type.
+:::
+
 Note: Please choose the appropriate `outputType` based on your project's requirements and the desired output structure.
 
 ### valueAccessorConfigs

--- a/versioned_docs/version-v4.7/framework-integration/react.md
+++ b/versioned_docs/version-v4.7/framework-integration/react.md
@@ -427,6 +427,11 @@ If `true`, all Web Components will automatically be registered with the Custom E
 
 If `true`, the output target will import the custom element instance and register it with the Custom Elements Registry when the component is imported inside of a user's app. This can only be used with the [Custom Elements](../output-targets/custom-elements.md) output and will not work with lazy loaded components.
 
+:::note
+The configuration for the [Custom Elements](../output-targets/custom-elements.md) output target must set the
+[export behavior](../output-targets/custom-elements.md#customelementsexportbehavior) to `single-export-module` for the wrappers to generate correctly.
+:::
+
 ### includePolyfills
 
 **Optional**

--- a/versioned_docs/version-v4.7/framework-integration/vue.md
+++ b/versioned_docs/version-v4.7/framework-integration/vue.md
@@ -470,6 +470,11 @@ If `true`, all Web Components will automatically be registered with the Custom E
 
 If `true`, the output target will import the custom element instance and register it with the Custom Elements Registry when the component is imported inside of a user's app. This can only be used with the [Custom Elements Bundle](../output-targets/custom-elements.md) and will not work with lazy loaded components.
 
+:::note
+The configuration for the [Custom Elements](../output-targets/custom-elements.md) output target must set the
+[export behavior](../output-targets/custom-elements.md#customelementsexportbehavior) to `single-export-module` for the wrappers to generate correctly.
+:::
+
 ### includePolyfills
 
 **Optional**

--- a/versioned_docs/version-v4.8/framework-integration/angular.md
+++ b/versioned_docs/version-v4.8/framework-integration/angular.md
@@ -417,6 +417,12 @@ Specifies the type of output to be generated. It can take one of the following v
 
 Both `scam` and `standalone` options are compatible with the `dist-custom-elements` output.
 
+:::note
+The configuration for the [Custom Elements](../output-targets/custom-elements.md) output target must set the
+[export behavior](../output-targets/custom-elements.md#customelementsexportbehavior) to `single-export-module` for the wrappers to generate correctly
+if using the `scam` or `standalone` output type.
+:::
+
 Note: Please choose the appropriate `outputType` based on your project's requirements and the desired output structure.
 
 ### valueAccessorConfigs

--- a/versioned_docs/version-v4.8/framework-integration/react.md
+++ b/versioned_docs/version-v4.8/framework-integration/react.md
@@ -427,6 +427,11 @@ If `true`, all Web Components will automatically be registered with the Custom E
 
 If `true`, the output target will import the custom element instance and register it with the Custom Elements Registry when the component is imported inside of a user's app. This can only be used with the [Custom Elements](../output-targets/custom-elements.md) output and will not work with lazy loaded components.
 
+:::note
+The configuration for the [Custom Elements](../output-targets/custom-elements.md) output target must set the
+[export behavior](../output-targets/custom-elements.md#customelementsexportbehavior) to `single-export-module` for the wrappers to generate correctly.
+:::
+
 ### includePolyfills
 
 **Optional**

--- a/versioned_docs/version-v4.8/framework-integration/vue.md
+++ b/versioned_docs/version-v4.8/framework-integration/vue.md
@@ -470,6 +470,11 @@ If `true`, all Web Components will automatically be registered with the Custom E
 
 If `true`, the output target will import the custom element instance and register it with the Custom Elements Registry when the component is imported inside of a user's app. This can only be used with the [Custom Elements Bundle](../output-targets/custom-elements.md) and will not work with lazy loaded components.
 
+:::note
+The configuration for the [Custom Elements](../output-targets/custom-elements.md) output target must set the
+[export behavior](../output-targets/custom-elements.md#customelementsexportbehavior) to `single-export-module` for the wrappers to generate correctly.
+:::
+
 ### includePolyfills
 
 **Optional**

--- a/versioned_docs/version-v4.9/framework-integration/angular.md
+++ b/versioned_docs/version-v4.9/framework-integration/angular.md
@@ -417,6 +417,12 @@ Specifies the type of output to be generated. It can take one of the following v
 
 Both `scam` and `standalone` options are compatible with the `dist-custom-elements` output.
 
+:::note
+The configuration for the [Custom Elements](../output-targets/custom-elements.md) output target must set the
+[export behavior](../output-targets/custom-elements.md#customelementsexportbehavior) to `single-export-module` for the wrappers to generate correctly
+if using the `scam` or `standalone` output type.
+:::
+
 Note: Please choose the appropriate `outputType` based on your project's requirements and the desired output structure.
 
 ### valueAccessorConfigs

--- a/versioned_docs/version-v4.9/framework-integration/react.md
+++ b/versioned_docs/version-v4.9/framework-integration/react.md
@@ -427,6 +427,11 @@ If `true`, all Web Components will automatically be registered with the Custom E
 
 If `true`, the output target will import the custom element instance and register it with the Custom Elements Registry when the component is imported inside of a user's app. This can only be used with the [Custom Elements](../output-targets/custom-elements.md) output and will not work with lazy loaded components.
 
+:::note
+The configuration for the [Custom Elements](../output-targets/custom-elements.md) output target must set the
+[export behavior](../output-targets/custom-elements.md#customelementsexportbehavior) to `single-export-module` for the wrappers to generate correctly.
+:::
+
 ### includePolyfills
 
 **Optional**

--- a/versioned_docs/version-v4.9/framework-integration/vue.md
+++ b/versioned_docs/version-v4.9/framework-integration/vue.md
@@ -470,6 +470,11 @@ If `true`, all Web Components will automatically be registered with the Custom E
 
 If `true`, the output target will import the custom element instance and register it with the Custom Elements Registry when the component is imported inside of a user's app. This can only be used with the [Custom Elements Bundle](../output-targets/custom-elements.md) and will not work with lazy loaded components.
 
+:::note
+The configuration for the [Custom Elements](../output-targets/custom-elements.md) output target must set the
+[export behavior](../output-targets/custom-elements.md#customelementsexportbehavior) to `single-export-module` for the wrappers to generate correctly.
+:::
+
 ### includePolyfills
 
 **Optional**


### PR DESCRIPTION
This adds an admonition to each of the framework wrapper output targets about consuming the output of `dist-custom-elements`. 

Since Stencil v4, we had to introduce [`customElementExportBehavior`](https://stenciljs.com/docs/custom-elements#customelementsexportbehavior) and the build no-longer automatically has the output of `single-export-module` behavior. Unfortunately, our framework wrappers rely on this behavior when generating the proxies, so devs need to be aware to explicitly set this option.

Note: I will propagate this changes to all v4 versions once approved