### PR TITLE
docs(support): update typescript support for 5.4.3

### DIFF
--- a/docs/reference/support-policy.md
+++ b/docs/reference/support-policy.md
@@ -86,7 +86,8 @@ The table below describes recent versions of Stencil and the version of TypeScri
 
 | Stencil Version | TypeScript Version |
 |:---------------:|:------------------:|
-|     v4.13.0     |       v5.4.0       |
+|     v4.14.0     |       v5.4.3       |
+|     v4.13.0     |       v5.4.2       |
 |     v4.10.0     |       v5.3.0       |
 |     v4.4.0      |       v5.2.2       |
 |     v4.2.0      |       v5.1.6       |

--- a/versioned_docs/version-v4.13.0/reference/support-policy.md
+++ b/versioned_docs/version-v4.13.0/reference/support-policy.md
@@ -86,7 +86,7 @@ The table below describes recent versions of Stencil and the version of TypeScri
 
 | Stencil Version | TypeScript Version |
 |:---------------:|:------------------:|
-|     v4.13.0     |       v5.4.0       |
+|     v4.13.0     |       v5.4.2       |
 |     v4.10.0     |       v5.3.0       |
 |     v4.4.0      |       v5.2.2       |
 |     v4.2.0      |       v5.1.6       |


### PR DESCRIPTION
update the typescript support table to account for typescript v5.4.3.

the thinking here even though this is a patch version of TS, it reverts a handful of PRs that made it into a release, whose behavior folks could be relying on. as a result, I'd rather be safe than sorry here.

update the v4.13.0 table to specify v5.4.2 instead of v5.4.0, as the typescript team uses the ".0" patch for beta releases and ".1" patch for RC at the moment.


For: https://github.com/ionic-team/stencil/pull/5588