### PR TITLE
docs(compiler): remove references to using the compiler in a browser

### DIFF
--- a/docs/core/compiler-api.md
+++ b/docs/core/compiler-api.md
@@ -8,8 +8,8 @@ slug: /compiler-api
 # Stencil Core Compiler API
 
 The compiler API can be found at `@stencil/core/compiler/stencil.js`. This module can 
-work within a NodeJS environment, web worker, and browser window. The
-`stencil.min.js` file is also provided and recommended when used within a browser.
+work in a NodeJS environment.
+
 
 ```tsx
 // NodeJS (commonjs)

--- a/versioned_docs/version-v4.0/core/compiler-api.md
+++ b/versioned_docs/version-v4.0/core/compiler-api.md
@@ -8,8 +8,8 @@ slug: /compiler-api
 # Stencil Core Compiler API
 
 The compiler API can be found at `@stencil/core/compiler/stencil.js`. This module can 
-work within a NodeJS environment, web worker, and browser window. The
-`stencil.min.js` file is also provided and recommended when used within a browser.
+work in a NodeJS environment.
+
 
 ```tsx
 // NodeJS (commonjs)

--- a/versioned_docs/version-v4.1/core/compiler-api.md
+++ b/versioned_docs/version-v4.1/core/compiler-api.md
@@ -8,8 +8,8 @@ slug: /compiler-api
 # Stencil Core Compiler API
 
 The compiler API can be found at `@stencil/core/compiler/stencil.js`. This module can 
-work within a NodeJS environment, web worker, and browser window. The
-`stencil.min.js` file is also provided and recommended when used within a browser.
+work in a NodeJS environment.
+
 
 ```tsx
 // NodeJS (commonjs)

--- a/versioned_docs/version-v4.10/core/compiler-api.md
+++ b/versioned_docs/version-v4.10/core/compiler-api.md
@@ -8,8 +8,8 @@ slug: /compiler-api
 # Stencil Core Compiler API
 
 The compiler API can be found at `@stencil/core/compiler/stencil.js`. This module can 
-work within a NodeJS environment, web worker, and browser window. The
-`stencil.min.js` file is also provided and recommended when used within a browser.
+work in a NodeJS environment.
+
 
 ```tsx
 // NodeJS (commonjs)

--- a/versioned_docs/version-v4.11/core/compiler-api.md
+++ b/versioned_docs/version-v4.11/core/compiler-api.md
@@ -8,8 +8,8 @@ slug: /compiler-api
 # Stencil Core Compiler API
 
 The compiler API can be found at `@stencil/core/compiler/stencil.js`. This module can 
-work within a NodeJS environment, web worker, and browser window. The
-`stencil.min.js` file is also provided and recommended when used within a browser.
+work in a NodeJS environment.
+
 
 ```tsx
 // NodeJS (commonjs)

--- a/versioned_docs/version-v4.12/core/compiler-api.md
+++ b/versioned_docs/version-v4.12/core/compiler-api.md
@@ -8,8 +8,8 @@ slug: /compiler-api
 # Stencil Core Compiler API
 
 The compiler API can be found at `@stencil/core/compiler/stencil.js`. This module can 
-work within a NodeJS environment, web worker, and browser window. The
-`stencil.min.js` file is also provided and recommended when used within a browser.
+work in a NodeJS environment.
+
 
 ```tsx
 // NodeJS (commonjs)

--- a/versioned_docs/version-v4.13.0/core/compiler-api.md
+++ b/versioned_docs/version-v4.13.0/core/compiler-api.md
@@ -8,8 +8,8 @@ slug: /compiler-api
 # Stencil Core Compiler API
 
 The compiler API can be found at `@stencil/core/compiler/stencil.js`. This module can 
-work within a NodeJS environment, web worker, and browser window. The
-`stencil.min.js` file is also provided and recommended when used within a browser.
+work in a NodeJS environment.
+
 
 ```tsx
 // NodeJS (commonjs)

--- a/versioned_docs/version-v4.14/core/compiler-api.md
+++ b/versioned_docs/version-v4.14/core/compiler-api.md
@@ -8,8 +8,7 @@ slug: /compiler-api
 # Stencil Core Compiler API
 
 The compiler API can be found at `@stencil/core/compiler/stencil.js`. This module can 
-work within a NodeJS environment, web worker, and browser window. The
-`stencil.min.js` file is also provided and recommended when used within a browser.
+work in a NodeJS environment.
 
 ```tsx
 // NodeJS (commonjs)

--- a/versioned_docs/version-v4.15/core/compiler-api.md
+++ b/versioned_docs/version-v4.15/core/compiler-api.md
@@ -8,8 +8,8 @@ slug: /compiler-api
 # Stencil Core Compiler API
 
 The compiler API can be found at `@stencil/core/compiler/stencil.js`. This module can 
-work within a NodeJS environment, web worker, and browser window. The
-`stencil.min.js` file is also provided and recommended when used within a browser.
+work in a NodeJS environment.
+
 
 ```tsx
 // NodeJS (commonjs)

--- a/versioned_docs/version-v4.2/core/compiler-api.md
+++ b/versioned_docs/version-v4.2/core/compiler-api.md
@@ -8,8 +8,8 @@ slug: /compiler-api
 # Stencil Core Compiler API
 
 The compiler API can be found at `@stencil/core/compiler/stencil.js`. This module can 
-work within a NodeJS environment, web worker, and browser window. The
-`stencil.min.js` file is also provided and recommended when used within a browser.
+work in a NodeJS environment.
+
 
 ```tsx
 // NodeJS (commonjs)

--- a/versioned_docs/version-v4.3/core/compiler-api.md
+++ b/versioned_docs/version-v4.3/core/compiler-api.md
@@ -8,8 +8,8 @@ slug: /compiler-api
 # Stencil Core Compiler API
 
 The compiler API can be found at `@stencil/core/compiler/stencil.js`. This module can 
-work within a NodeJS environment, web worker, and browser window. The
-`stencil.min.js` file is also provided and recommended when used within a browser.
+work in a NodeJS environment.
+
 
 ```tsx
 // NodeJS (commonjs)

--- a/versioned_docs/version-v4.4/core/compiler-api.md
+++ b/versioned_docs/version-v4.4/core/compiler-api.md
@@ -8,8 +8,8 @@ slug: /compiler-api
 # Stencil Core Compiler API
 
 The compiler API can be found at `@stencil/core/compiler/stencil.js`. This module can 
-work within a NodeJS environment, web worker, and browser window. The
-`stencil.min.js` file is also provided and recommended when used within a browser.
+work in a NodeJS environment.
+
 
 ```tsx
 // NodeJS (commonjs)

--- a/versioned_docs/version-v4.5/core/compiler-api.md
+++ b/versioned_docs/version-v4.5/core/compiler-api.md
@@ -8,8 +8,8 @@ slug: /compiler-api
 # Stencil Core Compiler API
 
 The compiler API can be found at `@stencil/core/compiler/stencil.js`. This module can 
-work within a NodeJS environment, web worker, and browser window. The
-`stencil.min.js` file is also provided and recommended when used within a browser.
+work in a NodeJS environment.
+
 
 ```tsx
 // NodeJS (commonjs)

--- a/versioned_docs/version-v4.6/core/compiler-api.md
+++ b/versioned_docs/version-v4.6/core/compiler-api.md
@@ -8,8 +8,8 @@ slug: /compiler-api
 # Stencil Core Compiler API
 
 The compiler API can be found at `@stencil/core/compiler/stencil.js`. This module can 
-work within a NodeJS environment, web worker, and browser window. The
-`stencil.min.js` file is also provided and recommended when used within a browser.
+work in a NodeJS environment.
+
 
 ```tsx
 // NodeJS (commonjs)

--- a/versioned_docs/version-v4.7/core/compiler-api.md
+++ b/versioned_docs/version-v4.7/core/compiler-api.md
@@ -8,8 +8,8 @@ slug: /compiler-api
 # Stencil Core Compiler API
 
 The compiler API can be found at `@stencil/core/compiler/stencil.js`. This module can 
-work within a NodeJS environment, web worker, and browser window. The
-`stencil.min.js` file is also provided and recommended when used within a browser.
+work in a NodeJS environment.
+
 
 ```tsx
 // NodeJS (commonjs)

--- a/versioned_docs/version-v4.8/core/compiler-api.md
+++ b/versioned_docs/version-v4.8/core/compiler-api.md
@@ -8,8 +8,8 @@ slug: /compiler-api
 # Stencil Core Compiler API
 
 The compiler API can be found at `@stencil/core/compiler/stencil.js`. This module can 
-work within a NodeJS environment, web worker, and browser window. The
-`stencil.min.js` file is also provided and recommended when used within a browser.
+work in a NodeJS environment.
+
 
 ```tsx
 // NodeJS (commonjs)

--- a/versioned_docs/version-v4.9/core/compiler-api.md
+++ b/versioned_docs/version-v4.9/core/compiler-api.md
@@ -8,8 +8,8 @@ slug: /compiler-api
 # Stencil Core Compiler API
 
 The compiler API can be found at `@stencil/core/compiler/stencil.js`. This module can 
-work within a NodeJS environment, web worker, and browser window. The
-`stencil.min.js` file is also provided and recommended when used within a browser.
+work in a NodeJS environment.
+
 
 ```tsx
 // NodeJS (commonjs)


### PR DESCRIPTION
For ionic-team/stencil#5645