### PR TITLE
docs(playwright): add section for migrating to/testing playwright

### DIFF
--- a/docs/testing/playwright/01-overview.md
+++ b/docs/testing/playwright/01-overview.md
@@ -97,3 +97,55 @@ To install the Stencil Playwright adapter in an existing Stencil project, follow
    :::
 
 1. Test away! Check out the [e2e testing page](./02-e2e-testing.md) for more help getting started writing tests.
+
+## Migrating to Playwright
+
+If you are working in a Stencil project with an existing end-to-end testing setup via the [Stencil Test Runner](../stencil-testrunner/05-e2e-testing.md),
+you can continue using your existing e2e testing setup while sampling the Playwright adapter or migrating tests over time. To do so, there are two
+options:
+
+- **Option 1:** Update the Playwright config to match a different test file pattern:
+
+  ```ts title="playwright.config.ts"
+  export default createStencilPlaywrightConfig({
+    // Example: match all test files with the 'e2e.playwright.ts' naming convention
+    testMatch: '*.e2e.playwright.ts',
+  });
+  ```
+
+  By default, the Playwright adapter will match all files with the '.e2e.ts' extension, which is the same pattern used by the Stencil test
+  runner for e2e tests. See the [Playwright`testMatch` documentation](https://playwright.dev/docs/api/class-testconfig#test-config-test-match)
+  for more information on acceptable values.
+
+  Changing this value is useful if you are just testing out Playwright, but haven't committed to migrating all test files.
+
+- **Option 2:** Update the Stencil Test Runner to match a different test file pattern:
+
+  ```ts title="stencil.config.ts"
+  export config: Config = {
+     ...,
+     test: {
+        // Stencil Test Runner will no longer execute any 'e2e.ts` files
+        testRegex: '(/__tests__/.*|(\\.|/)(test|spec)|[//](e2e))\\.[jt]sx?$'
+     }
+  }
+  ```
+
+  Changing this value is useful if you intend on using Playwright as your main e2e testing solution and want to keep the 'e2e.ts` extension
+  for test files.
+
+:::tip
+You could also separate tests into specific directories for each test runner and have the test patterns match only their respective directories.
+:::
+
+In addition, Playwright will not execute as a part of the Stencil CLI's `test` command (i.e. `stencil test --e2e`). To have Playwright execute
+alongside the Stencil Test Runner, you'll need to include an explicit call to the Playwright CLI as a part of your project's `package.json` test
+script:
+
+```json title="package.json"
+{
+  "scripts": {
+    "test.e2e": "stencil test --e2e && playwright test"
+  }
+}
+```

--- a/versioned_docs/version-v4.13.0/testing/playwright/01-overview.md
+++ b/versioned_docs/version-v4.13.0/testing/playwright/01-overview.md
@@ -97,3 +97,55 @@ To install the Stencil Playwright adapter in an existing Stencil project, follow
    :::
 
 1. Test away! Check out the [e2e testing page](./02-e2e-testing.md) for more help getting started writing tests.
+
+## Migrating to Playwright
+
+If you are working in a Stencil project with an existing end-to-end testing setup via the [Stencil Test Runner](../stencil-testrunner/05-e2e-testing.md),
+you can continue using your existing e2e testing setup while sampling the Playwright adapter or migrating tests over time. To do so, there are two
+options:
+
+- **Option 1:** Update the Playwright config to match a different test file pattern:
+
+  ```ts title="playwright.config.ts"
+  export default createStencilPlaywrightConfig({
+    // Example: match all test files with the 'e2e.playwright.ts' naming convention
+    testMatch: '*.e2e.playwright.ts',
+  });
+  ```
+
+  By default, the Playwright adapter will match all files with the '.e2e.ts' extension, which is the same pattern used by the Stencil test
+  runner for e2e tests. See the [Playwright`testMatch` documentation](https://playwright.dev/docs/api/class-testconfig#test-config-test-match)
+  for more information on acceptable values.
+
+  Changing this value is useful if you are just testing out Playwright, but haven't committed to migrating all test files.
+
+- **Option 2:** Update the Stencil Test Runner to match a different test file pattern:
+
+  ```ts title="stencil.config.ts"
+  export config: Config = {
+     ...,
+     test: {
+        // Stencil Test Runner will no longer execute any 'e2e.ts` files
+        testRegex: '(/__tests__/.*|(\\.|/)(test|spec)|[//](e2e))\\.[jt]sx?$'
+     }
+  }
+  ```
+
+  Changing this value is useful if you intend on using Playwright as your main e2e testing solution and want to keep the 'e2e.ts` extension
+  for test files.
+
+:::tip
+You could also separate tests into specific directories for each test runner and have the test patterns match only their respective directories.
+:::
+
+In addition, Playwright will not execute as a part of the Stencil CLI's `test` command (i.e. `stencil test --e2e`). To have Playwright execute
+alongside the Stencil Test Runner, you'll need to include an explicit call to the Playwright CLI as a part of your project's `package.json` test
+script:
+
+```json title="package.json"
+{
+  "scripts": {
+    "test.e2e": "stencil test --e2e && playwright test"
+  }
+}
+```

--- a/versioned_docs/version-v4.14/testing/playwright/01-overview.md
+++ b/versioned_docs/version-v4.14/testing/playwright/01-overview.md
@@ -97,3 +97,55 @@ To install the Stencil Playwright adapter in an existing Stencil project, follow
    :::
 
 1. Test away! Check out the [e2e testing page](./02-e2e-testing.md) for more help getting started writing tests.
+
+## Migrating to Playwright
+
+If you are working in a Stencil project with an existing end-to-end testing setup via the [Stencil Test Runner](../stencil-testrunner/05-e2e-testing.md),
+you can continue using your existing e2e testing setup while sampling the Playwright adapter or migrating tests over time. To do so, there are two
+options:
+
+- **Option 1:** Update the Playwright config to match a different test file pattern:
+
+  ```ts title="playwright.config.ts"
+  export default createStencilPlaywrightConfig({
+    // Example: match all test files with the 'e2e.playwright.ts' naming convention
+    testMatch: '*.e2e.playwright.ts',
+  });
+  ```
+
+  By default, the Playwright adapter will match all files with the '.e2e.ts' extension, which is the same pattern used by the Stencil test
+  runner for e2e tests. See the [Playwright`testMatch` documentation](https://playwright.dev/docs/api/class-testconfig#test-config-test-match)
+  for more information on acceptable values.
+
+  Changing this value is useful if you are just testing out Playwright, but haven't committed to migrating all test files.
+
+- **Option 2:** Update the Stencil Test Runner to match a different test file pattern:
+
+  ```ts title="stencil.config.ts"
+  export config: Config = {
+     ...,
+     test: {
+        // Stencil Test Runner will no longer execute any 'e2e.ts` files
+        testRegex: '(/__tests__/.*|(\\.|/)(test|spec)|[//](e2e))\\.[jt]sx?$'
+     }
+  }
+  ```
+
+  Changing this value is useful if you intend on using Playwright as your main e2e testing solution and want to keep the 'e2e.ts` extension
+  for test files.
+
+:::tip
+You could also separate tests into specific directories for each test runner and have the test patterns match only their respective directories.
+:::
+
+In addition, Playwright will not execute as a part of the Stencil CLI's `test` command (i.e. `stencil test --e2e`). To have Playwright execute
+alongside the Stencil Test Runner, you'll need to include an explicit call to the Playwright CLI as a part of your project's `package.json` test
+script:
+
+```json title="package.json"
+{
+  "scripts": {
+    "test.e2e": "stencil test --e2e && playwright test"
+  }
+}
+```

--- a/versioned_docs/version-v4.15/testing/playwright/01-overview.md
+++ b/versioned_docs/version-v4.15/testing/playwright/01-overview.md
@@ -97,3 +97,55 @@ To install the Stencil Playwright adapter in an existing Stencil project, follow
    :::
 
 1. Test away! Check out the [e2e testing page](./02-e2e-testing.md) for more help getting started writing tests.
+
+## Migrating to Playwright
+
+If you are working in a Stencil project with an existing end-to-end testing setup via the [Stencil Test Runner](../stencil-testrunner/05-e2e-testing.md),
+you can continue using your existing e2e testing setup while sampling the Playwright adapter or migrating tests over time. To do so, there are two
+options:
+
+- **Option 1:** Update the Playwright config to match a different test file pattern:
+
+  ```ts title="playwright.config.ts"
+  export default createStencilPlaywrightConfig({
+    // Example: match all test files with the 'e2e.playwright.ts' naming convention
+    testMatch: '*.e2e.playwright.ts',
+  });
+  ```
+
+  By default, the Playwright adapter will match all files with the '.e2e.ts' extension, which is the same pattern used by the Stencil test
+  runner for e2e tests. See the [Playwright`testMatch` documentation](https://playwright.dev/docs/api/class-testconfig#test-config-test-match)
+  for more information on acceptable values.
+
+  Changing this value is useful if you are just testing out Playwright, but haven't committed to migrating all test files.
+
+- **Option 2:** Update the Stencil Test Runner to match a different test file pattern:
+
+  ```ts title="stencil.config.ts"
+  export config: Config = {
+     ...,
+     test: {
+        // Stencil Test Runner will no longer execute any 'e2e.ts` files
+        testRegex: '(/__tests__/.*|(\\.|/)(test|spec)|[//](e2e))\\.[jt]sx?$'
+     }
+  }
+  ```
+
+  Changing this value is useful if you intend on using Playwright as your main e2e testing solution and want to keep the 'e2e.ts` extension
+  for test files.
+
+:::tip
+You could also separate tests into specific directories for each test runner and have the test patterns match only their respective directories.
+:::
+
+In addition, Playwright will not execute as a part of the Stencil CLI's `test` command (i.e. `stencil test --e2e`). To have Playwright execute
+alongside the Stencil Test Runner, you'll need to include an explicit call to the Playwright CLI as a part of your project's `package.json` test
+script:
+
+```json title="package.json"
+{
+  "scripts": {
+    "test.e2e": "stencil test --e2e && playwright test"
+  }
+}
+```


### PR DESCRIPTION
Adds a section to the Playwright overview for users coming from an established e2e testing setup using the Stencil Test Runner. This covers ways in which users can test out the Playwright adapter without fully migrating, or for updating file match patterns while a project is migrated to use Playwright over time.

Changes also backfilled to v4.13, v4.14, & v4.15 docs.