### PR TITLE
docs(copy-tasks): rewrite documentation for copy tasks

### DIFF
--- a/docs/output-targets/copy-tasks.md
+++ b/docs/output-targets/copy-tasks.md
@@ -8,13 +8,26 @@ slug: /copy-tasks
 
 # Copy Tasks for Output Targets
 
-Each output target can have its own `copy` config, which is an array of objects that defines any files or folders that should be copied over to the output target's build directory.
+All of Stencil's non-documentation output targets
+([`dist-custom-elements`](./custom-elements.md), [`dist`](./dist.md), and
+[`www`](./www.md)) support a `copy` config which allows you to define file copy
+operations which Stencil will automatically perform as part of the build. This
+could be useful if, for instance, you had some static assets like images which
+should be distributed alongside your components.
 
-### src
+The `copy` attribute on these output targets expects an array of objects corresponding to the following `CopyTask` interface:
 
-Each object in the array must include a `src` property which can be either an absolute path, a relative path from the `srcDir`, or a glob pattern. By default the item copied to the destination will take the same name as the source.
+```ts reference title="CopyTask"
+https://github.com/ionic-team/stencil/blob/6ed2d4e285544945949ad8e4802fe7f70e392636/src/declarations/stencil-public-compiler.ts#L1594-L1665
+```
 
-In the `copy` config within the `www` output target example below, the build will copy the entire directory from `src/images` over to `www/images`. In this example, since the `srcDir` property is not set, the default source directory is `src`.
+## Examples
+
+### Images in the `www` Output Target
+
+The `copy` config within the following [`www` output target](./www.md) config
+will cause Stencil to copy the entire directory from `src/images` to
+`www/images`:
 
 ```tsx
   outputTargets: [
@@ -27,10 +40,20 @@ In the `copy` config within the `www` output target example below, the build wil
   ]
 ```
 
+In this example, since the `srcDir` property is not set, the default source
+directory is `src/`, and since `dest` is not set the contents of `src/images`
+will be copied to a new `images` directory in `www`, the default destination
+directory for the `www` Output Target.
 
-### dest
 
-The config can also provide an optional `dest` property which can be either an absolute path, or a path relative to the build directory of that output target. In the example below, we've customized the build directory to be `public` instead of the default, which will copy `src/files/fonts` over to `public/static/web-fonts`.
+### Setting the `dest` option
+
+The `dest` property can also be optionally set on a `CopyTask` to either an
+absolute path or a path relative to the build directory of the output target.
+
+In this example we've customized the build directory to be `public` instead of
+the default (`'www'`), which, in combination with `dest: 'static/web-fonts'`
+will copy the contents of `src/files/fonts` over to `public/static/web-fonts`:
 
 ```tsx
   outputTargets: [
@@ -44,9 +67,23 @@ The config can also provide an optional `dest` property which can be either an a
   ]
 ```
 
-### warn
+:::note
+When `dest` is set on a `CopyTask` Stencil will, by default, copy all the contents
+of the `src` directory to the `dest` directory without creating a new
+subdirectory for the contents of `src`. The `keepDirStructure` option can
+control this behavior. If it's set to `true` Stencil will always create a
+new subdirectory within `dest` with the same name as the `src` directory. In the
+above example this would result in the contents of `src/files/fonts` being copied
+to `public/static/web-fonts/fonts` instead of `public/static/web-fonts`.
 
-By default, if a file or directory is not available it will not warn if the copy task cannot find it. To see the warnings if a copy task source cannot be found, please set `warn: true` with the copy config object.
+See the above documentation for the `keepDirStructure` option for more details.
+:::
+
+### Opting-in to warnings
+
+By default, Stencil will not log a warning if a file or directory specified in
+`src` cannot be located. To opt-in to warnings if a copy task source cannot be
+found, set `warn: true` in the `CopyTask` object, like so:
 
 ```tsx
   outputTargets: [

--- a/versioned_docs/version-v4.0/output-targets/copy-tasks.md
+++ b/versioned_docs/version-v4.0/output-targets/copy-tasks.md
@@ -8,13 +8,26 @@ slug: /copy-tasks
 
 # Copy Tasks for Output Targets
 
-Each output target can have its own `copy` config, which is an array of objects that defines any files or folders that should be copied over to the output target's build directory.
+All of Stencil's non-documentation output targets
+([`dist-custom-elements`](./custom-elements.md), [`dist`](./dist.md), and
+[`www`](./www.md)) support a `copy` config which allows you to define file copy
+operations which Stencil will automatically perform as part of the build. This
+could be useful if, for instance, you had some static assets like images which
+should be distributed alongside your components.
 
-### src
+The `copy` attribute on these output targets expects an array of objects corresponding to the following `CopyTask` interface:
 
-Each object in the array must include a `src` property which can be either an absolute path, a relative path from the `srcDir`, or a glob pattern. By default the item copied to the destination will take the same name as the source.
+```ts reference title="CopyTask"
+https://github.com/ionic-team/stencil/blob/6ed2d4e285544945949ad8e4802fe7f70e392636/src/declarations/stencil-public-compiler.ts#L1594-L1665
+```
 
-In the `copy` config within the `www` output target example below, the build will copy the entire directory from `src/images` over to `www/images`. In this example, since the `srcDir` property is not set, the default source directory is `src`.
+## Examples
+
+### Images in the `www` Output Target
+
+The `copy` config within the following [`www` output target](./www.md) config
+will cause Stencil to copy the entire directory from `src/images` to
+`www/images`:
 
 ```tsx
   outputTargets: [
@@ -27,10 +40,20 @@ In the `copy` config within the `www` output target example below, the build wil
   ]
 ```
 
+In this example, since the `srcDir` property is not set, the default source
+directory is `src/`, and since `dest` is not set the contents of `src/images`
+will be copied to a new `images` directory in `www`, the default destination
+directory for the `www` Output Target.
 
-### dest
 
-The config can also provide an optional `dest` property which can be either an absolute path, or a path relative to the build directory of that output target. In the example below, we've customized the build directory to be `public` instead of the default, which will copy `src/files/fonts` over to `public/static/web-fonts`.
+### Setting the `dest` option
+
+The `dest` property can also be optionally set on a `CopyTask` to either an
+absolute path or a path relative to the build directory of the output target.
+
+In this example we've customized the build directory to be `public` instead of
+the default (`'www'`), which, in combination with `dest: 'static/web-fonts'`
+will copy the contents of `src/files/fonts` over to `public/static/web-fonts`:
 
 ```tsx
   outputTargets: [
@@ -44,9 +67,23 @@ The config can also provide an optional `dest` property which can be either an a
   ]
 ```
 
-### warn
+:::note
+When `dest` is set on a `CopyTask` Stencil will, by default, copy all the contents
+of the `src` directory to the `dest` directory without creating a new
+subdirectory for the contents of `src`. The `keepDirStructure` option can
+control this behavior. If it's set to `true` Stencil will always create a
+new subdirectory within `dest` with the same name as the `src` directory. In the
+above example this would result in the contents of `src/files/fonts` being copied
+to `public/static/web-fonts/fonts` instead of `public/static/web-fonts`.
 
-By default, if a file or directory is not available it will not warn if the copy task cannot find it. To see the warnings if a copy task source cannot be found, please set `warn: true` with the copy config object.
+See the above documentation for the `keepDirStructure` option for more details.
+:::
+
+### Opting-in to warnings
+
+By default, Stencil will not log a warning if a file or directory specified in
+`src` cannot be located. To opt-in to warnings if a copy task source cannot be
+found, set `warn: true` in the `CopyTask` object, like so:
 
 ```tsx
   outputTargets: [

--- a/versioned_docs/version-v4.1/output-targets/copy-tasks.md
+++ b/versioned_docs/version-v4.1/output-targets/copy-tasks.md
@@ -8,13 +8,26 @@ slug: /copy-tasks
 
 # Copy Tasks for Output Targets
 
-Each output target can have its own `copy` config, which is an array of objects that defines any files or folders that should be copied over to the output target's build directory.
+All of Stencil's non-documentation output targets
+([`dist-custom-elements`](./custom-elements.md), [`dist`](./dist.md), and
+[`www`](./www.md)) support a `copy` config which allows you to define file copy
+operations which Stencil will automatically perform as part of the build. This
+could be useful if, for instance, you had some static assets like images which
+should be distributed alongside your components.
 
-### src
+The `copy` attribute on these output targets expects an array of objects corresponding to the following `CopyTask` interface:
 
-Each object in the array must include a `src` property which can be either an absolute path, a relative path from the `srcDir`, or a glob pattern. By default the item copied to the destination will take the same name as the source.
+```ts reference title="CopyTask"
+https://github.com/ionic-team/stencil/blob/6ed2d4e285544945949ad8e4802fe7f70e392636/src/declarations/stencil-public-compiler.ts#L1594-L1665
+```
 
-In the `copy` config within the `www` output target example below, the build will copy the entire directory from `src/images` over to `www/images`. In this example, since the `srcDir` property is not set, the default source directory is `src`.
+## Examples
+
+### Images in the `www` Output Target
+
+The `copy` config within the following [`www` output target](./www.md) config
+will cause Stencil to copy the entire directory from `src/images` to
+`www/images`:
 
 ```tsx
   outputTargets: [
@@ -27,10 +40,20 @@ In the `copy` config within the `www` output target example below, the build wil
   ]
 ```
 
+In this example, since the `srcDir` property is not set, the default source
+directory is `src/`, and since `dest` is not set the contents of `src/images`
+will be copied to a new `images` directory in `www`, the default destination
+directory for the `www` Output Target.
 
-### dest
 
-The config can also provide an optional `dest` property which can be either an absolute path, or a path relative to the build directory of that output target. In the example below, we've customized the build directory to be `public` instead of the default, which will copy `src/files/fonts` over to `public/static/web-fonts`.
+### Setting the `dest` option
+
+The `dest` property can also be optionally set on a `CopyTask` to either an
+absolute path or a path relative to the build directory of the output target.
+
+In this example we've customized the build directory to be `public` instead of
+the default (`'www'`), which, in combination with `dest: 'static/web-fonts'`
+will copy the contents of `src/files/fonts` over to `public/static/web-fonts`:
 
 ```tsx
   outputTargets: [
@@ -44,9 +67,23 @@ The config can also provide an optional `dest` property which can be either an a
   ]
 ```
 
-### warn
+:::note
+When `dest` is set on a `CopyTask` Stencil will, by default, copy all the contents
+of the `src` directory to the `dest` directory without creating a new
+subdirectory for the contents of `src`. The `keepDirStructure` option can
+control this behavior. If it's set to `true` Stencil will always create a
+new subdirectory within `dest` with the same name as the `src` directory. In the
+above example this would result in the contents of `src/files/fonts` being copied
+to `public/static/web-fonts/fonts` instead of `public/static/web-fonts`.
 
-By default, if a file or directory is not available it will not warn if the copy task cannot find it. To see the warnings if a copy task source cannot be found, please set `warn: true` with the copy config object.
+See the above documentation for the `keepDirStructure` option for more details.
+:::
+
+### Opting-in to warnings
+
+By default, Stencil will not log a warning if a file or directory specified in
+`src` cannot be located. To opt-in to warnings if a copy task source cannot be
+found, set `warn: true` in the `CopyTask` object, like so:
 
 ```tsx
   outputTargets: [

--- a/versioned_docs/version-v4.10/output-targets/copy-tasks.md
+++ b/versioned_docs/version-v4.10/output-targets/copy-tasks.md
@@ -8,13 +8,26 @@ slug: /copy-tasks
 
 # Copy Tasks for Output Targets
 
-Each output target can have its own `copy` config, which is an array of objects that defines any files or folders that should be copied over to the output target's build directory.
+All of Stencil's non-documentation output targets
+([`dist-custom-elements`](./custom-elements.md), [`dist`](./dist.md), and
+[`www`](./www.md)) support a `copy` config which allows you to define file copy
+operations which Stencil will automatically perform as part of the build. This
+could be useful if, for instance, you had some static assets like images which
+should be distributed alongside your components.
 
-### src
+The `copy` attribute on these output targets expects an array of objects corresponding to the following `CopyTask` interface:
 
-Each object in the array must include a `src` property which can be either an absolute path, a relative path from the `srcDir`, or a glob pattern. By default the item copied to the destination will take the same name as the source.
+```ts reference title="CopyTask"
+https://github.com/ionic-team/stencil/blob/6ed2d4e285544945949ad8e4802fe7f70e392636/src/declarations/stencil-public-compiler.ts#L1594-L1665
+```
 
-In the `copy` config within the `www` output target example below, the build will copy the entire directory from `src/images` over to `www/images`. In this example, since the `srcDir` property is not set, the default source directory is `src`.
+## Examples
+
+### Images in the `www` Output Target
+
+The `copy` config within the following [`www` output target](./www.md) config
+will cause Stencil to copy the entire directory from `src/images` to
+`www/images`:
 
 ```tsx
   outputTargets: [
@@ -27,10 +40,20 @@ In the `copy` config within the `www` output target example below, the build wil
   ]
 ```
 
+In this example, since the `srcDir` property is not set, the default source
+directory is `src/`, and since `dest` is not set the contents of `src/images`
+will be copied to a new `images` directory in `www`, the default destination
+directory for the `www` Output Target.
 
-### dest
 
-The config can also provide an optional `dest` property which can be either an absolute path, or a path relative to the build directory of that output target. In the example below, we've customized the build directory to be `public` instead of the default, which will copy `src/files/fonts` over to `public/static/web-fonts`.
+### Setting the `dest` option
+
+The `dest` property can also be optionally set on a `CopyTask` to either an
+absolute path or a path relative to the build directory of the output target.
+
+In this example we've customized the build directory to be `public` instead of
+the default (`'www'`), which, in combination with `dest: 'static/web-fonts'`
+will copy the contents of `src/files/fonts` over to `public/static/web-fonts`:
 
 ```tsx
   outputTargets: [
@@ -44,9 +67,23 @@ The config can also provide an optional `dest` property which can be either an a
   ]
 ```
 
-### warn
+:::note
+When `dest` is set on a `CopyTask` Stencil will, by default, copy all the contents
+of the `src` directory to the `dest` directory without creating a new
+subdirectory for the contents of `src`. The `keepDirStructure` option can
+control this behavior. If it's set to `true` Stencil will always create a
+new subdirectory within `dest` with the same name as the `src` directory. In the
+above example this would result in the contents of `src/files/fonts` being copied
+to `public/static/web-fonts/fonts` instead of `public/static/web-fonts`.
 
-By default, if a file or directory is not available it will not warn if the copy task cannot find it. To see the warnings if a copy task source cannot be found, please set `warn: true` with the copy config object.
+See the above documentation for the `keepDirStructure` option for more details.
+:::
+
+### Opting-in to warnings
+
+By default, Stencil will not log a warning if a file or directory specified in
+`src` cannot be located. To opt-in to warnings if a copy task source cannot be
+found, set `warn: true` in the `CopyTask` object, like so:
 
 ```tsx
   outputTargets: [

--- a/versioned_docs/version-v4.11/output-targets/copy-tasks.md
+++ b/versioned_docs/version-v4.11/output-targets/copy-tasks.md
@@ -8,13 +8,26 @@ slug: /copy-tasks
 
 # Copy Tasks for Output Targets
 
-Each output target can have its own `copy` config, which is an array of objects that defines any files or folders that should be copied over to the output target's build directory.
+All of Stencil's non-documentation output targets
+([`dist-custom-elements`](./custom-elements.md), [`dist`](./dist.md), and
+[`www`](./www.md)) support a `copy` config which allows you to define file copy
+operations which Stencil will automatically perform as part of the build. This
+could be useful if, for instance, you had some static assets like images which
+should be distributed alongside your components.
 
-### src
+The `copy` attribute on these output targets expects an array of objects corresponding to the following `CopyTask` interface:
 
-Each object in the array must include a `src` property which can be either an absolute path, a relative path from the `srcDir`, or a glob pattern. By default the item copied to the destination will take the same name as the source.
+```ts reference title="CopyTask"
+https://github.com/ionic-team/stencil/blob/6ed2d4e285544945949ad8e4802fe7f70e392636/src/declarations/stencil-public-compiler.ts#L1594-L1665
+```
 
-In the `copy` config within the `www` output target example below, the build will copy the entire directory from `src/images` over to `www/images`. In this example, since the `srcDir` property is not set, the default source directory is `src`.
+## Examples
+
+### Images in the `www` Output Target
+
+The `copy` config within the following [`www` output target](./www.md) config
+will cause Stencil to copy the entire directory from `src/images` to
+`www/images`:
 
 ```tsx
   outputTargets: [
@@ -27,10 +40,20 @@ In the `copy` config within the `www` output target example below, the build wil
   ]
 ```
 
+In this example, since the `srcDir` property is not set, the default source
+directory is `src/`, and since `dest` is not set the contents of `src/images`
+will be copied to a new `images` directory in `www`, the default destination
+directory for the `www` Output Target.
 
-### dest
 
-The config can also provide an optional `dest` property which can be either an absolute path, or a path relative to the build directory of that output target. In the example below, we've customized the build directory to be `public` instead of the default, which will copy `src/files/fonts` over to `public/static/web-fonts`.
+### Setting the `dest` option
+
+The `dest` property can also be optionally set on a `CopyTask` to either an
+absolute path or a path relative to the build directory of the output target.
+
+In this example we've customized the build directory to be `public` instead of
+the default (`'www'`), which, in combination with `dest: 'static/web-fonts'`
+will copy the contents of `src/files/fonts` over to `public/static/web-fonts`:
 
 ```tsx
   outputTargets: [
@@ -44,9 +67,23 @@ The config can also provide an optional `dest` property which can be either an a
   ]
 ```
 
-### warn
+:::note
+When `dest` is set on a `CopyTask` Stencil will, by default, copy all the contents
+of the `src` directory to the `dest` directory without creating a new
+subdirectory for the contents of `src`. The `keepDirStructure` option can
+control this behavior. If it's set to `true` Stencil will always create a
+new subdirectory within `dest` with the same name as the `src` directory. In the
+above example this would result in the contents of `src/files/fonts` being copied
+to `public/static/web-fonts/fonts` instead of `public/static/web-fonts`.
 
-By default, if a file or directory is not available it will not warn if the copy task cannot find it. To see the warnings if a copy task source cannot be found, please set `warn: true` with the copy config object.
+See the above documentation for the `keepDirStructure` option for more details.
+:::
+
+### Opting-in to warnings
+
+By default, Stencil will not log a warning if a file or directory specified in
+`src` cannot be located. To opt-in to warnings if a copy task source cannot be
+found, set `warn: true` in the `CopyTask` object, like so:
 
 ```tsx
   outputTargets: [

--- a/versioned_docs/version-v4.12/output-targets/copy-tasks.md
+++ b/versioned_docs/version-v4.12/output-targets/copy-tasks.md
@@ -8,13 +8,26 @@ slug: /copy-tasks
 
 # Copy Tasks for Output Targets
 
-Each output target can have its own `copy` config, which is an array of objects that defines any files or folders that should be copied over to the output target's build directory.
+All of Stencil's non-documentation output targets
+([`dist-custom-elements`](./custom-elements.md), [`dist`](./dist.md), and
+[`www`](./www.md)) support a `copy` config which allows you to define file copy
+operations which Stencil will automatically perform as part of the build. This
+could be useful if, for instance, you had some static assets like images which
+should be distributed alongside your components.
 
-### src
+The `copy` attribute on these output targets expects an array of objects corresponding to the following `CopyTask` interface:
 
-Each object in the array must include a `src` property which can be either an absolute path, a relative path from the `srcDir`, or a glob pattern. By default the item copied to the destination will take the same name as the source.
+```ts reference title="CopyTask"
+https://github.com/ionic-team/stencil/blob/6ed2d4e285544945949ad8e4802fe7f70e392636/src/declarations/stencil-public-compiler.ts#L1594-L1665
+```
 
-In the `copy` config within the `www` output target example below, the build will copy the entire directory from `src/images` over to `www/images`. In this example, since the `srcDir` property is not set, the default source directory is `src`.
+## Examples
+
+### Images in the `www` Output Target
+
+The `copy` config within the following [`www` output target](./www.md) config
+will cause Stencil to copy the entire directory from `src/images` to
+`www/images`:
 
 ```tsx
   outputTargets: [
@@ -27,10 +40,20 @@ In the `copy` config within the `www` output target example below, the build wil
   ]
 ```
 
+In this example, since the `srcDir` property is not set, the default source
+directory is `src/`, and since `dest` is not set the contents of `src/images`
+will be copied to a new `images` directory in `www`, the default destination
+directory for the `www` Output Target.
 
-### dest
 
-The config can also provide an optional `dest` property which can be either an absolute path, or a path relative to the build directory of that output target. In the example below, we've customized the build directory to be `public` instead of the default, which will copy `src/files/fonts` over to `public/static/web-fonts`.
+### Setting the `dest` option
+
+The `dest` property can also be optionally set on a `CopyTask` to either an
+absolute path or a path relative to the build directory of the output target.
+
+In this example we've customized the build directory to be `public` instead of
+the default (`'www'`), which, in combination with `dest: 'static/web-fonts'`
+will copy the contents of `src/files/fonts` over to `public/static/web-fonts`:
 
 ```tsx
   outputTargets: [
@@ -44,9 +67,23 @@ The config can also provide an optional `dest` property which can be either an a
   ]
 ```
 
-### warn
+:::note
+When `dest` is set on a `CopyTask` Stencil will, by default, copy all the contents
+of the `src` directory to the `dest` directory without creating a new
+subdirectory for the contents of `src`. The `keepDirStructure` option can
+control this behavior. If it's set to `true` Stencil will always create a
+new subdirectory within `dest` with the same name as the `src` directory. In the
+above example this would result in the contents of `src/files/fonts` being copied
+to `public/static/web-fonts/fonts` instead of `public/static/web-fonts`.
 
-By default, if a file or directory is not available it will not warn if the copy task cannot find it. To see the warnings if a copy task source cannot be found, please set `warn: true` with the copy config object.
+See the above documentation for the `keepDirStructure` option for more details.
+:::
+
+### Opting-in to warnings
+
+By default, Stencil will not log a warning if a file or directory specified in
+`src` cannot be located. To opt-in to warnings if a copy task source cannot be
+found, set `warn: true` in the `CopyTask` object, like so:
 
 ```tsx
   outputTargets: [

--- a/versioned_docs/version-v4.2/output-targets/copy-tasks.md
+++ b/versioned_docs/version-v4.2/output-targets/copy-tasks.md
@@ -8,13 +8,26 @@ slug: /copy-tasks
 
 # Copy Tasks for Output Targets
 
-Each output target can have its own `copy` config, which is an array of objects that defines any files or folders that should be copied over to the output target's build directory.
+All of Stencil's non-documentation output targets
+([`dist-custom-elements`](./custom-elements.md), [`dist`](./dist.md), and
+[`www`](./www.md)) support a `copy` config which allows you to define file copy
+operations which Stencil will automatically perform as part of the build. This
+could be useful if, for instance, you had some static assets like images which
+should be distributed alongside your components.
 
-### src
+The `copy` attribute on these output targets expects an array of objects corresponding to the following `CopyTask` interface:
 
-Each object in the array must include a `src` property which can be either an absolute path, a relative path from the `srcDir`, or a glob pattern. By default the item copied to the destination will take the same name as the source.
+```ts reference title="CopyTask"
+https://github.com/ionic-team/stencil/blob/6ed2d4e285544945949ad8e4802fe7f70e392636/src/declarations/stencil-public-compiler.ts#L1594-L1665
+```
 
-In the `copy` config within the `www` output target example below, the build will copy the entire directory from `src/images` over to `www/images`. In this example, since the `srcDir` property is not set, the default source directory is `src`.
+## Examples
+
+### Images in the `www` Output Target
+
+The `copy` config within the following [`www` output target](./www.md) config
+will cause Stencil to copy the entire directory from `src/images` to
+`www/images`:
 
 ```tsx
   outputTargets: [
@@ -27,10 +40,20 @@ In the `copy` config within the `www` output target example below, the build wil
   ]
 ```
 
+In this example, since the `srcDir` property is not set, the default source
+directory is `src/`, and since `dest` is not set the contents of `src/images`
+will be copied to a new `images` directory in `www`, the default destination
+directory for the `www` Output Target.
 
-### dest
 
-The config can also provide an optional `dest` property which can be either an absolute path, or a path relative to the build directory of that output target. In the example below, we've customized the build directory to be `public` instead of the default, which will copy `src/files/fonts` over to `public/static/web-fonts`.
+### Setting the `dest` option
+
+The `dest` property can also be optionally set on a `CopyTask` to either an
+absolute path or a path relative to the build directory of the output target.
+
+In this example we've customized the build directory to be `public` instead of
+the default (`'www'`), which, in combination with `dest: 'static/web-fonts'`
+will copy the contents of `src/files/fonts` over to `public/static/web-fonts`:
 
 ```tsx
   outputTargets: [
@@ -44,9 +67,23 @@ The config can also provide an optional `dest` property which can be either an a
   ]
 ```
 
-### warn
+:::note
+When `dest` is set on a `CopyTask` Stencil will, by default, copy all the contents
+of the `src` directory to the `dest` directory without creating a new
+subdirectory for the contents of `src`. The `keepDirStructure` option can
+control this behavior. If it's set to `true` Stencil will always create a
+new subdirectory within `dest` with the same name as the `src` directory. In the
+above example this would result in the contents of `src/files/fonts` being copied
+to `public/static/web-fonts/fonts` instead of `public/static/web-fonts`.
 
-By default, if a file or directory is not available it will not warn if the copy task cannot find it. To see the warnings if a copy task source cannot be found, please set `warn: true` with the copy config object.
+See the above documentation for the `keepDirStructure` option for more details.
+:::
+
+### Opting-in to warnings
+
+By default, Stencil will not log a warning if a file or directory specified in
+`src` cannot be located. To opt-in to warnings if a copy task source cannot be
+found, set `warn: true` in the `CopyTask` object, like so:
 
 ```tsx
   outputTargets: [

--- a/versioned_docs/version-v4.3/output-targets/copy-tasks.md
+++ b/versioned_docs/version-v4.3/output-targets/copy-tasks.md
@@ -8,13 +8,26 @@ slug: /copy-tasks
 
 # Copy Tasks for Output Targets
 
-Each output target can have its own `copy` config, which is an array of objects that defines any files or folders that should be copied over to the output target's build directory.
+All of Stencil's non-documentation output targets
+([`dist-custom-elements`](./custom-elements.md), [`dist`](./dist.md), and
+[`www`](./www.md)) support a `copy` config which allows you to define file copy
+operations which Stencil will automatically perform as part of the build. This
+could be useful if, for instance, you had some static assets like images which
+should be distributed alongside your components.
 
-### src
+The `copy` attribute on these output targets expects an array of objects corresponding to the following `CopyTask` interface:
 
-Each object in the array must include a `src` property which can be either an absolute path, a relative path from the `srcDir`, or a glob pattern. By default the item copied to the destination will take the same name as the source.
+```ts reference title="CopyTask"
+https://github.com/ionic-team/stencil/blob/6ed2d4e285544945949ad8e4802fe7f70e392636/src/declarations/stencil-public-compiler.ts#L1594-L1665
+```
 
-In the `copy` config within the `www` output target example below, the build will copy the entire directory from `src/images` over to `www/images`. In this example, since the `srcDir` property is not set, the default source directory is `src`.
+## Examples
+
+### Images in the `www` Output Target
+
+The `copy` config within the following [`www` output target](./www.md) config
+will cause Stencil to copy the entire directory from `src/images` to
+`www/images`:
 
 ```tsx
   outputTargets: [
@@ -27,10 +40,20 @@ In the `copy` config within the `www` output target example below, the build wil
   ]
 ```
 
+In this example, since the `srcDir` property is not set, the default source
+directory is `src/`, and since `dest` is not set the contents of `src/images`
+will be copied to a new `images` directory in `www`, the default destination
+directory for the `www` Output Target.
 
-### dest
 
-The config can also provide an optional `dest` property which can be either an absolute path, or a path relative to the build directory of that output target. In the example below, we've customized the build directory to be `public` instead of the default, which will copy `src/files/fonts` over to `public/static/web-fonts`.
+### Setting the `dest` option
+
+The `dest` property can also be optionally set on a `CopyTask` to either an
+absolute path or a path relative to the build directory of the output target.
+
+In this example we've customized the build directory to be `public` instead of
+the default (`'www'`), which, in combination with `dest: 'static/web-fonts'`
+will copy the contents of `src/files/fonts` over to `public/static/web-fonts`:
 
 ```tsx
   outputTargets: [
@@ -44,9 +67,23 @@ The config can also provide an optional `dest` property which can be either an a
   ]
 ```
 
-### warn
+:::note
+When `dest` is set on a `CopyTask` Stencil will, by default, copy all the contents
+of the `src` directory to the `dest` directory without creating a new
+subdirectory for the contents of `src`. The `keepDirStructure` option can
+control this behavior. If it's set to `true` Stencil will always create a
+new subdirectory within `dest` with the same name as the `src` directory. In the
+above example this would result in the contents of `src/files/fonts` being copied
+to `public/static/web-fonts/fonts` instead of `public/static/web-fonts`.
 
-By default, if a file or directory is not available it will not warn if the copy task cannot find it. To see the warnings if a copy task source cannot be found, please set `warn: true` with the copy config object.
+See the above documentation for the `keepDirStructure` option for more details.
+:::
+
+### Opting-in to warnings
+
+By default, Stencil will not log a warning if a file or directory specified in
+`src` cannot be located. To opt-in to warnings if a copy task source cannot be
+found, set `warn: true` in the `CopyTask` object, like so:
 
 ```tsx
   outputTargets: [

--- a/versioned_docs/version-v4.4/output-targets/copy-tasks.md
+++ b/versioned_docs/version-v4.4/output-targets/copy-tasks.md
@@ -8,13 +8,26 @@ slug: /copy-tasks
 
 # Copy Tasks for Output Targets
 
-Each output target can have its own `copy` config, which is an array of objects that defines any files or folders that should be copied over to the output target's build directory.
+All of Stencil's non-documentation output targets
+([`dist-custom-elements`](./custom-elements.md), [`dist`](./dist.md), and
+[`www`](./www.md)) support a `copy` config which allows you to define file copy
+operations which Stencil will automatically perform as part of the build. This
+could be useful if, for instance, you had some static assets like images which
+should be distributed alongside your components.
 
-### src
+The `copy` attribute on these output targets expects an array of objects corresponding to the following `CopyTask` interface:
 
-Each object in the array must include a `src` property which can be either an absolute path, a relative path from the `srcDir`, or a glob pattern. By default the item copied to the destination will take the same name as the source.
+```ts reference title="CopyTask"
+https://github.com/ionic-team/stencil/blob/6ed2d4e285544945949ad8e4802fe7f70e392636/src/declarations/stencil-public-compiler.ts#L1594-L1665
+```
 
-In the `copy` config within the `www` output target example below, the build will copy the entire directory from `src/images` over to `www/images`. In this example, since the `srcDir` property is not set, the default source directory is `src`.
+## Examples
+
+### Images in the `www` Output Target
+
+The `copy` config within the following [`www` output target](./www.md) config
+will cause Stencil to copy the entire directory from `src/images` to
+`www/images`:
 
 ```tsx
   outputTargets: [
@@ -27,10 +40,20 @@ In the `copy` config within the `www` output target example below, the build wil
   ]
 ```
 
+In this example, since the `srcDir` property is not set, the default source
+directory is `src/`, and since `dest` is not set the contents of `src/images`
+will be copied to a new `images` directory in `www`, the default destination
+directory for the `www` Output Target.
 
-### dest
 
-The config can also provide an optional `dest` property which can be either an absolute path, or a path relative to the build directory of that output target. In the example below, we've customized the build directory to be `public` instead of the default, which will copy `src/files/fonts` over to `public/static/web-fonts`.
+### Setting the `dest` option
+
+The `dest` property can also be optionally set on a `CopyTask` to either an
+absolute path or a path relative to the build directory of the output target.
+
+In this example we've customized the build directory to be `public` instead of
+the default (`'www'`), which, in combination with `dest: 'static/web-fonts'`
+will copy the contents of `src/files/fonts` over to `public/static/web-fonts`:
 
 ```tsx
   outputTargets: [
@@ -44,9 +67,23 @@ The config can also provide an optional `dest` property which can be either an a
   ]
 ```
 
-### warn
+:::note
+When `dest` is set on a `CopyTask` Stencil will, by default, copy all the contents
+of the `src` directory to the `dest` directory without creating a new
+subdirectory for the contents of `src`. The `keepDirStructure` option can
+control this behavior. If it's set to `true` Stencil will always create a
+new subdirectory within `dest` with the same name as the `src` directory. In the
+above example this would result in the contents of `src/files/fonts` being copied
+to `public/static/web-fonts/fonts` instead of `public/static/web-fonts`.
 
-By default, if a file or directory is not available it will not warn if the copy task cannot find it. To see the warnings if a copy task source cannot be found, please set `warn: true` with the copy config object.
+See the above documentation for the `keepDirStructure` option for more details.
+:::
+
+### Opting-in to warnings
+
+By default, Stencil will not log a warning if a file or directory specified in
+`src` cannot be located. To opt-in to warnings if a copy task source cannot be
+found, set `warn: true` in the `CopyTask` object, like so:
 
 ```tsx
   outputTargets: [

--- a/versioned_docs/version-v4.5/output-targets/copy-tasks.md
+++ b/versioned_docs/version-v4.5/output-targets/copy-tasks.md
@@ -8,13 +8,26 @@ slug: /copy-tasks
 
 # Copy Tasks for Output Targets
 
-Each output target can have its own `copy` config, which is an array of objects that defines any files or folders that should be copied over to the output target's build directory.
+All of Stencil's non-documentation output targets
+([`dist-custom-elements`](./custom-elements.md), [`dist`](./dist.md), and
+[`www`](./www.md)) support a `copy` config which allows you to define file copy
+operations which Stencil will automatically perform as part of the build. This
+could be useful if, for instance, you had some static assets like images which
+should be distributed alongside your components.
 
-### src
+The `copy` attribute on these output targets expects an array of objects corresponding to the following `CopyTask` interface:
 
-Each object in the array must include a `src` property which can be either an absolute path, a relative path from the `srcDir`, or a glob pattern. By default the item copied to the destination will take the same name as the source.
+```ts reference title="CopyTask"
+https://github.com/ionic-team/stencil/blob/6ed2d4e285544945949ad8e4802fe7f70e392636/src/declarations/stencil-public-compiler.ts#L1594-L1665
+```
 
-In the `copy` config within the `www` output target example below, the build will copy the entire directory from `src/images` over to `www/images`. In this example, since the `srcDir` property is not set, the default source directory is `src`.
+## Examples
+
+### Images in the `www` Output Target
+
+The `copy` config within the following [`www` output target](./www.md) config
+will cause Stencil to copy the entire directory from `src/images` to
+`www/images`:
 
 ```tsx
   outputTargets: [
@@ -27,10 +40,20 @@ In the `copy` config within the `www` output target example below, the build wil
   ]
 ```
 
+In this example, since the `srcDir` property is not set, the default source
+directory is `src/`, and since `dest` is not set the contents of `src/images`
+will be copied to a new `images` directory in `www`, the default destination
+directory for the `www` Output Target.
 
-### dest
 
-The config can also provide an optional `dest` property which can be either an absolute path, or a path relative to the build directory of that output target. In the example below, we've customized the build directory to be `public` instead of the default, which will copy `src/files/fonts` over to `public/static/web-fonts`.
+### Setting the `dest` option
+
+The `dest` property can also be optionally set on a `CopyTask` to either an
+absolute path or a path relative to the build directory of the output target.
+
+In this example we've customized the build directory to be `public` instead of
+the default (`'www'`), which, in combination with `dest: 'static/web-fonts'`
+will copy the contents of `src/files/fonts` over to `public/static/web-fonts`:
 
 ```tsx
   outputTargets: [
@@ -44,9 +67,23 @@ The config can also provide an optional `dest` property which can be either an a
   ]
 ```
 
-### warn
+:::note
+When `dest` is set on a `CopyTask` Stencil will, by default, copy all the contents
+of the `src` directory to the `dest` directory without creating a new
+subdirectory for the contents of `src`. The `keepDirStructure` option can
+control this behavior. If it's set to `true` Stencil will always create a
+new subdirectory within `dest` with the same name as the `src` directory. In the
+above example this would result in the contents of `src/files/fonts` being copied
+to `public/static/web-fonts/fonts` instead of `public/static/web-fonts`.
 
-By default, if a file or directory is not available it will not warn if the copy task cannot find it. To see the warnings if a copy task source cannot be found, please set `warn: true` with the copy config object.
+See the above documentation for the `keepDirStructure` option for more details.
+:::
+
+### Opting-in to warnings
+
+By default, Stencil will not log a warning if a file or directory specified in
+`src` cannot be located. To opt-in to warnings if a copy task source cannot be
+found, set `warn: true` in the `CopyTask` object, like so:
 
 ```tsx
   outputTargets: [

--- a/versioned_docs/version-v4.6/output-targets/copy-tasks.md
+++ b/versioned_docs/version-v4.6/output-targets/copy-tasks.md
@@ -8,13 +8,26 @@ slug: /copy-tasks
 
 # Copy Tasks for Output Targets
 
-Each output target can have its own `copy` config, which is an array of objects that defines any files or folders that should be copied over to the output target's build directory.
+All of Stencil's non-documentation output targets
+([`dist-custom-elements`](./custom-elements.md), [`dist`](./dist.md), and
+[`www`](./www.md)) support a `copy` config which allows you to define file copy
+operations which Stencil will automatically perform as part of the build. This
+could be useful if, for instance, you had some static assets like images which
+should be distributed alongside your components.
 
-### src
+The `copy` attribute on these output targets expects an array of objects corresponding to the following `CopyTask` interface:
 
-Each object in the array must include a `src` property which can be either an absolute path, a relative path from the `srcDir`, or a glob pattern. By default the item copied to the destination will take the same name as the source.
+```ts reference title="CopyTask"
+https://github.com/ionic-team/stencil/blob/6ed2d4e285544945949ad8e4802fe7f70e392636/src/declarations/stencil-public-compiler.ts#L1594-L1665
+```
 
-In the `copy` config within the `www` output target example below, the build will copy the entire directory from `src/images` over to `www/images`. In this example, since the `srcDir` property is not set, the default source directory is `src`.
+## Examples
+
+### Images in the `www` Output Target
+
+The `copy` config within the following [`www` output target](./www.md) config
+will cause Stencil to copy the entire directory from `src/images` to
+`www/images`:
 
 ```tsx
   outputTargets: [
@@ -27,10 +40,20 @@ In the `copy` config within the `www` output target example below, the build wil
   ]
 ```
 
+In this example, since the `srcDir` property is not set, the default source
+directory is `src/`, and since `dest` is not set the contents of `src/images`
+will be copied to a new `images` directory in `www`, the default destination
+directory for the `www` Output Target.
 
-### dest
 
-The config can also provide an optional `dest` property which can be either an absolute path, or a path relative to the build directory of that output target. In the example below, we've customized the build directory to be `public` instead of the default, which will copy `src/files/fonts` over to `public/static/web-fonts`.
+### Setting the `dest` option
+
+The `dest` property can also be optionally set on a `CopyTask` to either an
+absolute path or a path relative to the build directory of the output target.
+
+In this example we've customized the build directory to be `public` instead of
+the default (`'www'`), which, in combination with `dest: 'static/web-fonts'`
+will copy the contents of `src/files/fonts` over to `public/static/web-fonts`:
 
 ```tsx
   outputTargets: [
@@ -44,9 +67,23 @@ The config can also provide an optional `dest` property which can be either an a
   ]
 ```
 
-### warn
+:::note
+When `dest` is set on a `CopyTask` Stencil will, by default, copy all the contents
+of the `src` directory to the `dest` directory without creating a new
+subdirectory for the contents of `src`. The `keepDirStructure` option can
+control this behavior. If it's set to `true` Stencil will always create a
+new subdirectory within `dest` with the same name as the `src` directory. In the
+above example this would result in the contents of `src/files/fonts` being copied
+to `public/static/web-fonts/fonts` instead of `public/static/web-fonts`.
 
-By default, if a file or directory is not available it will not warn if the copy task cannot find it. To see the warnings if a copy task source cannot be found, please set `warn: true` with the copy config object.
+See the above documentation for the `keepDirStructure` option for more details.
+:::
+
+### Opting-in to warnings
+
+By default, Stencil will not log a warning if a file or directory specified in
+`src` cannot be located. To opt-in to warnings if a copy task source cannot be
+found, set `warn: true` in the `CopyTask` object, like so:
 
 ```tsx
   outputTargets: [

--- a/versioned_docs/version-v4.7/output-targets/copy-tasks.md
+++ b/versioned_docs/version-v4.7/output-targets/copy-tasks.md
@@ -8,13 +8,26 @@ slug: /copy-tasks
 
 # Copy Tasks for Output Targets
 
-Each output target can have its own `copy` config, which is an array of objects that defines any files or folders that should be copied over to the output target's build directory.
+All of Stencil's non-documentation output targets
+([`dist-custom-elements`](./custom-elements.md), [`dist`](./dist.md), and
+[`www`](./www.md)) support a `copy` config which allows you to define file copy
+operations which Stencil will automatically perform as part of the build. This
+could be useful if, for instance, you had some static assets like images which
+should be distributed alongside your components.
 
-### src
+The `copy` attribute on these output targets expects an array of objects corresponding to the following `CopyTask` interface:
 
-Each object in the array must include a `src` property which can be either an absolute path, a relative path from the `srcDir`, or a glob pattern. By default the item copied to the destination will take the same name as the source.
+```ts reference title="CopyTask"
+https://github.com/ionic-team/stencil/blob/6ed2d4e285544945949ad8e4802fe7f70e392636/src/declarations/stencil-public-compiler.ts#L1594-L1665
+```
 
-In the `copy` config within the `www` output target example below, the build will copy the entire directory from `src/images` over to `www/images`. In this example, since the `srcDir` property is not set, the default source directory is `src`.
+## Examples
+
+### Images in the `www` Output Target
+
+The `copy` config within the following [`www` output target](./www.md) config
+will cause Stencil to copy the entire directory from `src/images` to
+`www/images`:
 
 ```tsx
   outputTargets: [
@@ -27,10 +40,20 @@ In the `copy` config within the `www` output target example below, the build wil
   ]
 ```
 
+In this example, since the `srcDir` property is not set, the default source
+directory is `src/`, and since `dest` is not set the contents of `src/images`
+will be copied to a new `images` directory in `www`, the default destination
+directory for the `www` Output Target.
 
-### dest
 
-The config can also provide an optional `dest` property which can be either an absolute path, or a path relative to the build directory of that output target. In the example below, we've customized the build directory to be `public` instead of the default, which will copy `src/files/fonts` over to `public/static/web-fonts`.
+### Setting the `dest` option
+
+The `dest` property can also be optionally set on a `CopyTask` to either an
+absolute path or a path relative to the build directory of the output target.
+
+In this example we've customized the build directory to be `public` instead of
+the default (`'www'`), which, in combination with `dest: 'static/web-fonts'`
+will copy the contents of `src/files/fonts` over to `public/static/web-fonts`:
 
 ```tsx
   outputTargets: [
@@ -44,9 +67,23 @@ The config can also provide an optional `dest` property which can be either an a
   ]
 ```
 
-### warn
+:::note
+When `dest` is set on a `CopyTask` Stencil will, by default, copy all the contents
+of the `src` directory to the `dest` directory without creating a new
+subdirectory for the contents of `src`. The `keepDirStructure` option can
+control this behavior. If it's set to `true` Stencil will always create a
+new subdirectory within `dest` with the same name as the `src` directory. In the
+above example this would result in the contents of `src/files/fonts` being copied
+to `public/static/web-fonts/fonts` instead of `public/static/web-fonts`.
 
-By default, if a file or directory is not available it will not warn if the copy task cannot find it. To see the warnings if a copy task source cannot be found, please set `warn: true` with the copy config object.
+See the above documentation for the `keepDirStructure` option for more details.
+:::
+
+### Opting-in to warnings
+
+By default, Stencil will not log a warning if a file or directory specified in
+`src` cannot be located. To opt-in to warnings if a copy task source cannot be
+found, set `warn: true` in the `CopyTask` object, like so:
 
 ```tsx
   outputTargets: [

--- a/versioned_docs/version-v4.8/output-targets/copy-tasks.md
+++ b/versioned_docs/version-v4.8/output-targets/copy-tasks.md
@@ -8,13 +8,26 @@ slug: /copy-tasks
 
 # Copy Tasks for Output Targets
 
-Each output target can have its own `copy` config, which is an array of objects that defines any files or folders that should be copied over to the output target's build directory.
+All of Stencil's non-documentation output targets
+([`dist-custom-elements`](./custom-elements.md), [`dist`](./dist.md), and
+[`www`](./www.md)) support a `copy` config which allows you to define file copy
+operations which Stencil will automatically perform as part of the build. This
+could be useful if, for instance, you had some static assets like images which
+should be distributed alongside your components.
 
-### src
+The `copy` attribute on these output targets expects an array of objects corresponding to the following `CopyTask` interface:
 
-Each object in the array must include a `src` property which can be either an absolute path, a relative path from the `srcDir`, or a glob pattern. By default the item copied to the destination will take the same name as the source.
+```ts reference title="CopyTask"
+https://github.com/ionic-team/stencil/blob/6ed2d4e285544945949ad8e4802fe7f70e392636/src/declarations/stencil-public-compiler.ts#L1594-L1665
+```
 
-In the `copy` config within the `www` output target example below, the build will copy the entire directory from `src/images` over to `www/images`. In this example, since the `srcDir` property is not set, the default source directory is `src`.
+## Examples
+
+### Images in the `www` Output Target
+
+The `copy` config within the following [`www` output target](./www.md) config
+will cause Stencil to copy the entire directory from `src/images` to
+`www/images`:
 
 ```tsx
   outputTargets: [
@@ -27,10 +40,20 @@ In the `copy` config within the `www` output target example below, the build wil
   ]
 ```
 
+In this example, since the `srcDir` property is not set, the default source
+directory is `src/`, and since `dest` is not set the contents of `src/images`
+will be copied to a new `images` directory in `www`, the default destination
+directory for the `www` Output Target.
 
-### dest
 
-The config can also provide an optional `dest` property which can be either an absolute path, or a path relative to the build directory of that output target. In the example below, we've customized the build directory to be `public` instead of the default, which will copy `src/files/fonts` over to `public/static/web-fonts`.
+### Setting the `dest` option
+
+The `dest` property can also be optionally set on a `CopyTask` to either an
+absolute path or a path relative to the build directory of the output target.
+
+In this example we've customized the build directory to be `public` instead of
+the default (`'www'`), which, in combination with `dest: 'static/web-fonts'`
+will copy the contents of `src/files/fonts` over to `public/static/web-fonts`:
 
 ```tsx
   outputTargets: [
@@ -44,9 +67,23 @@ The config can also provide an optional `dest` property which can be either an a
   ]
 ```
 
-### warn
+:::note
+When `dest` is set on a `CopyTask` Stencil will, by default, copy all the contents
+of the `src` directory to the `dest` directory without creating a new
+subdirectory for the contents of `src`. The `keepDirStructure` option can
+control this behavior. If it's set to `true` Stencil will always create a
+new subdirectory within `dest` with the same name as the `src` directory. In the
+above example this would result in the contents of `src/files/fonts` being copied
+to `public/static/web-fonts/fonts` instead of `public/static/web-fonts`.
 
-By default, if a file or directory is not available it will not warn if the copy task cannot find it. To see the warnings if a copy task source cannot be found, please set `warn: true` with the copy config object.
+See the above documentation for the `keepDirStructure` option for more details.
+:::
+
+### Opting-in to warnings
+
+By default, Stencil will not log a warning if a file or directory specified in
+`src` cannot be located. To opt-in to warnings if a copy task source cannot be
+found, set `warn: true` in the `CopyTask` object, like so:
 
 ```tsx
   outputTargets: [

--- a/versioned_docs/version-v4.9/output-targets/copy-tasks.md
+++ b/versioned_docs/version-v4.9/output-targets/copy-tasks.md
@@ -8,13 +8,26 @@ slug: /copy-tasks
 
 # Copy Tasks for Output Targets
 
-Each output target can have its own `copy` config, which is an array of objects that defines any files or folders that should be copied over to the output target's build directory.
+All of Stencil's non-documentation output targets
+([`dist-custom-elements`](./custom-elements.md), [`dist`](./dist.md), and
+[`www`](./www.md)) support a `copy` config which allows you to define file copy
+operations which Stencil will automatically perform as part of the build. This
+could be useful if, for instance, you had some static assets like images which
+should be distributed alongside your components.
 
-### src
+The `copy` attribute on these output targets expects an array of objects corresponding to the following `CopyTask` interface:
 
-Each object in the array must include a `src` property which can be either an absolute path, a relative path from the `srcDir`, or a glob pattern. By default the item copied to the destination will take the same name as the source.
+```ts reference title="CopyTask"
+https://github.com/ionic-team/stencil/blob/6ed2d4e285544945949ad8e4802fe7f70e392636/src/declarations/stencil-public-compiler.ts#L1594-L1665
+```
 
-In the `copy` config within the `www` output target example below, the build will copy the entire directory from `src/images` over to `www/images`. In this example, since the `srcDir` property is not set, the default source directory is `src`.
+## Examples
+
+### Images in the `www` Output Target
+
+The `copy` config within the following [`www` output target](./www.md) config
+will cause Stencil to copy the entire directory from `src/images` to
+`www/images`:
 
 ```tsx
   outputTargets: [
@@ -27,10 +40,20 @@ In the `copy` config within the `www` output target example below, the build wil
   ]
 ```
 
+In this example, since the `srcDir` property is not set, the default source
+directory is `src/`, and since `dest` is not set the contents of `src/images`
+will be copied to a new `images` directory in `www`, the default destination
+directory for the `www` Output Target.
 
-### dest
 
-The config can also provide an optional `dest` property which can be either an absolute path, or a path relative to the build directory of that output target. In the example below, we've customized the build directory to be `public` instead of the default, which will copy `src/files/fonts` over to `public/static/web-fonts`.
+### Setting the `dest` option
+
+The `dest` property can also be optionally set on a `CopyTask` to either an
+absolute path or a path relative to the build directory of the output target.
+
+In this example we've customized the build directory to be `public` instead of
+the default (`'www'`), which, in combination with `dest: 'static/web-fonts'`
+will copy the contents of `src/files/fonts` over to `public/static/web-fonts`:
 
 ```tsx
   outputTargets: [
@@ -44,9 +67,23 @@ The config can also provide an optional `dest` property which can be either an a
   ]
 ```
 
-### warn
+:::note
+When `dest` is set on a `CopyTask` Stencil will, by default, copy all the contents
+of the `src` directory to the `dest` directory without creating a new
+subdirectory for the contents of `src`. The `keepDirStructure` option can
+control this behavior. If it's set to `true` Stencil will always create a
+new subdirectory within `dest` with the same name as the `src` directory. In the
+above example this would result in the contents of `src/files/fonts` being copied
+to `public/static/web-fonts/fonts` instead of `public/static/web-fonts`.
 
-By default, if a file or directory is not available it will not warn if the copy task cannot find it. To see the warnings if a copy task source cannot be found, please set `warn: true` with the copy config object.
+See the above documentation for the `keepDirStructure` option for more details.
+:::
+
+### Opting-in to warnings
+
+By default, Stencil will not log a warning if a file or directory specified in
+`src` cannot be located. To opt-in to warnings if a copy task source cannot be
+found, set `warn: true` in the `CopyTask` object, like so:
 
 ```tsx
   outputTargets: [


### PR DESCRIPTION
This updates the documentation for the `copy` configuration that can be made on the `www`, `dist-custom-elements`, and `dist` output targets. This was motivated by wanting to clarify that this option is not supported on the documentation-related output targets (e.g. `docs-json`).

A change was recently made in Stencil to document the related interface, which we can take advantage of here:
https://github.com/ionic-team/stencil/pull/5413

fixes #852
STENCIl-1047