### PR TITLE
docs(support): add typescript 5.4.4 to support table

### DIFF
--- a/docs/reference/support-policy.md
+++ b/docs/reference/support-policy.md
@@ -86,6 +86,7 @@ The table below describes recent versions of Stencil and the version of TypeScri
 
 | Stencil Version | TypeScript Version |
 |:---------------:|:------------------:|
+|     v4.15.0     |       v5.4.4       |
 |     v4.14.0     |       v5.4.3       |
 |     v4.13.0     |       v5.4.2       |
 |     v4.10.0     |       v5.3.0       |


### PR DESCRIPTION
add typescript v5.4.4 to the suport table, in antcipation of this being a part of the v4.15.0 release

Implementation -  https://github.com/ionic-team/stencil/pull/5636

STENCIL-1255