### PR TITLE
docs(compiler): remove docs on loading the Stencil compiler in a Web Worker or browser

### DIFF
--- a/docs/core/compiler-api.md
+++ b/docs/core/compiler-api.md
@@ -12,13 +12,9 @@ work within a NodeJS environment, web worker, and browser window. The
 `stencil.min.js` file is also provided and recommended when used within a browser.
 
 ```tsx
-// NodeJS (esm)
-import stencil from '@stencil/core/compiler';
-
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
 ```
-
 
 ## transpile()
 

--- a/docs/core/compiler-api.md
+++ b/docs/core/compiler-api.md
@@ -17,10 +17,6 @@ import stencil from '@stencil/core/compiler';
 
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
-
-// Web Worker from CDN URL (add the version to in the URL)
-importScripts('https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js');
-// self.stencil will be available after the script import
 ```
 
 

--- a/docs/core/compiler-api.md
+++ b/docs/core/compiler-api.md
@@ -12,16 +12,15 @@ work within a NodeJS environment, web worker, and browser window. The
 `stencil.min.js` file is also provided and recommended when used within a browser.
 
 ```tsx
+// NodeJS (esm)
+import stencil from '@stencil/core/compiler';
+
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
 
 // Web Worker from CDN URL (add the version to in the URL)
 importScripts('https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js');
 // self.stencil will be available after the script import
-
-// Browser Window
-<script src="https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js"></script>
-// window.stencil will be available after the script executes
 ```
 
 

--- a/versioned_docs/version-v4.0/core/compiler-api.md
+++ b/versioned_docs/version-v4.0/core/compiler-api.md
@@ -12,13 +12,9 @@ work within a NodeJS environment, web worker, and browser window. The
 `stencil.min.js` file is also provided and recommended when used within a browser.
 
 ```tsx
-// NodeJS (esm)
-import stencil from '@stencil/core/compiler';
-
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
 ```
-
 
 ## transpile()
 

--- a/versioned_docs/version-v4.0/core/compiler-api.md
+++ b/versioned_docs/version-v4.0/core/compiler-api.md
@@ -17,10 +17,6 @@ import stencil from '@stencil/core/compiler';
 
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
-
-// Web Worker from CDN URL (add the version to in the URL)
-importScripts('https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js');
-// self.stencil will be available after the script import
 ```
 
 

--- a/versioned_docs/version-v4.0/core/compiler-api.md
+++ b/versioned_docs/version-v4.0/core/compiler-api.md
@@ -12,16 +12,15 @@ work within a NodeJS environment, web worker, and browser window. The
 `stencil.min.js` file is also provided and recommended when used within a browser.
 
 ```tsx
+// NodeJS (esm)
+import stencil from '@stencil/core/compiler';
+
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
 
 // Web Worker from CDN URL (add the version to in the URL)
 importScripts('https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js');
 // self.stencil will be available after the script import
-
-// Browser Window
-<script src="https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js"></script>
-// window.stencil will be available after the script executes
 ```
 
 

--- a/versioned_docs/version-v4.1/core/compiler-api.md
+++ b/versioned_docs/version-v4.1/core/compiler-api.md
@@ -12,13 +12,9 @@ work within a NodeJS environment, web worker, and browser window. The
 `stencil.min.js` file is also provided and recommended when used within a browser.
 
 ```tsx
-// NodeJS (esm)
-import stencil from '@stencil/core/compiler';
-
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
 ```
-
 
 ## transpile()
 

--- a/versioned_docs/version-v4.1/core/compiler-api.md
+++ b/versioned_docs/version-v4.1/core/compiler-api.md
@@ -17,10 +17,6 @@ import stencil from '@stencil/core/compiler';
 
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
-
-// Web Worker from CDN URL (add the version to in the URL)
-importScripts('https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js');
-// self.stencil will be available after the script import
 ```
 
 

--- a/versioned_docs/version-v4.1/core/compiler-api.md
+++ b/versioned_docs/version-v4.1/core/compiler-api.md
@@ -12,16 +12,15 @@ work within a NodeJS environment, web worker, and browser window. The
 `stencil.min.js` file is also provided and recommended when used within a browser.
 
 ```tsx
+// NodeJS (esm)
+import stencil from '@stencil/core/compiler';
+
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
 
 // Web Worker from CDN URL (add the version to in the URL)
 importScripts('https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js');
 // self.stencil will be available after the script import
-
-// Browser Window
-<script src="https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js"></script>
-// window.stencil will be available after the script executes
 ```
 
 

--- a/versioned_docs/version-v4.10/core/compiler-api.md
+++ b/versioned_docs/version-v4.10/core/compiler-api.md
@@ -12,13 +12,9 @@ work within a NodeJS environment, web worker, and browser window. The
 `stencil.min.js` file is also provided and recommended when used within a browser.
 
 ```tsx
-// NodeJS (esm)
-import stencil from '@stencil/core/compiler';
-
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
 ```
-
 
 ## transpile()
 

--- a/versioned_docs/version-v4.10/core/compiler-api.md
+++ b/versioned_docs/version-v4.10/core/compiler-api.md
@@ -17,10 +17,6 @@ import stencil from '@stencil/core/compiler';
 
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
-
-// Web Worker from CDN URL (add the version to in the URL)
-importScripts('https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js');
-// self.stencil will be available after the script import
 ```
 
 

--- a/versioned_docs/version-v4.10/core/compiler-api.md
+++ b/versioned_docs/version-v4.10/core/compiler-api.md
@@ -12,16 +12,15 @@ work within a NodeJS environment, web worker, and browser window. The
 `stencil.min.js` file is also provided and recommended when used within a browser.
 
 ```tsx
+// NodeJS (esm)
+import stencil from '@stencil/core/compiler';
+
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
 
 // Web Worker from CDN URL (add the version to in the URL)
 importScripts('https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js');
 // self.stencil will be available after the script import
-
-// Browser Window
-<script src="https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js"></script>
-// window.stencil will be available after the script executes
 ```
 
 

--- a/versioned_docs/version-v4.11/core/compiler-api.md
+++ b/versioned_docs/version-v4.11/core/compiler-api.md
@@ -12,13 +12,9 @@ work within a NodeJS environment, web worker, and browser window. The
 `stencil.min.js` file is also provided and recommended when used within a browser.
 
 ```tsx
-// NodeJS (esm)
-import stencil from '@stencil/core/compiler';
-
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
 ```
-
 
 ## transpile()
 

--- a/versioned_docs/version-v4.11/core/compiler-api.md
+++ b/versioned_docs/version-v4.11/core/compiler-api.md
@@ -17,10 +17,6 @@ import stencil from '@stencil/core/compiler';
 
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
-
-// Web Worker from CDN URL (add the version to in the URL)
-importScripts('https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js');
-// self.stencil will be available after the script import
 ```
 
 

--- a/versioned_docs/version-v4.11/core/compiler-api.md
+++ b/versioned_docs/version-v4.11/core/compiler-api.md
@@ -12,16 +12,15 @@ work within a NodeJS environment, web worker, and browser window. The
 `stencil.min.js` file is also provided and recommended when used within a browser.
 
 ```tsx
+// NodeJS (esm)
+import stencil from '@stencil/core/compiler';
+
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
 
 // Web Worker from CDN URL (add the version to in the URL)
 importScripts('https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js');
 // self.stencil will be available after the script import
-
-// Browser Window
-<script src="https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js"></script>
-// window.stencil will be available after the script executes
 ```
 
 

--- a/versioned_docs/version-v4.12/core/compiler-api.md
+++ b/versioned_docs/version-v4.12/core/compiler-api.md
@@ -12,13 +12,9 @@ work within a NodeJS environment, web worker, and browser window. The
 `stencil.min.js` file is also provided and recommended when used within a browser.
 
 ```tsx
-// NodeJS (esm)
-import stencil from '@stencil/core/compiler';
-
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
 ```
-
 
 ## transpile()
 

--- a/versioned_docs/version-v4.12/core/compiler-api.md
+++ b/versioned_docs/version-v4.12/core/compiler-api.md
@@ -17,10 +17,6 @@ import stencil from '@stencil/core/compiler';
 
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
-
-// Web Worker from CDN URL (add the version to in the URL)
-importScripts('https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js');
-// self.stencil will be available after the script import
 ```
 
 

--- a/versioned_docs/version-v4.12/core/compiler-api.md
+++ b/versioned_docs/version-v4.12/core/compiler-api.md
@@ -12,16 +12,15 @@ work within a NodeJS environment, web worker, and browser window. The
 `stencil.min.js` file is also provided and recommended when used within a browser.
 
 ```tsx
+// NodeJS (esm)
+import stencil from '@stencil/core/compiler';
+
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
 
 // Web Worker from CDN URL (add the version to in the URL)
 importScripts('https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js');
 // self.stencil will be available after the script import
-
-// Browser Window
-<script src="https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js"></script>
-// window.stencil will be available after the script executes
 ```
 
 

--- a/versioned_docs/version-v4.13.0/core/compiler-api.md
+++ b/versioned_docs/version-v4.13.0/core/compiler-api.md
@@ -12,13 +12,9 @@ work within a NodeJS environment, web worker, and browser window. The
 `stencil.min.js` file is also provided and recommended when used within a browser.
 
 ```tsx
-// NodeJS (esm)
-import stencil from '@stencil/core/compiler';
-
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
 ```
-
 
 ## transpile()
 

--- a/versioned_docs/version-v4.13.0/core/compiler-api.md
+++ b/versioned_docs/version-v4.13.0/core/compiler-api.md
@@ -17,10 +17,6 @@ import stencil from '@stencil/core/compiler';
 
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
-
-// Web Worker from CDN URL (add the version to in the URL)
-importScripts('https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js');
-// self.stencil will be available after the script import
 ```
 
 

--- a/versioned_docs/version-v4.13.0/core/compiler-api.md
+++ b/versioned_docs/version-v4.13.0/core/compiler-api.md
@@ -12,16 +12,15 @@ work within a NodeJS environment, web worker, and browser window. The
 `stencil.min.js` file is also provided and recommended when used within a browser.
 
 ```tsx
+// NodeJS (esm)
+import stencil from '@stencil/core/compiler';
+
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
 
 // Web Worker from CDN URL (add the version to in the URL)
 importScripts('https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js');
 // self.stencil will be available after the script import
-
-// Browser Window
-<script src="https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js"></script>
-// window.stencil will be available after the script executes
 ```
 
 

--- a/versioned_docs/version-v4.14/core/compiler-api.md
+++ b/versioned_docs/version-v4.14/core/compiler-api.md
@@ -12,13 +12,9 @@ work within a NodeJS environment, web worker, and browser window. The
 `stencil.min.js` file is also provided and recommended when used within a browser.
 
 ```tsx
-// NodeJS (esm)
-import stencil from '@stencil/core/compiler';
-
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
 ```
-
 
 ## transpile()
 

--- a/versioned_docs/version-v4.14/core/compiler-api.md
+++ b/versioned_docs/version-v4.14/core/compiler-api.md
@@ -17,10 +17,6 @@ import stencil from '@stencil/core/compiler';
 
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
-
-// Web Worker from CDN URL (add the version to in the URL)
-importScripts('https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js');
-// self.stencil will be available after the script import
 ```
 
 

--- a/versioned_docs/version-v4.14/core/compiler-api.md
+++ b/versioned_docs/version-v4.14/core/compiler-api.md
@@ -12,16 +12,15 @@ work within a NodeJS environment, web worker, and browser window. The
 `stencil.min.js` file is also provided and recommended when used within a browser.
 
 ```tsx
+// NodeJS (esm)
+import stencil from '@stencil/core/compiler';
+
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
 
 // Web Worker from CDN URL (add the version to in the URL)
 importScripts('https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js');
 // self.stencil will be available after the script import
-
-// Browser Window
-<script src="https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js"></script>
-// window.stencil will be available after the script executes
 ```
 
 

--- a/versioned_docs/version-v4.2/core/compiler-api.md
+++ b/versioned_docs/version-v4.2/core/compiler-api.md
@@ -12,13 +12,9 @@ work within a NodeJS environment, web worker, and browser window. The
 `stencil.min.js` file is also provided and recommended when used within a browser.
 
 ```tsx
-// NodeJS (esm)
-import stencil from '@stencil/core/compiler';
-
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
 ```
-
 
 ## transpile()
 

--- a/versioned_docs/version-v4.2/core/compiler-api.md
+++ b/versioned_docs/version-v4.2/core/compiler-api.md
@@ -17,10 +17,6 @@ import stencil from '@stencil/core/compiler';
 
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
-
-// Web Worker from CDN URL (add the version to in the URL)
-importScripts('https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js');
-// self.stencil will be available after the script import
 ```
 
 

--- a/versioned_docs/version-v4.2/core/compiler-api.md
+++ b/versioned_docs/version-v4.2/core/compiler-api.md
@@ -12,16 +12,15 @@ work within a NodeJS environment, web worker, and browser window. The
 `stencil.min.js` file is also provided and recommended when used within a browser.
 
 ```tsx
+// NodeJS (esm)
+import stencil from '@stencil/core/compiler';
+
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
 
 // Web Worker from CDN URL (add the version to in the URL)
 importScripts('https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js');
 // self.stencil will be available after the script import
-
-// Browser Window
-<script src="https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js"></script>
-// window.stencil will be available after the script executes
 ```
 
 

--- a/versioned_docs/version-v4.3/core/compiler-api.md
+++ b/versioned_docs/version-v4.3/core/compiler-api.md
@@ -12,13 +12,9 @@ work within a NodeJS environment, web worker, and browser window. The
 `stencil.min.js` file is also provided and recommended when used within a browser.
 
 ```tsx
-// NodeJS (esm)
-import stencil from '@stencil/core/compiler';
-
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
 ```
-
 
 ## transpile()
 

--- a/versioned_docs/version-v4.3/core/compiler-api.md
+++ b/versioned_docs/version-v4.3/core/compiler-api.md
@@ -17,10 +17,6 @@ import stencil from '@stencil/core/compiler';
 
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
-
-// Web Worker from CDN URL (add the version to in the URL)
-importScripts('https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js');
-// self.stencil will be available after the script import
 ```
 
 

--- a/versioned_docs/version-v4.3/core/compiler-api.md
+++ b/versioned_docs/version-v4.3/core/compiler-api.md
@@ -12,16 +12,15 @@ work within a NodeJS environment, web worker, and browser window. The
 `stencil.min.js` file is also provided and recommended when used within a browser.
 
 ```tsx
+// NodeJS (esm)
+import stencil from '@stencil/core/compiler';
+
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
 
 // Web Worker from CDN URL (add the version to in the URL)
 importScripts('https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js');
 // self.stencil will be available after the script import
-
-// Browser Window
-<script src="https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js"></script>
-// window.stencil will be available after the script executes
 ```
 
 

--- a/versioned_docs/version-v4.4/core/compiler-api.md
+++ b/versioned_docs/version-v4.4/core/compiler-api.md
@@ -12,13 +12,9 @@ work within a NodeJS environment, web worker, and browser window. The
 `stencil.min.js` file is also provided and recommended when used within a browser.
 
 ```tsx
-// NodeJS (esm)
-import stencil from '@stencil/core/compiler';
-
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
 ```
-
 
 ## transpile()
 

--- a/versioned_docs/version-v4.4/core/compiler-api.md
+++ b/versioned_docs/version-v4.4/core/compiler-api.md
@@ -17,10 +17,6 @@ import stencil from '@stencil/core/compiler';
 
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
-
-// Web Worker from CDN URL (add the version to in the URL)
-importScripts('https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js');
-// self.stencil will be available after the script import
 ```
 
 

--- a/versioned_docs/version-v4.4/core/compiler-api.md
+++ b/versioned_docs/version-v4.4/core/compiler-api.md
@@ -12,16 +12,15 @@ work within a NodeJS environment, web worker, and browser window. The
 `stencil.min.js` file is also provided and recommended when used within a browser.
 
 ```tsx
+// NodeJS (esm)
+import stencil from '@stencil/core/compiler';
+
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
 
 // Web Worker from CDN URL (add the version to in the URL)
 importScripts('https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js');
 // self.stencil will be available after the script import
-
-// Browser Window
-<script src="https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js"></script>
-// window.stencil will be available after the script executes
 ```
 
 

--- a/versioned_docs/version-v4.5/core/compiler-api.md
+++ b/versioned_docs/version-v4.5/core/compiler-api.md
@@ -12,13 +12,9 @@ work within a NodeJS environment, web worker, and browser window. The
 `stencil.min.js` file is also provided and recommended when used within a browser.
 
 ```tsx
-// NodeJS (esm)
-import stencil from '@stencil/core/compiler';
-
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
 ```
-
 
 ## transpile()
 

--- a/versioned_docs/version-v4.5/core/compiler-api.md
+++ b/versioned_docs/version-v4.5/core/compiler-api.md
@@ -17,10 +17,6 @@ import stencil from '@stencil/core/compiler';
 
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
-
-// Web Worker from CDN URL (add the version to in the URL)
-importScripts('https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js');
-// self.stencil will be available after the script import
 ```
 
 

--- a/versioned_docs/version-v4.5/core/compiler-api.md
+++ b/versioned_docs/version-v4.5/core/compiler-api.md
@@ -12,16 +12,15 @@ work within a NodeJS environment, web worker, and browser window. The
 `stencil.min.js` file is also provided and recommended when used within a browser.
 
 ```tsx
+// NodeJS (esm)
+import stencil from '@stencil/core/compiler';
+
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
 
 // Web Worker from CDN URL (add the version to in the URL)
 importScripts('https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js');
 // self.stencil will be available after the script import
-
-// Browser Window
-<script src="https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js"></script>
-// window.stencil will be available after the script executes
 ```
 
 

--- a/versioned_docs/version-v4.6/core/compiler-api.md
+++ b/versioned_docs/version-v4.6/core/compiler-api.md
@@ -12,13 +12,9 @@ work within a NodeJS environment, web worker, and browser window. The
 `stencil.min.js` file is also provided and recommended when used within a browser.
 
 ```tsx
-// NodeJS (esm)
-import stencil from '@stencil/core/compiler';
-
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
 ```
-
 
 ## transpile()
 

--- a/versioned_docs/version-v4.6/core/compiler-api.md
+++ b/versioned_docs/version-v4.6/core/compiler-api.md
@@ -17,10 +17,6 @@ import stencil from '@stencil/core/compiler';
 
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
-
-// Web Worker from CDN URL (add the version to in the URL)
-importScripts('https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js');
-// self.stencil will be available after the script import
 ```
 
 

--- a/versioned_docs/version-v4.6/core/compiler-api.md
+++ b/versioned_docs/version-v4.6/core/compiler-api.md
@@ -12,16 +12,15 @@ work within a NodeJS environment, web worker, and browser window. The
 `stencil.min.js` file is also provided and recommended when used within a browser.
 
 ```tsx
+// NodeJS (esm)
+import stencil from '@stencil/core/compiler';
+
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
 
 // Web Worker from CDN URL (add the version to in the URL)
 importScripts('https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js');
 // self.stencil will be available after the script import
-
-// Browser Window
-<script src="https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js"></script>
-// window.stencil will be available after the script executes
 ```
 
 

--- a/versioned_docs/version-v4.7/core/compiler-api.md
+++ b/versioned_docs/version-v4.7/core/compiler-api.md
@@ -12,13 +12,9 @@ work within a NodeJS environment, web worker, and browser window. The
 `stencil.min.js` file is also provided and recommended when used within a browser.
 
 ```tsx
-// NodeJS (esm)
-import stencil from '@stencil/core/compiler';
-
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
 ```
-
 
 ## transpile()
 

--- a/versioned_docs/version-v4.7/core/compiler-api.md
+++ b/versioned_docs/version-v4.7/core/compiler-api.md
@@ -17,10 +17,6 @@ import stencil from '@stencil/core/compiler';
 
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
-
-// Web Worker from CDN URL (add the version to in the URL)
-importScripts('https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js');
-// self.stencil will be available after the script import
 ```
 
 

--- a/versioned_docs/version-v4.7/core/compiler-api.md
+++ b/versioned_docs/version-v4.7/core/compiler-api.md
@@ -12,16 +12,15 @@ work within a NodeJS environment, web worker, and browser window. The
 `stencil.min.js` file is also provided and recommended when used within a browser.
 
 ```tsx
+// NodeJS (esm)
+import stencil from '@stencil/core/compiler';
+
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
 
 // Web Worker from CDN URL (add the version to in the URL)
 importScripts('https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js');
 // self.stencil will be available after the script import
-
-// Browser Window
-<script src="https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js"></script>
-// window.stencil will be available after the script executes
 ```
 
 

--- a/versioned_docs/version-v4.8/core/compiler-api.md
+++ b/versioned_docs/version-v4.8/core/compiler-api.md
@@ -12,13 +12,9 @@ work within a NodeJS environment, web worker, and browser window. The
 `stencil.min.js` file is also provided and recommended when used within a browser.
 
 ```tsx
-// NodeJS (esm)
-import stencil from '@stencil/core/compiler';
-
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
 ```
-
 
 ## transpile()
 

--- a/versioned_docs/version-v4.8/core/compiler-api.md
+++ b/versioned_docs/version-v4.8/core/compiler-api.md
@@ -17,10 +17,6 @@ import stencil from '@stencil/core/compiler';
 
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
-
-// Web Worker from CDN URL (add the version to in the URL)
-importScripts('https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js');
-// self.stencil will be available after the script import
 ```
 
 

--- a/versioned_docs/version-v4.8/core/compiler-api.md
+++ b/versioned_docs/version-v4.8/core/compiler-api.md
@@ -12,16 +12,15 @@ work within a NodeJS environment, web worker, and browser window. The
 `stencil.min.js` file is also provided and recommended when used within a browser.
 
 ```tsx
+// NodeJS (esm)
+import stencil from '@stencil/core/compiler';
+
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
 
 // Web Worker from CDN URL (add the version to in the URL)
 importScripts('https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js');
 // self.stencil will be available after the script import
-
-// Browser Window
-<script src="https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js"></script>
-// window.stencil will be available after the script executes
 ```
 
 

--- a/versioned_docs/version-v4.9/core/compiler-api.md
+++ b/versioned_docs/version-v4.9/core/compiler-api.md
@@ -12,13 +12,9 @@ work within a NodeJS environment, web worker, and browser window. The
 `stencil.min.js` file is also provided and recommended when used within a browser.
 
 ```tsx
-// NodeJS (esm)
-import stencil from '@stencil/core/compiler';
-
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
 ```
-
 
 ## transpile()
 

--- a/versioned_docs/version-v4.9/core/compiler-api.md
+++ b/versioned_docs/version-v4.9/core/compiler-api.md
@@ -17,10 +17,6 @@ import stencil from '@stencil/core/compiler';
 
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
-
-// Web Worker from CDN URL (add the version to in the URL)
-importScripts('https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js');
-// self.stencil will be available after the script import
 ```
 
 

--- a/versioned_docs/version-v4.9/core/compiler-api.md
+++ b/versioned_docs/version-v4.9/core/compiler-api.md
@@ -12,16 +12,15 @@ work within a NodeJS environment, web worker, and browser window. The
 `stencil.min.js` file is also provided and recommended when used within a browser.
 
 ```tsx
+// NodeJS (esm)
+import stencil from '@stencil/core/compiler';
+
 // NodeJS (commonjs)
 const stencil = require('@stencil/core/compiler');
 
 // Web Worker from CDN URL (add the version to in the URL)
 importScripts('https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js');
 // self.stencil will be available after the script import
-
-// Browser Window
-<script src="https://cdn.jsdelivr.net/npm/@stencil/core@[VERSION]/compiler/stencil.min.js"></script>
-// window.stencil will be available after the script executes
 ```
 
 


### PR DESCRIPTION
It turns out this is not supported anymore since v3.3.0 of Stencil and the introduction of TypeScript v5. This patch removes these artifacts from the docs, except v3 and v2.