### PR TITLE
chore(test): update piercing docs

### DIFF
--- a/docs/testing/stencil-testrunner/05-e2e-testing.md
+++ b/docs/testing/stencil-testrunner/05-e2e-testing.md
@@ -85,19 +85,11 @@ Use the "piercing" selector `>>>` to query for an object inside a component's sh
 const el = await page.find('foo-component >>> .close-button');
 ```
 
-:::caution
-Make sure to only use `>>>` once in your query. Puppeteer does not support nested deep selectors. Instead, separate the calls into two queries, e.g.:
+By default Stencil will look into all shadow roots to find the element. However if you want to restrict your query by specifying the shadow root of a particular component, you can chain multiple deep selectors within the same query, e.g.:
 
-```ts
-// 👎 multiple nested deep selector aren't supported
-const otherShadowElement = await page.find('my-component >>> div > my-other-component >>> h3');
-// 👍 separated calls using `>>>` once
-const divElement = await page.find('my-component >>> div');
-const otherShadowElement = await divElement.find('my-other-component >>> h3');
+```typescript
+const el = await page.find('foo-component >>> div bar-component >>> div');
 ```
-:::
-
-Find more information about this selector type for Puppeteer in their [project docs](https://pptr.dev/guides/query-selectors#-and--combinators).
 
 ### Set a @Prop() on a component
 


### PR DESCRIPTION
__Background:__

I've discovered a limitation with Stencils deep locator and put up [a PR](https://github.com/ionic-team/stencil-site/pull/1373) to let users know about this limitation. Now, after working on https://github.com/ionic-team/stencil/pull/5481 this limitation was fixed and we can update the docs again.

__Summary:__
This patch documents that user can use multiple deep selectors in their queries.