### PR TITLE
docs(ot-readme): add internal jsdoc documentation

### DIFF
--- a/docs/documentation-generation/docs-readme.md
+++ b/docs/documentation-generation/docs-readme.md
@@ -78,7 +78,7 @@ Any custom content placed above this comment will be persisted on subsequent bui
 
 ### Internal Components
 
-A Stencil component may be marked as deprecated using the unofficial JSDoc `@internal` tag.
+A Stencil component may be marked as internal to a library using the unofficial JSDoc `@internal` tag.
 By placing `@internal` in a component's class-level JSDoc it will skip the generation of the README for the component.
 
 In the code block below, `@internal` is added to the JSDoc for `MyComponent`:

--- a/docs/documentation-generation/docs-readme.md
+++ b/docs/documentation-generation/docs-readme.md
@@ -76,6 +76,28 @@ Custom content goes here!
 
 Any custom content placed above this comment will be persisted on subsequent builds of the README file.
 
+### Internal Components
+
+A Stencil component may be marked as deprecated using the unofficial JSDoc `@internal` tag.
+By placing `@internal` in a component's class-level JSDoc it will skip the generation of the README for the component.
+
+In the code block below, `@internal` is added to the JSDoc for `MyComponent`:
+
+```tsx title="A component with @internal in its JSDoc"
+/**
+ * @internal
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent { /* omitted */ }
+```
+
+The usage of `@internal` causes no README to be generated for `MyComponent`.
+
+If a README already exists for the component, it will not be updated.
+
 ### Deprecation Notices
 
 A Stencil component may be marked as deprecated using the [JSDoc `@deprecated` tag](https://jsdoc.app/tags-deprecated).

--- a/versioned_docs/version-v3/documentation-generation/docs-readme.md
+++ b/versioned_docs/version-v3/documentation-generation/docs-readme.md
@@ -76,6 +76,28 @@ Custom content goes here!
 
 Any custom content placed above this comment will be persisted on subsequent builds of the README file.
 
+### Internal Components
+
+A Stencil component may be marked as internal to a library using the unofficial JSDoc `@internal` tag.
+By placing `@internal` in a component's class-level JSDoc it will skip the generation of the README for the component.
+
+In the code block below, `@internal` is added to the JSDoc for `MyComponent`:
+
+```tsx title="A component with @internal in its JSDoc"
+/**
+ * @internal
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent { /* omitted */ }
+```
+
+The usage of `@internal` causes no README to be generated for `MyComponent`.
+
+If a README already exists for the component, it will not be updated.
+
 ### Deprecation Notices
 
 A Stencil component may be marked as deprecated using the [JSDoc `@deprecated` tag](https://jsdoc.app/tags-deprecated).

--- a/versioned_docs/version-v4.0/documentation-generation/docs-readme.md
+++ b/versioned_docs/version-v4.0/documentation-generation/docs-readme.md
@@ -76,6 +76,28 @@ Custom content goes here!
 
 Any custom content placed above this comment will be persisted on subsequent builds of the README file.
 
+### Internal Components
+
+A Stencil component may be marked as internal to a library using the unofficial JSDoc `@internal` tag.
+By placing `@internal` in a component's class-level JSDoc it will skip the generation of the README for the component.
+
+In the code block below, `@internal` is added to the JSDoc for `MyComponent`:
+
+```tsx title="A component with @internal in its JSDoc"
+/**
+ * @internal
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent { /* omitted */ }
+```
+
+The usage of `@internal` causes no README to be generated for `MyComponent`.
+
+If a README already exists for the component, it will not be updated.
+
 ### Deprecation Notices
 
 A Stencil component may be marked as deprecated using the [JSDoc `@deprecated` tag](https://jsdoc.app/tags-deprecated).

--- a/versioned_docs/version-v4.1/documentation-generation/docs-readme.md
+++ b/versioned_docs/version-v4.1/documentation-generation/docs-readme.md
@@ -76,6 +76,28 @@ Custom content goes here!
 
 Any custom content placed above this comment will be persisted on subsequent builds of the README file.
 
+### Internal Components
+
+A Stencil component may be marked as internal to a library using the unofficial JSDoc `@internal` tag.
+By placing `@internal` in a component's class-level JSDoc it will skip the generation of the README for the component.
+
+In the code block below, `@internal` is added to the JSDoc for `MyComponent`:
+
+```tsx title="A component with @internal in its JSDoc"
+/**
+ * @internal
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent { /* omitted */ }
+```
+
+The usage of `@internal` causes no README to be generated for `MyComponent`.
+
+If a README already exists for the component, it will not be updated.
+
 ### Deprecation Notices
 
 A Stencil component may be marked as deprecated using the [JSDoc `@deprecated` tag](https://jsdoc.app/tags-deprecated).

--- a/versioned_docs/version-v4.10/documentation-generation/docs-readme.md
+++ b/versioned_docs/version-v4.10/documentation-generation/docs-readme.md
@@ -76,6 +76,28 @@ Custom content goes here!
 
 Any custom content placed above this comment will be persisted on subsequent builds of the README file.
 
+### Internal Components
+
+A Stencil component may be marked as internal to a library using the unofficial JSDoc `@internal` tag.
+By placing `@internal` in a component's class-level JSDoc it will skip the generation of the README for the component.
+
+In the code block below, `@internal` is added to the JSDoc for `MyComponent`:
+
+```tsx title="A component with @internal in its JSDoc"
+/**
+ * @internal
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent { /* omitted */ }
+```
+
+The usage of `@internal` causes no README to be generated for `MyComponent`.
+
+If a README already exists for the component, it will not be updated.
+
 ### Deprecation Notices
 
 A Stencil component may be marked as deprecated using the [JSDoc `@deprecated` tag](https://jsdoc.app/tags-deprecated).

--- a/versioned_docs/version-v4.11/documentation-generation/docs-readme.md
+++ b/versioned_docs/version-v4.11/documentation-generation/docs-readme.md
@@ -76,6 +76,28 @@ Custom content goes here!
 
 Any custom content placed above this comment will be persisted on subsequent builds of the README file.
 
+### Internal Components
+
+A Stencil component may be marked as internal to a library using the unofficial JSDoc `@internal` tag.
+By placing `@internal` in a component's class-level JSDoc it will skip the generation of the README for the component.
+
+In the code block below, `@internal` is added to the JSDoc for `MyComponent`:
+
+```tsx title="A component with @internal in its JSDoc"
+/**
+ * @internal
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent { /* omitted */ }
+```
+
+The usage of `@internal` causes no README to be generated for `MyComponent`.
+
+If a README already exists for the component, it will not be updated.
+
 ### Deprecation Notices
 
 A Stencil component may be marked as deprecated using the [JSDoc `@deprecated` tag](https://jsdoc.app/tags-deprecated).

--- a/versioned_docs/version-v4.12/documentation-generation/docs-readme.md
+++ b/versioned_docs/version-v4.12/documentation-generation/docs-readme.md
@@ -76,6 +76,28 @@ Custom content goes here!
 
 Any custom content placed above this comment will be persisted on subsequent builds of the README file.
 
+### Internal Components
+
+A Stencil component may be marked as internal to a library using the unofficial JSDoc `@internal` tag.
+By placing `@internal` in a component's class-level JSDoc it will skip the generation of the README for the component.
+
+In the code block below, `@internal` is added to the JSDoc for `MyComponent`:
+
+```tsx title="A component with @internal in its JSDoc"
+/**
+ * @internal
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent { /* omitted */ }
+```
+
+The usage of `@internal` causes no README to be generated for `MyComponent`.
+
+If a README already exists for the component, it will not be updated.
+
 ### Deprecation Notices
 
 A Stencil component may be marked as deprecated using the [JSDoc `@deprecated` tag](https://jsdoc.app/tags-deprecated).

--- a/versioned_docs/version-v4.13.0/documentation-generation/docs-readme.md
+++ b/versioned_docs/version-v4.13.0/documentation-generation/docs-readme.md
@@ -76,6 +76,28 @@ Custom content goes here!
 
 Any custom content placed above this comment will be persisted on subsequent builds of the README file.
 
+### Internal Components
+
+A Stencil component may be marked as internal to a library using the unofficial JSDoc `@internal` tag.
+By placing `@internal` in a component's class-level JSDoc it will skip the generation of the README for the component.
+
+In the code block below, `@internal` is added to the JSDoc for `MyComponent`:
+
+```tsx title="A component with @internal in its JSDoc"
+/**
+ * @internal
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent { /* omitted */ }
+```
+
+The usage of `@internal` causes no README to be generated for `MyComponent`.
+
+If a README already exists for the component, it will not be updated.
+
 ### Deprecation Notices
 
 A Stencil component may be marked as deprecated using the [JSDoc `@deprecated` tag](https://jsdoc.app/tags-deprecated).

--- a/versioned_docs/version-v4.2/documentation-generation/docs-readme.md
+++ b/versioned_docs/version-v4.2/documentation-generation/docs-readme.md
@@ -76,6 +76,28 @@ Custom content goes here!
 
 Any custom content placed above this comment will be persisted on subsequent builds of the README file.
 
+### Internal Components
+
+A Stencil component may be marked as internal to a library using the unofficial JSDoc `@internal` tag.
+By placing `@internal` in a component's class-level JSDoc it will skip the generation of the README for the component.
+
+In the code block below, `@internal` is added to the JSDoc for `MyComponent`:
+
+```tsx title="A component with @internal in its JSDoc"
+/**
+ * @internal
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent { /* omitted */ }
+```
+
+The usage of `@internal` causes no README to be generated for `MyComponent`.
+
+If a README already exists for the component, it will not be updated.
+
 ### Deprecation Notices
 
 A Stencil component may be marked as deprecated using the [JSDoc `@deprecated` tag](https://jsdoc.app/tags-deprecated).

--- a/versioned_docs/version-v4.3/documentation-generation/docs-readme.md
+++ b/versioned_docs/version-v4.3/documentation-generation/docs-readme.md
@@ -76,6 +76,28 @@ Custom content goes here!
 
 Any custom content placed above this comment will be persisted on subsequent builds of the README file.
 
+### Internal Components
+
+A Stencil component may be marked as internal to a library using the unofficial JSDoc `@internal` tag.
+By placing `@internal` in a component's class-level JSDoc it will skip the generation of the README for the component.
+
+In the code block below, `@internal` is added to the JSDoc for `MyComponent`:
+
+```tsx title="A component with @internal in its JSDoc"
+/**
+ * @internal
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent { /* omitted */ }
+```
+
+The usage of `@internal` causes no README to be generated for `MyComponent`.
+
+If a README already exists for the component, it will not be updated.
+
 ### Deprecation Notices
 
 A Stencil component may be marked as deprecated using the [JSDoc `@deprecated` tag](https://jsdoc.app/tags-deprecated).

--- a/versioned_docs/version-v4.4/documentation-generation/docs-readme.md
+++ b/versioned_docs/version-v4.4/documentation-generation/docs-readme.md
@@ -76,6 +76,28 @@ Custom content goes here!
 
 Any custom content placed above this comment will be persisted on subsequent builds of the README file.
 
+### Internal Components
+
+A Stencil component may be marked as internal to a library using the unofficial JSDoc `@internal` tag.
+By placing `@internal` in a component's class-level JSDoc it will skip the generation of the README for the component.
+
+In the code block below, `@internal` is added to the JSDoc for `MyComponent`:
+
+```tsx title="A component with @internal in its JSDoc"
+/**
+ * @internal
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent { /* omitted */ }
+```
+
+The usage of `@internal` causes no README to be generated for `MyComponent`.
+
+If a README already exists for the component, it will not be updated.
+
 ### Deprecation Notices
 
 A Stencil component may be marked as deprecated using the [JSDoc `@deprecated` tag](https://jsdoc.app/tags-deprecated).

--- a/versioned_docs/version-v4.5/documentation-generation/docs-readme.md
+++ b/versioned_docs/version-v4.5/documentation-generation/docs-readme.md
@@ -76,6 +76,28 @@ Custom content goes here!
 
 Any custom content placed above this comment will be persisted on subsequent builds of the README file.
 
+### Internal Components
+
+A Stencil component may be marked as internal to a library using the unofficial JSDoc `@internal` tag.
+By placing `@internal` in a component's class-level JSDoc it will skip the generation of the README for the component.
+
+In the code block below, `@internal` is added to the JSDoc for `MyComponent`:
+
+```tsx title="A component with @internal in its JSDoc"
+/**
+ * @internal
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent { /* omitted */ }
+```
+
+The usage of `@internal` causes no README to be generated for `MyComponent`.
+
+If a README already exists for the component, it will not be updated.
+
 ### Deprecation Notices
 
 A Stencil component may be marked as deprecated using the [JSDoc `@deprecated` tag](https://jsdoc.app/tags-deprecated).

--- a/versioned_docs/version-v4.6/documentation-generation/docs-readme.md
+++ b/versioned_docs/version-v4.6/documentation-generation/docs-readme.md
@@ -76,6 +76,28 @@ Custom content goes here!
 
 Any custom content placed above this comment will be persisted on subsequent builds of the README file.
 
+### Internal Components
+
+A Stencil component may be marked as internal to a library using the unofficial JSDoc `@internal` tag.
+By placing `@internal` in a component's class-level JSDoc it will skip the generation of the README for the component.
+
+In the code block below, `@internal` is added to the JSDoc for `MyComponent`:
+
+```tsx title="A component with @internal in its JSDoc"
+/**
+ * @internal
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent { /* omitted */ }
+```
+
+The usage of `@internal` causes no README to be generated for `MyComponent`.
+
+If a README already exists for the component, it will not be updated.
+
 ### Deprecation Notices
 
 A Stencil component may be marked as deprecated using the [JSDoc `@deprecated` tag](https://jsdoc.app/tags-deprecated).

--- a/versioned_docs/version-v4.7/documentation-generation/docs-readme.md
+++ b/versioned_docs/version-v4.7/documentation-generation/docs-readme.md
@@ -76,6 +76,28 @@ Custom content goes here!
 
 Any custom content placed above this comment will be persisted on subsequent builds of the README file.
 
+### Internal Components
+
+A Stencil component may be marked as internal to a library using the unofficial JSDoc `@internal` tag.
+By placing `@internal` in a component's class-level JSDoc it will skip the generation of the README for the component.
+
+In the code block below, `@internal` is added to the JSDoc for `MyComponent`:
+
+```tsx title="A component with @internal in its JSDoc"
+/**
+ * @internal
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent { /* omitted */ }
+```
+
+The usage of `@internal` causes no README to be generated for `MyComponent`.
+
+If a README already exists for the component, it will not be updated.
+
 ### Deprecation Notices
 
 A Stencil component may be marked as deprecated using the [JSDoc `@deprecated` tag](https://jsdoc.app/tags-deprecated).

--- a/versioned_docs/version-v4.8/documentation-generation/docs-readme.md
+++ b/versioned_docs/version-v4.8/documentation-generation/docs-readme.md
@@ -76,6 +76,28 @@ Custom content goes here!
 
 Any custom content placed above this comment will be persisted on subsequent builds of the README file.
 
+### Internal Components
+
+A Stencil component may be marked as internal to a library using the unofficial JSDoc `@internal` tag.
+By placing `@internal` in a component's class-level JSDoc it will skip the generation of the README for the component.
+
+In the code block below, `@internal` is added to the JSDoc for `MyComponent`:
+
+```tsx title="A component with @internal in its JSDoc"
+/**
+ * @internal
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent { /* omitted */ }
+```
+
+The usage of `@internal` causes no README to be generated for `MyComponent`.
+
+If a README already exists for the component, it will not be updated.
+
 ### Deprecation Notices
 
 A Stencil component may be marked as deprecated using the [JSDoc `@deprecated` tag](https://jsdoc.app/tags-deprecated).

--- a/versioned_docs/version-v4.9/documentation-generation/docs-readme.md
+++ b/versioned_docs/version-v4.9/documentation-generation/docs-readme.md
@@ -76,6 +76,28 @@ Custom content goes here!
 
 Any custom content placed above this comment will be persisted on subsequent builds of the README file.
 
+### Internal Components
+
+A Stencil component may be marked as internal to a library using the unofficial JSDoc `@internal` tag.
+By placing `@internal` in a component's class-level JSDoc it will skip the generation of the README for the component.
+
+In the code block below, `@internal` is added to the JSDoc for `MyComponent`:
+
+```tsx title="A component with @internal in its JSDoc"
+/**
+ * @internal
+ */
+@Component({
+  tag: 'my-component',
+  shadow: true,
+})
+export class MyComponent { /* omitted */ }
+```
+
+The usage of `@internal` causes no README to be generated for `MyComponent`.
+
+If a README already exists for the component, it will not be updated.
+
 ### Deprecation Notices
 
 A Stencil component may be marked as deprecated using the [JSDoc `@deprecated` tag](https://jsdoc.app/tags-deprecated).


### PR DESCRIPTION
add a section on the behavior of the `@internal` jsdoc tag

ths impetus for this is an internal slack convo with Liam in the ask-stencil channel

I'll backport it once it's been approved