### PR TITLE
docs(dist): clarify `dist` output target

### DIFF
--- a/versioned_docs/version-v3/output-targets/dist.md
+++ b/versioned_docs/version-v3/output-targets/dist.md
@@ -7,7 +7,7 @@ slug: /distribution
 
 # Distribution Output Target
 
-The `dist` type is to generate the component(s) as a reusable library that can be self-lazy loading, such as [Ionic](https://www.npmjs.com/package/@ionic/core). When creating a distribution, the project's `package.json` will also have to be updated. However, the generated bundle is tree-shakable, ensuring that only imported components will end up in the build.
+The `dist` type is to generate the component(s) as a reusable library that can be self-lazy loading, such as [Ionic](https://www.npmjs.com/package/@ionic/core). The `dist` output will bundle all components into your application and only load the ones it needs at runtime.  When creating a distribution, the project's `package.json` will also have to be updated.
 
 ```tsx
 outputTargets: [

--- a/versioned_docs/version-v4.0/output-targets/dist.md
+++ b/versioned_docs/version-v4.0/output-targets/dist.md
@@ -7,7 +7,7 @@ slug: /distribution
 
 # Distribution Output Target
 
-The `dist` type is to generate the component(s) as a reusable library that can be self-lazy loading, such as [Ionic](https://www.npmjs.com/package/@ionic/core). When creating a distribution, the project's `package.json` will also have to be updated. However, the generated bundle is tree-shakable, ensuring that only imported components will end up in the build.
+The `dist` type is to generate the component(s) as a reusable library that can be self-lazy loading, such as [Ionic](https://www.npmjs.com/package/@ionic/core). The `dist` output will bundle all components into your application and only load the ones it needs at runtime.  When creating a distribution, the project's `package.json` will also have to be updated.
 
 ```tsx
 outputTargets: [

--- a/versioned_docs/version-v4.1/output-targets/dist.md
+++ b/versioned_docs/version-v4.1/output-targets/dist.md
@@ -7,7 +7,7 @@ slug: /distribution
 
 # Distribution Output Target
 
-The `dist` type is to generate the component(s) as a reusable library that can be self-lazy loading, such as [Ionic](https://www.npmjs.com/package/@ionic/core). When creating a distribution, the project's `package.json` will also have to be updated. However, the generated bundle is tree-shakable, ensuring that only imported components will end up in the build.
+The `dist` type is to generate the component(s) as a reusable library that can be self-lazy loading, such as [Ionic](https://www.npmjs.com/package/@ionic/core). The `dist` output will bundle all components into your application and only load the ones it needs at runtime.  When creating a distribution, the project's `package.json` will also have to be updated.
 
 ```tsx
 outputTargets: [

--- a/versioned_docs/version-v4.10/output-targets/dist.md
+++ b/versioned_docs/version-v4.10/output-targets/dist.md
@@ -7,7 +7,7 @@ slug: /distribution
 
 # Distribution Output Target
 
-The `dist` type is to generate the component(s) as a reusable library that can be self-lazy loading, such as [Ionic](https://www.npmjs.com/package/@ionic/core). When creating a distribution, the project's `package.json` will also have to be updated. However, the generated bundle is tree-shakable, ensuring that only imported components will end up in the build.
+The `dist` type is to generate the component(s) as a reusable library that can be self-lazy loading, such as [Ionic](https://www.npmjs.com/package/@ionic/core). The `dist` output will bundle all components into your application and only load the ones it needs at runtime.  When creating a distribution, the project's `package.json` will also have to be updated.
 
 ```tsx
 outputTargets: [

--- a/versioned_docs/version-v4.11/output-targets/dist.md
+++ b/versioned_docs/version-v4.11/output-targets/dist.md
@@ -7,7 +7,7 @@ slug: /distribution
 
 # Distribution Output Target
 
-The `dist` type is to generate the component(s) as a reusable library that can be self-lazy loading, such as [Ionic](https://www.npmjs.com/package/@ionic/core). When creating a distribution, the project's `package.json` will also have to be updated. However, the generated bundle is tree-shakable, ensuring that only imported components will end up in the build.
+The `dist` type is to generate the component(s) as a reusable library that can be self-lazy loading, such as [Ionic](https://www.npmjs.com/package/@ionic/core). The `dist` output will bundle all components into your application and only load the ones it needs at runtime.  When creating a distribution, the project's `package.json` will also have to be updated.
 
 ```tsx
 outputTargets: [

--- a/versioned_docs/version-v4.12/output-targets/dist.md
+++ b/versioned_docs/version-v4.12/output-targets/dist.md
@@ -7,7 +7,7 @@ slug: /distribution
 
 # Distribution Output Target
 
-The `dist` type is to generate the component(s) as a reusable library that can be self-lazy loading, such as [Ionic](https://www.npmjs.com/package/@ionic/core). When creating a distribution, the project's `package.json` will also have to be updated. However, the generated bundle is tree-shakable, ensuring that only imported components will end up in the build.
+The `dist` type is to generate the component(s) as a reusable library that can be self-lazy loading, such as [Ionic](https://www.npmjs.com/package/@ionic/core). The `dist` output will bundle all components into your application and only load the ones it needs at runtime.  When creating a distribution, the project's `package.json` will also have to be updated.
 
 ```tsx
 outputTargets: [

--- a/versioned_docs/version-v4.13.0/output-targets/dist.md
+++ b/versioned_docs/version-v4.13.0/output-targets/dist.md
@@ -9,7 +9,6 @@ slug: /distribution
 
 The `dist` type is to generate the component(s) as a reusable library that can be self-lazy loading, such as [Ionic](https://www.npmjs.com/package/@ionic/core). The `dist` output will bundle all components into your application and only load the ones it needs at runtime.  When creating a distribution, the project's `package.json` will also have to be updated. 
 
-
 ```tsx
 outputTargets: [
   {

--- a/versioned_docs/version-v4.13.0/output-targets/dist.md
+++ b/versioned_docs/version-v4.13.0/output-targets/dist.md
@@ -7,7 +7,8 @@ slug: /distribution
 
 # Distribution Output Target
 
-The `dist` type is to generate the component(s) as a reusable library that can be self-lazy loading, such as [Ionic](https://www.npmjs.com/package/@ionic/core). When creating a distribution, the project's `package.json` will also have to be updated. However, the generated bundle is tree-shakable, ensuring that only imported components will end up in the build.
+The `dist` type is to generate the component(s) as a reusable library that can be self-lazy loading, such as [Ionic](https://www.npmjs.com/package/@ionic/core). The `dist` output will bundle all components into your application and only load the ones it needs at runtime.  When creating a distribution, the project's `package.json` will also have to be updated. 
+
 
 ```tsx
 outputTargets: [

--- a/versioned_docs/version-v4.2/output-targets/dist.md
+++ b/versioned_docs/version-v4.2/output-targets/dist.md
@@ -7,7 +7,7 @@ slug: /distribution
 
 # Distribution Output Target
 
-The `dist` type is to generate the component(s) as a reusable library that can be self-lazy loading, such as [Ionic](https://www.npmjs.com/package/@ionic/core). When creating a distribution, the project's `package.json` will also have to be updated. However, the generated bundle is tree-shakable, ensuring that only imported components will end up in the build.
+The `dist` type is to generate the component(s) as a reusable library that can be self-lazy loading, such as [Ionic](https://www.npmjs.com/package/@ionic/core). The `dist` output will bundle all components into your application and only load the ones it needs at runtime.  When creating a distribution, the project's `package.json` will also have to be updated.
 
 ```tsx
 outputTargets: [

--- a/versioned_docs/version-v4.3/output-targets/dist.md
+++ b/versioned_docs/version-v4.3/output-targets/dist.md
@@ -7,7 +7,7 @@ slug: /distribution
 
 # Distribution Output Target
 
-The `dist` type is to generate the component(s) as a reusable library that can be self-lazy loading, such as [Ionic](https://www.npmjs.com/package/@ionic/core). When creating a distribution, the project's `package.json` will also have to be updated. However, the generated bundle is tree-shakable, ensuring that only imported components will end up in the build.
+The `dist` type is to generate the component(s) as a reusable library that can be self-lazy loading, such as [Ionic](https://www.npmjs.com/package/@ionic/core). The `dist` output will bundle all components into your application and only load the ones it needs at runtime.  When creating a distribution, the project's `package.json` will also have to be updated.
 
 ```tsx
 outputTargets: [

--- a/versioned_docs/version-v4.4/output-targets/dist.md
+++ b/versioned_docs/version-v4.4/output-targets/dist.md
@@ -7,7 +7,7 @@ slug: /distribution
 
 # Distribution Output Target
 
-The `dist` type is to generate the component(s) as a reusable library that can be self-lazy loading, such as [Ionic](https://www.npmjs.com/package/@ionic/core). When creating a distribution, the project's `package.json` will also have to be updated. However, the generated bundle is tree-shakable, ensuring that only imported components will end up in the build.
+The `dist` type is to generate the component(s) as a reusable library that can be self-lazy loading, such as [Ionic](https://www.npmjs.com/package/@ionic/core). The `dist` output will bundle all components into your application and only load the ones it needs at runtime.  When creating a distribution, the project's `package.json` will also have to be updated.
 
 ```tsx
 outputTargets: [

--- a/versioned_docs/version-v4.5/output-targets/dist.md
+++ b/versioned_docs/version-v4.5/output-targets/dist.md
@@ -7,7 +7,7 @@ slug: /distribution
 
 # Distribution Output Target
 
-The `dist` type is to generate the component(s) as a reusable library that can be self-lazy loading, such as [Ionic](https://www.npmjs.com/package/@ionic/core). When creating a distribution, the project's `package.json` will also have to be updated. However, the generated bundle is tree-shakable, ensuring that only imported components will end up in the build.
+The `dist` type is to generate the component(s) as a reusable library that can be self-lazy loading, such as [Ionic](https://www.npmjs.com/package/@ionic/core). The `dist` output will bundle all components into your application and only load the ones it needs at runtime.  When creating a distribution, the project's `package.json` will also have to be updated.
 
 ```tsx
 outputTargets: [

--- a/versioned_docs/version-v4.6/output-targets/dist.md
+++ b/versioned_docs/version-v4.6/output-targets/dist.md
@@ -7,7 +7,7 @@ slug: /distribution
 
 # Distribution Output Target
 
-The `dist` type is to generate the component(s) as a reusable library that can be self-lazy loading, such as [Ionic](https://www.npmjs.com/package/@ionic/core). When creating a distribution, the project's `package.json` will also have to be updated. However, the generated bundle is tree-shakable, ensuring that only imported components will end up in the build.
+The `dist` type is to generate the component(s) as a reusable library that can be self-lazy loading, such as [Ionic](https://www.npmjs.com/package/@ionic/core). The `dist` output will bundle all components into your application and only load the ones it needs at runtime.  When creating a distribution, the project's `package.json` will also have to be updated.
 
 ```tsx
 outputTargets: [

--- a/versioned_docs/version-v4.7/output-targets/dist.md
+++ b/versioned_docs/version-v4.7/output-targets/dist.md
@@ -7,7 +7,7 @@ slug: /distribution
 
 # Distribution Output Target
 
-The `dist` type is to generate the component(s) as a reusable library that can be self-lazy loading, such as [Ionic](https://www.npmjs.com/package/@ionic/core). When creating a distribution, the project's `package.json` will also have to be updated. However, the generated bundle is tree-shakable, ensuring that only imported components will end up in the build.
+The `dist` type is to generate the component(s) as a reusable library that can be self-lazy loading, such as [Ionic](https://www.npmjs.com/package/@ionic/core). The `dist` output will bundle all components into your application and only load the ones it needs at runtime.  When creating a distribution, the project's `package.json` will also have to be updated.
 
 ```tsx
 outputTargets: [

--- a/versioned_docs/version-v4.8/output-targets/dist.md
+++ b/versioned_docs/version-v4.8/output-targets/dist.md
@@ -7,7 +7,7 @@ slug: /distribution
 
 # Distribution Output Target
 
-The `dist` type is to generate the component(s) as a reusable library that can be self-lazy loading, such as [Ionic](https://www.npmjs.com/package/@ionic/core). When creating a distribution, the project's `package.json` will also have to be updated. However, the generated bundle is tree-shakable, ensuring that only imported components will end up in the build.
+The `dist` type is to generate the component(s) as a reusable library that can be self-lazy loading, such as [Ionic](https://www.npmjs.com/package/@ionic/core). The `dist` output will bundle all components into your application and only load the ones it needs at runtime.  When creating a distribution, the project's `package.json` will also have to be updated.
 
 ```tsx
 outputTargets: [

--- a/versioned_docs/version-v4.9/output-targets/dist.md
+++ b/versioned_docs/version-v4.9/output-targets/dist.md
@@ -7,7 +7,7 @@ slug: /distribution
 
 # Distribution Output Target
 
-The `dist` type is to generate the component(s) as a reusable library that can be self-lazy loading, such as [Ionic](https://www.npmjs.com/package/@ionic/core). When creating a distribution, the project's `package.json` will also have to be updated. However, the generated bundle is tree-shakable, ensuring that only imported components will end up in the build.
+The `dist` type is to generate the component(s) as a reusable library that can be self-lazy loading, such as [Ionic](https://www.npmjs.com/package/@ionic/core). The `dist` output will bundle all components into your application and only load the ones it needs at runtime.  When creating a distribution, the project's `package.json` will also have to be updated.
 
 ```tsx
 outputTargets: [


### PR DESCRIPTION
we're a little misleading here with respect to how `dist` works. adding a new sentence to clarify this better.

Impetus: https://discord.com/channels/520266681499779082/1143895925325058121/1219625948647919659