### PR TITLE
chore(cli): clarify --no-build-flag

### DIFF
--- a/docs/config/cli.md
+++ b/docs/config/cli.md
@@ -96,7 +96,7 @@ Tests a Stencil project. The flags below are the available options for the `test
 |------|-------------|
 | `--spec` | Tests `.spec.ts` files using [Jest](https://jestjs.io/). |
 | `--e2e` | Tests `.e2e.ts` files using [Puppeteer](https://developers.google.com/web/tools/puppeteer) and [Jest](https://jestjs.io/). |
-| `--no-build` | Skips build process before running the tests. (You are expected to have built it beforehand). |
+| `--no-build` | Skips the build process before running end-to-end tests. When using this flag, it is assumed that your Stencil project has been built prior to running `stencil test`. Unit tests do not require this flag. |
 | `--devtools` | Opens the dev tools panel in Chrome for end-to-end tests. Setting this flag will disable `--headless` |
 | `--headless` | Sets the headless mode to use in Chrome for end-to-end tests. `--headless` and `--headless=true` will enable the "old" headless mode in Chrome, that was used by default prior to Chrome v112. `--headless=new` will enable the new headless mode introduced in Chrome v112. See [this article](https://developer.chrome.com/articles/new-headless/) for more information on Chrome's new headless mode. |
 

--- a/versioned_docs/version-v4.1/config/cli.md
+++ b/versioned_docs/version-v4.1/config/cli.md
@@ -96,7 +96,7 @@ Tests a Stencil project. The flags below are the available options for the `test
 |------|-------------|
 | `--spec` | Tests `.spec.ts` files using [Jest](https://jestjs.io/). |
 | `--e2e` | Tests `.e2e.ts` files using [Puppeteer](https://developers.google.com/web/tools/puppeteer) and [Jest](https://jestjs.io/). |
-| `--no-build` | Skips build process before running the tests. (You are expected to have built it beforehand). |
+| `--no-build` | Skips the build process before running end-to-end tests. When using this flag, it is assumed that your Stencil project has been built prior to running `stencil test`. Unit tests do not require this flag. |
 | `--devtools` | Opens the dev tools panel in Chrome for end-to-end tests. Setting this flag will disable `--headless` |
 | `--headless` | Sets the headless mode to use in Chrome for end-to-end tests. `--headless` and `--headless=true` will enable the "old" headless mode in Chrome, that was used by default prior to Chrome v112. `--headless=new` will enable the new headless mode introduced in Chrome v112. See [this article](https://developer.chrome.com/articles/new-headless/) for more information on Chrome's new headless mode. |
 

--- a/versioned_docs/version-v4.10/config/cli.md
+++ b/versioned_docs/version-v4.10/config/cli.md
@@ -96,7 +96,7 @@ Tests a Stencil project. The flags below are the available options for the `test
 |------|-------------|
 | `--spec` | Tests `.spec.ts` files using [Jest](https://jestjs.io/). |
 | `--e2e` | Tests `.e2e.ts` files using [Puppeteer](https://developers.google.com/web/tools/puppeteer) and [Jest](https://jestjs.io/). |
-| `--no-build` | Skips build process before running the tests. (You are expected to have built it beforehand). |
+| `--no-build` | Skips the build process before running end-to-end tests. When using this flag, it is assumed that your Stencil project has been built prior to running `stencil test`. Unit tests do not require this flag. |
 | `--devtools` | Opens the dev tools panel in Chrome for end-to-end tests. Setting this flag will disable `--headless` |
 | `--headless` | Sets the headless mode to use in Chrome for end-to-end tests. `--headless` and `--headless=true` will enable the "old" headless mode in Chrome, that was used by default prior to Chrome v112. `--headless=new` will enable the new headless mode introduced in Chrome v112. See [this article](https://developer.chrome.com/articles/new-headless/) for more information on Chrome's new headless mode. |
 

--- a/versioned_docs/version-v4.11/config/cli.md
+++ b/versioned_docs/version-v4.11/config/cli.md
@@ -96,7 +96,7 @@ Tests a Stencil project. The flags below are the available options for the `test
 |------|-------------|
 | `--spec` | Tests `.spec.ts` files using [Jest](https://jestjs.io/). |
 | `--e2e` | Tests `.e2e.ts` files using [Puppeteer](https://developers.google.com/web/tools/puppeteer) and [Jest](https://jestjs.io/). |
-| `--no-build` | Skips build process before running the tests. (You are expected to have built it beforehand). |
+| `--no-build` | Skips the build process before running end-to-end tests. When using this flag, it is assumed that your Stencil project has been built prior to running `stencil test`. Unit tests do not require this flag. |
 | `--devtools` | Opens the dev tools panel in Chrome for end-to-end tests. Setting this flag will disable `--headless` |
 | `--headless` | Sets the headless mode to use in Chrome for end-to-end tests. `--headless` and `--headless=true` will enable the "old" headless mode in Chrome, that was used by default prior to Chrome v112. `--headless=new` will enable the new headless mode introduced in Chrome v112. See [this article](https://developer.chrome.com/articles/new-headless/) for more information on Chrome's new headless mode. |
 

--- a/versioned_docs/version-v4.12/config/cli.md
+++ b/versioned_docs/version-v4.12/config/cli.md
@@ -96,7 +96,7 @@ Tests a Stencil project. The flags below are the available options for the `test
 |------|-------------|
 | `--spec` | Tests `.spec.ts` files using [Jest](https://jestjs.io/). |
 | `--e2e` | Tests `.e2e.ts` files using [Puppeteer](https://developers.google.com/web/tools/puppeteer) and [Jest](https://jestjs.io/). |
-| `--no-build` | Skips build process before running the tests. (You are expected to have built it beforehand). |
+| `--no-build` | Skips the build process before running end-to-end tests. When using this flag, it is assumed that your Stencil project has been built prior to running `stencil test`. Unit tests do not require this flag. |
 | `--devtools` | Opens the dev tools panel in Chrome for end-to-end tests. Setting this flag will disable `--headless` |
 | `--headless` | Sets the headless mode to use in Chrome for end-to-end tests. `--headless` and `--headless=true` will enable the "old" headless mode in Chrome, that was used by default prior to Chrome v112. `--headless=new` will enable the new headless mode introduced in Chrome v112. See [this article](https://developer.chrome.com/articles/new-headless/) for more information on Chrome's new headless mode. |
 

--- a/versioned_docs/version-v4.2/config/cli.md
+++ b/versioned_docs/version-v4.2/config/cli.md
@@ -96,7 +96,7 @@ Tests a Stencil project. The flags below are the available options for the `test
 |------|-------------|
 | `--spec` | Tests `.spec.ts` files using [Jest](https://jestjs.io/). |
 | `--e2e` | Tests `.e2e.ts` files using [Puppeteer](https://developers.google.com/web/tools/puppeteer) and [Jest](https://jestjs.io/). |
-| `--no-build` | Skips build process before running the tests. (You are expected to have built it beforehand). |
+| `--no-build` | Skips the build process before running end-to-end tests. When using this flag, it is assumed that your Stencil project has been built prior to running `stencil test`. Unit tests do not require this flag. |
 | `--devtools` | Opens the dev tools panel in Chrome for end-to-end tests. Setting this flag will disable `--headless` |
 | `--headless` | Sets the headless mode to use in Chrome for end-to-end tests. `--headless` and `--headless=true` will enable the "old" headless mode in Chrome, that was used by default prior to Chrome v112. `--headless=new` will enable the new headless mode introduced in Chrome v112. See [this article](https://developer.chrome.com/articles/new-headless/) for more information on Chrome's new headless mode. |
 

--- a/versioned_docs/version-v4.3/config/cli.md
+++ b/versioned_docs/version-v4.3/config/cli.md
@@ -96,7 +96,7 @@ Tests a Stencil project. The flags below are the available options for the `test
 |------|-------------|
 | `--spec` | Tests `.spec.ts` files using [Jest](https://jestjs.io/). |
 | `--e2e` | Tests `.e2e.ts` files using [Puppeteer](https://developers.google.com/web/tools/puppeteer) and [Jest](https://jestjs.io/). |
-| `--no-build` | Skips build process before running the tests. (You are expected to have built it beforehand). |
+| `--no-build` | Skips the build process before running end-to-end tests. When using this flag, it is assumed that your Stencil project has been built prior to running `stencil test`. Unit tests do not require this flag. |
 | `--devtools` | Opens the dev tools panel in Chrome for end-to-end tests. Setting this flag will disable `--headless` |
 | `--headless` | Sets the headless mode to use in Chrome for end-to-end tests. `--headless` and `--headless=true` will enable the "old" headless mode in Chrome, that was used by default prior to Chrome v112. `--headless=new` will enable the new headless mode introduced in Chrome v112. See [this article](https://developer.chrome.com/articles/new-headless/) for more information on Chrome's new headless mode. |
 

--- a/versioned_docs/version-v4.4/config/cli.md
+++ b/versioned_docs/version-v4.4/config/cli.md
@@ -96,7 +96,7 @@ Tests a Stencil project. The flags below are the available options for the `test
 |------|-------------|
 | `--spec` | Tests `.spec.ts` files using [Jest](https://jestjs.io/). |
 | `--e2e` | Tests `.e2e.ts` files using [Puppeteer](https://developers.google.com/web/tools/puppeteer) and [Jest](https://jestjs.io/). |
-| `--no-build` | Skips build process before running the tests. (You are expected to have built it beforehand). |
+| `--no-build` | Skips the build process before running end-to-end tests. When using this flag, it is assumed that your Stencil project has been built prior to running `stencil test`. Unit tests do not require this flag. |
 | `--devtools` | Opens the dev tools panel in Chrome for end-to-end tests. Setting this flag will disable `--headless` |
 | `--headless` | Sets the headless mode to use in Chrome for end-to-end tests. `--headless` and `--headless=true` will enable the "old" headless mode in Chrome, that was used by default prior to Chrome v112. `--headless=new` will enable the new headless mode introduced in Chrome v112. See [this article](https://developer.chrome.com/articles/new-headless/) for more information on Chrome's new headless mode. |
 

--- a/versioned_docs/version-v4.5/config/cli.md
+++ b/versioned_docs/version-v4.5/config/cli.md
@@ -96,7 +96,7 @@ Tests a Stencil project. The flags below are the available options for the `test
 |------|-------------|
 | `--spec` | Tests `.spec.ts` files using [Jest](https://jestjs.io/). |
 | `--e2e` | Tests `.e2e.ts` files using [Puppeteer](https://developers.google.com/web/tools/puppeteer) and [Jest](https://jestjs.io/). |
-| `--no-build` | Skips build process before running the tests. (You are expected to have built it beforehand). |
+| `--no-build` | Skips the build process before running end-to-end tests. When using this flag, it is assumed that your Stencil project has been built prior to running `stencil test`. Unit tests do not require this flag. |
 | `--devtools` | Opens the dev tools panel in Chrome for end-to-end tests. Setting this flag will disable `--headless` |
 | `--headless` | Sets the headless mode to use in Chrome for end-to-end tests. `--headless` and `--headless=true` will enable the "old" headless mode in Chrome, that was used by default prior to Chrome v112. `--headless=new` will enable the new headless mode introduced in Chrome v112. See [this article](https://developer.chrome.com/articles/new-headless/) for more information on Chrome's new headless mode. |
 

--- a/versioned_docs/version-v4.6/config/cli.md
+++ b/versioned_docs/version-v4.6/config/cli.md
@@ -96,7 +96,7 @@ Tests a Stencil project. The flags below are the available options for the `test
 |------|-------------|
 | `--spec` | Tests `.spec.ts` files using [Jest](https://jestjs.io/). |
 | `--e2e` | Tests `.e2e.ts` files using [Puppeteer](https://developers.google.com/web/tools/puppeteer) and [Jest](https://jestjs.io/). |
-| `--no-build` | Skips build process before running the tests. (You are expected to have built it beforehand). |
+| `--no-build` | Skips the build process before running end-to-end tests. When using this flag, it is assumed that your Stencil project has been built prior to running `stencil test`. Unit tests do not require this flag. |
 | `--devtools` | Opens the dev tools panel in Chrome for end-to-end tests. Setting this flag will disable `--headless` |
 | `--headless` | Sets the headless mode to use in Chrome for end-to-end tests. `--headless` and `--headless=true` will enable the "old" headless mode in Chrome, that was used by default prior to Chrome v112. `--headless=new` will enable the new headless mode introduced in Chrome v112. See [this article](https://developer.chrome.com/articles/new-headless/) for more information on Chrome's new headless mode. |
 

--- a/versioned_docs/version-v4.7/config/cli.md
+++ b/versioned_docs/version-v4.7/config/cli.md
@@ -96,7 +96,7 @@ Tests a Stencil project. The flags below are the available options for the `test
 |------|-------------|
 | `--spec` | Tests `.spec.ts` files using [Jest](https://jestjs.io/). |
 | `--e2e` | Tests `.e2e.ts` files using [Puppeteer](https://developers.google.com/web/tools/puppeteer) and [Jest](https://jestjs.io/). |
-| `--no-build` | Skips build process before running the tests. (You are expected to have built it beforehand). |
+| `--no-build` | Skips the build process before running end-to-end tests. When using this flag, it is assumed that your Stencil project has been built prior to running `stencil test`. Unit tests do not require this flag. |
 | `--devtools` | Opens the dev tools panel in Chrome for end-to-end tests. Setting this flag will disable `--headless` |
 | `--headless` | Sets the headless mode to use in Chrome for end-to-end tests. `--headless` and `--headless=true` will enable the "old" headless mode in Chrome, that was used by default prior to Chrome v112. `--headless=new` will enable the new headless mode introduced in Chrome v112. See [this article](https://developer.chrome.com/articles/new-headless/) for more information on Chrome's new headless mode. |
 

--- a/versioned_docs/version-v4.8/config/cli.md
+++ b/versioned_docs/version-v4.8/config/cli.md
@@ -96,7 +96,7 @@ Tests a Stencil project. The flags below are the available options for the `test
 |------|-------------|
 | `--spec` | Tests `.spec.ts` files using [Jest](https://jestjs.io/). |
 | `--e2e` | Tests `.e2e.ts` files using [Puppeteer](https://developers.google.com/web/tools/puppeteer) and [Jest](https://jestjs.io/). |
-| `--no-build` | Skips build process before running the tests. (You are expected to have built it beforehand). |
+| `--no-build` | Skips the build process before running end-to-end tests. When using this flag, it is assumed that your Stencil project has been built prior to running `stencil test`. Unit tests do not require this flag. |
 | `--devtools` | Opens the dev tools panel in Chrome for end-to-end tests. Setting this flag will disable `--headless` |
 | `--headless` | Sets the headless mode to use in Chrome for end-to-end tests. `--headless` and `--headless=true` will enable the "old" headless mode in Chrome, that was used by default prior to Chrome v112. `--headless=new` will enable the new headless mode introduced in Chrome v112. See [this article](https://developer.chrome.com/articles/new-headless/) for more information on Chrome's new headless mode. |
 

--- a/versioned_docs/version-v4.9/config/cli.md
+++ b/versioned_docs/version-v4.9/config/cli.md
@@ -96,7 +96,7 @@ Tests a Stencil project. The flags below are the available options for the `test
 |------|-------------|
 | `--spec` | Tests `.spec.ts` files using [Jest](https://jestjs.io/). |
 | `--e2e` | Tests `.e2e.ts` files using [Puppeteer](https://developers.google.com/web/tools/puppeteer) and [Jest](https://jestjs.io/). |
-| `--no-build` | Skips build process before running the tests. (You are expected to have built it beforehand). |
+| `--no-build` | Skips the build process before running end-to-end tests. When using this flag, it is assumed that your Stencil project has been built prior to running `stencil test`. Unit tests do not require this flag. |
 | `--devtools` | Opens the dev tools panel in Chrome for end-to-end tests. Setting this flag will disable `--headless` |
 | `--headless` | Sets the headless mode to use in Chrome for end-to-end tests. `--headless` and `--headless=true` will enable the "old" headless mode in Chrome, that was used by default prior to Chrome v112. `--headless=new` will enable the new headless mode introduced in Chrome v112. See [this article](https://developer.chrome.com/articles/new-headless/) for more information on Chrome's new headless mode. |
 


### PR DESCRIPTION
clarify when the `--no-build` flag can be used when running `npx stencil test`. this was motivated by a question in discord regarding `--no-build` and `--spec` being used (or if they should be used simultaneously) - https://discord.com/channels/520266681499779082/933029266562613309/1212752679579947008.

Note: I'll propagate this to other directories after it's been approved