### PR TITLE
fix(docs): update playwright config helper function name

### DIFF
--- a/docs/testing/playwright/01-overview.md
+++ b/docs/testing/playwright/01-overview.md
@@ -47,7 +47,7 @@ To install the Stencil Playwright adapter in an existing Stencil project, follow
    ```
 
    The `createConfig()` is a utility that will create a default Playwright configuration based on your project's Stencil config. Read
-   more about how to use this utility in the [API docs](./03-api.md#createConfig-function).
+   more about how to use this utility in the [API docs](./03-api.md#createconfig-function).
 
 1. update your project's `tsconfig.json` to add the `ESNext.Disposable` option to the `lib` array:
 

--- a/docs/testing/playwright/01-overview.md
+++ b/docs/testing/playwright/01-overview.md
@@ -36,18 +36,18 @@ To install the Stencil Playwright adapter in an existing Stencil project, follow
 
    ```ts title="playwright.config.ts"
    import { expect } from '@playwright/test';
-   import { matchers, createStencilPlaywrightConfig } from '@stencil/playwright';
+   import { matchers, createConfig } from '@stencil/playwright';
 
    // Add custom Stencil matchers to Playwright assertions
    expect.extend(matchers);
 
-   export default createStencilPlaywrightConfig({
+   export default createConfig({
      // Overwrite Playwright config options here
    });
    ```
 
-   The `createStencilPlaywrightConfig()` is a utility that will create a default Playwright configuration based on your project's Stencil config. Read
-   more about how to use this utility in the [API docs](./03-api.md#createstencilplaywrightconfig-function).
+   The `createConfig()` is a utility that will create a default Playwright configuration based on your project's Stencil config. Read
+   more about how to use this utility in the [API docs](./03-api.md#createConfig-function).
 
 1. update your project's `tsconfig.json` to add the `ESNext.Disposable` option to the `lib` array:
 
@@ -67,7 +67,7 @@ To install the Stencil Playwright adapter in an existing Stencil project, follow
    :::
 
 1. Ensure the Stencil project has a [`www` output target](../../output-targets/www.md). Playwright relies on pre-compiled output running in a dev server
-   to run tests against. When using the `createStencilPlaywrightConfig()` helper, a configuration for the dev server will be automatically created based on
+   to run tests against. When using the `createConfig()` helper, a configuration for the dev server will be automatically created based on
    the Stencil project's `www` output target config and [dev server config](../../config/dev-server.md). If no `www` output target is specified,
    tests will not be able to run.
 
@@ -107,7 +107,7 @@ options:
 - **Option 1:** Update the Playwright config to match a different test file pattern:
 
   ```ts title="playwright.config.ts"
-  export default createStencilPlaywrightConfig({
+  export default createConfig({
     // Example: match all test files with the 'e2e.playwright.ts' naming convention
     testMatch: '*.e2e.playwright.ts',
   });

--- a/docs/testing/playwright/02-e2e-testing.md
+++ b/docs/testing/playwright/02-e2e-testing.md
@@ -143,7 +143,7 @@ Playwright command.
 
 By default, the adapter will execute all tests in a project with a `.e2e.ts` file suffix. This can be modified by passing the
 [`testDir`](https://playwright.dev/docs/api/class-testproject#test-project-test-dir) and/or [`testMatch`](https://playwright.dev/docs/api/class-testproject#test-project-test-match)
-configuration options as overrides to `createStencilPlaywrightConfig()`.
+configuration options as overrides to `createConfig()`.
 
 ## Debugging
 

--- a/docs/testing/playwright/03-api.md
+++ b/docs/testing/playwright/03-api.md
@@ -3,9 +3,9 @@ title: Playwright Adapter API
 sidebar_label: API
 ---
 
-## `createStencilPlaywrightConfig` Function
+## `createConfig` Function
 
-**Signature:** `createStencilPlaywrightConfig(overrides?: CreateStencilPlaywrightConfigOptions): Promise<PlaywrightTestConfig>`
+**Signature:** `createConfig(overrides?: CreateStencilPlaywrightConfigOptions): Promise<PlaywrightTestConfig>`
 
 Returns a [Playwright test configuration](https://playwright.dev/docs/test-configuration#introduction).
 
@@ -17,11 +17,11 @@ as some options to override specific values in the config options related to the
 
 ```ts title="playwright.config.ts"
 import { expect } from '@playwright/test';
-import { matchers, createStencilPlaywrightConfig } from '@stencil/playwright';
+import { matchers, createConfig } from '@stencil/playwright';
 
 expect.extend(matchers);
 
-export default createStencilPlaywrightConfig({
+export default createConfig({
   // Change which test files Playwright will execute
   testMatch: '*.spec.ts',
 

--- a/versioned_docs/version-v4.13.0/testing/playwright/01-overview.md
+++ b/versioned_docs/version-v4.13.0/testing/playwright/01-overview.md
@@ -47,7 +47,7 @@ To install the Stencil Playwright adapter in an existing Stencil project, follow
    ```
 
    The `createConfig()` is a utility that will create a default Playwright configuration based on your project's Stencil config. Read
-   more about how to use this utility in the [API docs](./03-api.md#createConfig-function).
+   more about how to use this utility in the [API docs](./03-api.md#createconfig-function).
 
 1. update your project's `tsconfig.json` to add the `ESNext.Disposable` option to the `lib` array:
 

--- a/versioned_docs/version-v4.13.0/testing/playwright/01-overview.md
+++ b/versioned_docs/version-v4.13.0/testing/playwright/01-overview.md
@@ -36,18 +36,18 @@ To install the Stencil Playwright adapter in an existing Stencil project, follow
 
    ```ts title="playwright.config.ts"
    import { expect } from '@playwright/test';
-   import { matchers, createStencilPlaywrightConfig } from '@stencil/playwright';
+   import { matchers, createConfig } from '@stencil/playwright';
 
    // Add custom Stencil matchers to Playwright assertions
    expect.extend(matchers);
 
-   export default createStencilPlaywrightConfig({
+   export default createConfig({
      // Overwrite Playwright config options here
    });
    ```
 
-   The `createStencilPlaywrightConfig()` is a utility that will create a default Playwright configuration based on your project's Stencil config. Read
-   more about how to use this utility in the [API docs](./03-api.md#createstencilplaywrightconfig-function).
+   The `createConfig()` is a utility that will create a default Playwright configuration based on your project's Stencil config. Read
+   more about how to use this utility in the [API docs](./03-api.md#createConfig-function).
 
 1. update your project's `tsconfig.json` to add the `ESNext.Disposable` option to the `lib` array:
 
@@ -67,7 +67,7 @@ To install the Stencil Playwright adapter in an existing Stencil project, follow
    :::
 
 1. Ensure the Stencil project has a [`www` output target](../../output-targets/www.md). Playwright relies on pre-compiled output running in a dev server
-   to run tests against. When using the `createStencilPlaywrightConfig()` helper, a configuration for the dev server will be automatically created based on
+   to run tests against. When using the `createConfig()` helper, a configuration for the dev server will be automatically created based on
    the Stencil project's `www` output target config and [dev server config](../../config/dev-server.md). If no `www` output target is specified,
    tests will not be able to run.
 
@@ -107,7 +107,7 @@ options:
 - **Option 1:** Update the Playwright config to match a different test file pattern:
 
   ```ts title="playwright.config.ts"
-  export default createStencilPlaywrightConfig({
+  export default createConfig({
     // Example: match all test files with the 'e2e.playwright.ts' naming convention
     testMatch: '*.e2e.playwright.ts',
   });

--- a/versioned_docs/version-v4.13.0/testing/playwright/02-e2e-testing.md
+++ b/versioned_docs/version-v4.13.0/testing/playwright/02-e2e-testing.md
@@ -143,7 +143,7 @@ Playwright command.
 
 By default, the adapter will execute all tests in a project with a `.e2e.ts` file suffix. This can be modified by passing the
 [`testDir`](https://playwright.dev/docs/api/class-testproject#test-project-test-dir) and/or [`testMatch`](https://playwright.dev/docs/api/class-testproject#test-project-test-match)
-configuration options as overrides to `createStencilPlaywrightConfig()`.
+configuration options as overrides to `createConfig()`.
 
 ## Debugging
 

--- a/versioned_docs/version-v4.13.0/testing/playwright/03-api.md
+++ b/versioned_docs/version-v4.13.0/testing/playwright/03-api.md
@@ -3,9 +3,9 @@ title: Playwright Adapter API
 sidebar_label: API
 ---
 
-## `createStencilPlaywrightConfig` Function
+## `createConfig` Function
 
-**Signature:** `createStencilPlaywrightConfig(overrides?: CreateStencilPlaywrightConfigOptions): Promise<PlaywrightTestConfig>`
+**Signature:** `createConfig(overrides?: CreateStencilPlaywrightConfigOptions): Promise<PlaywrightTestConfig>`
 
 Returns a [Playwright test configuration](https://playwright.dev/docs/test-configuration#introduction).
 
@@ -17,11 +17,11 @@ as some options to override specific values in the config options related to the
 
 ```ts title="playwright.config.ts"
 import { expect } from '@playwright/test';
-import { matchers, createStencilPlaywrightConfig } from '@stencil/playwright';
+import { matchers, createConfig } from '@stencil/playwright';
 
 expect.extend(matchers);
 
-export default createStencilPlaywrightConfig({
+export default createConfig({
   // Change which test files Playwright will execute
   testMatch: '*.spec.ts',
 

--- a/versioned_docs/version-v4.14/testing/playwright/01-overview.md
+++ b/versioned_docs/version-v4.14/testing/playwright/01-overview.md
@@ -47,7 +47,7 @@ To install the Stencil Playwright adapter in an existing Stencil project, follow
    ```
 
    The `createConfig()` is a utility that will create a default Playwright configuration based on your project's Stencil config. Read
-   more about how to use this utility in the [API docs](./03-api.md#createConfig-function).
+   more about how to use this utility in the [API docs](./03-api.md#createconfig-function).
 
 1. update your project's `tsconfig.json` to add the `ESNext.Disposable` option to the `lib` array:
 

--- a/versioned_docs/version-v4.14/testing/playwright/01-overview.md
+++ b/versioned_docs/version-v4.14/testing/playwright/01-overview.md
@@ -36,18 +36,18 @@ To install the Stencil Playwright adapter in an existing Stencil project, follow
 
    ```ts title="playwright.config.ts"
    import { expect } from '@playwright/test';
-   import { matchers, createStencilPlaywrightConfig } from '@stencil/playwright';
+   import { matchers, createConfig } from '@stencil/playwright';
 
    // Add custom Stencil matchers to Playwright assertions
    expect.extend(matchers);
 
-   export default createStencilPlaywrightConfig({
+   export default createConfig({
      // Overwrite Playwright config options here
    });
    ```
 
-   The `createStencilPlaywrightConfig()` is a utility that will create a default Playwright configuration based on your project's Stencil config. Read
-   more about how to use this utility in the [API docs](./03-api.md#createstencilplaywrightconfig-function).
+   The `createConfig()` is a utility that will create a default Playwright configuration based on your project's Stencil config. Read
+   more about how to use this utility in the [API docs](./03-api.md#createConfig-function).
 
 1. update your project's `tsconfig.json` to add the `ESNext.Disposable` option to the `lib` array:
 
@@ -67,7 +67,7 @@ To install the Stencil Playwright adapter in an existing Stencil project, follow
    :::
 
 1. Ensure the Stencil project has a [`www` output target](../../output-targets/www.md). Playwright relies on pre-compiled output running in a dev server
-   to run tests against. When using the `createStencilPlaywrightConfig()` helper, a configuration for the dev server will be automatically created based on
+   to run tests against. When using the `createConfig()` helper, a configuration for the dev server will be automatically created based on
    the Stencil project's `www` output target config and [dev server config](../../config/dev-server.md). If no `www` output target is specified,
    tests will not be able to run.
 
@@ -107,7 +107,7 @@ options:
 - **Option 1:** Update the Playwright config to match a different test file pattern:
 
   ```ts title="playwright.config.ts"
-  export default createStencilPlaywrightConfig({
+  export default createConfig({
     // Example: match all test files with the 'e2e.playwright.ts' naming convention
     testMatch: '*.e2e.playwright.ts',
   });

--- a/versioned_docs/version-v4.14/testing/playwright/02-e2e-testing.md
+++ b/versioned_docs/version-v4.14/testing/playwright/02-e2e-testing.md
@@ -143,7 +143,7 @@ Playwright command.
 
 By default, the adapter will execute all tests in a project with a `.e2e.ts` file suffix. This can be modified by passing the
 [`testDir`](https://playwright.dev/docs/api/class-testproject#test-project-test-dir) and/or [`testMatch`](https://playwright.dev/docs/api/class-testproject#test-project-test-match)
-configuration options as overrides to `createStencilPlaywrightConfig()`.
+configuration options as overrides to `createConfig()`.
 
 ## Debugging
 

--- a/versioned_docs/version-v4.14/testing/playwright/03-api.md
+++ b/versioned_docs/version-v4.14/testing/playwright/03-api.md
@@ -3,9 +3,9 @@ title: Playwright Adapter API
 sidebar_label: API
 ---
 
-## `createStencilPlaywrightConfig` Function
+## `createConfig` Function
 
-**Signature:** `createStencilPlaywrightConfig(overrides?: CreateStencilPlaywrightConfigOptions): Promise<PlaywrightTestConfig>`
+**Signature:** `createConfig(overrides?: CreateStencilPlaywrightConfigOptions): Promise<PlaywrightTestConfig>`
 
 Returns a [Playwright test configuration](https://playwright.dev/docs/test-configuration#introduction).
 
@@ -17,11 +17,11 @@ as some options to override specific values in the config options related to the
 
 ```ts title="playwright.config.ts"
 import { expect } from '@playwright/test';
-import { matchers, createStencilPlaywrightConfig } from '@stencil/playwright';
+import { matchers, createConfig } from '@stencil/playwright';
 
 expect.extend(matchers);
 
-export default createStencilPlaywrightConfig({
+export default createConfig({
   // Change which test files Playwright will execute
   testMatch: '*.spec.ts',
 

--- a/versioned_docs/version-v4.15/testing/playwright/01-overview.md
+++ b/versioned_docs/version-v4.15/testing/playwright/01-overview.md
@@ -47,7 +47,7 @@ To install the Stencil Playwright adapter in an existing Stencil project, follow
    ```
 
    The `createConfig()` is a utility that will create a default Playwright configuration based on your project's Stencil config. Read
-   more about how to use this utility in the [API docs](./03-api.md#createConfig-function).
+   more about how to use this utility in the [API docs](./03-api.md#createconfig-function).
 
 1. update your project's `tsconfig.json` to add the `ESNext.Disposable` option to the `lib` array:
 

--- a/versioned_docs/version-v4.15/testing/playwright/01-overview.md
+++ b/versioned_docs/version-v4.15/testing/playwright/01-overview.md
@@ -36,18 +36,18 @@ To install the Stencil Playwright adapter in an existing Stencil project, follow
 
    ```ts title="playwright.config.ts"
    import { expect } from '@playwright/test';
-   import { matchers, createStencilPlaywrightConfig } from '@stencil/playwright';
+   import { matchers, createConfig } from '@stencil/playwright';
 
    // Add custom Stencil matchers to Playwright assertions
    expect.extend(matchers);
 
-   export default createStencilPlaywrightConfig({
+   export default createConfig({
      // Overwrite Playwright config options here
    });
    ```
 
-   The `createStencilPlaywrightConfig()` is a utility that will create a default Playwright configuration based on your project's Stencil config. Read
-   more about how to use this utility in the [API docs](./03-api.md#createstencilplaywrightconfig-function).
+   The `createConfig()` is a utility that will create a default Playwright configuration based on your project's Stencil config. Read
+   more about how to use this utility in the [API docs](./03-api.md#createConfig-function).
 
 1. update your project's `tsconfig.json` to add the `ESNext.Disposable` option to the `lib` array:
 
@@ -67,7 +67,7 @@ To install the Stencil Playwright adapter in an existing Stencil project, follow
    :::
 
 1. Ensure the Stencil project has a [`www` output target](../../output-targets/www.md). Playwright relies on pre-compiled output running in a dev server
-   to run tests against. When using the `createStencilPlaywrightConfig()` helper, a configuration for the dev server will be automatically created based on
+   to run tests against. When using the `createConfig()` helper, a configuration for the dev server will be automatically created based on
    the Stencil project's `www` output target config and [dev server config](../../config/dev-server.md). If no `www` output target is specified,
    tests will not be able to run.
 
@@ -107,7 +107,7 @@ options:
 - **Option 1:** Update the Playwright config to match a different test file pattern:
 
   ```ts title="playwright.config.ts"
-  export default createStencilPlaywrightConfig({
+  export default createConfig({
     // Example: match all test files with the 'e2e.playwright.ts' naming convention
     testMatch: '*.e2e.playwright.ts',
   });

--- a/versioned_docs/version-v4.15/testing/playwright/02-e2e-testing.md
+++ b/versioned_docs/version-v4.15/testing/playwright/02-e2e-testing.md
@@ -143,7 +143,7 @@ Playwright command.
 
 By default, the adapter will execute all tests in a project with a `.e2e.ts` file suffix. This can be modified by passing the
 [`testDir`](https://playwright.dev/docs/api/class-testproject#test-project-test-dir) and/or [`testMatch`](https://playwright.dev/docs/api/class-testproject#test-project-test-match)
-configuration options as overrides to `createStencilPlaywrightConfig()`.
+configuration options as overrides to `createConfig()`.
 
 ## Debugging
 

--- a/versioned_docs/version-v4.15/testing/playwright/03-api.md
+++ b/versioned_docs/version-v4.15/testing/playwright/03-api.md
@@ -3,9 +3,9 @@ title: Playwright Adapter API
 sidebar_label: API
 ---
 
-## `createStencilPlaywrightConfig` Function
+## `createConfig` Function
 
-**Signature:** `createStencilPlaywrightConfig(overrides?: CreateStencilPlaywrightConfigOptions): Promise<PlaywrightTestConfig>`
+**Signature:** `createConfig(overrides?: CreateStencilPlaywrightConfigOptions): Promise<PlaywrightTestConfig>`
 
 Returns a [Playwright test configuration](https://playwright.dev/docs/test-configuration#introduction).
 
@@ -17,11 +17,11 @@ as some options to override specific values in the config options related to the
 
 ```ts title="playwright.config.ts"
 import { expect } from '@playwright/test';
-import { matchers, createStencilPlaywrightConfig } from '@stencil/playwright';
+import { matchers, createConfig } from '@stencil/playwright';
 
 expect.extend(matchers);
 
-export default createStencilPlaywrightConfig({
+export default createConfig({
   // Change which test files Playwright will execute
   testMatch: '*.spec.ts',
 

--- a/versioned_docs/version-v4.16/testing/playwright/01-overview.md
+++ b/versioned_docs/version-v4.16/testing/playwright/01-overview.md
@@ -47,7 +47,7 @@ To install the Stencil Playwright adapter in an existing Stencil project, follow
    ```
 
    The `createConfig()` is a utility that will create a default Playwright configuration based on your project's Stencil config. Read
-   more about how to use this utility in the [API docs](./03-api.md#createConfig-function).
+   more about how to use this utility in the [API docs](./03-api.md#createconfig-function).
 
 1. update your project's `tsconfig.json` to add the `ESNext.Disposable` option to the `lib` array:
 

--- a/versioned_docs/version-v4.16/testing/playwright/01-overview.md
+++ b/versioned_docs/version-v4.16/testing/playwright/01-overview.md
@@ -36,18 +36,18 @@ To install the Stencil Playwright adapter in an existing Stencil project, follow
 
    ```ts title="playwright.config.ts"
    import { expect } from '@playwright/test';
-   import { matchers, createStencilPlaywrightConfig } from '@stencil/playwright';
+   import { matchers, createConfig } from '@stencil/playwright';
 
    // Add custom Stencil matchers to Playwright assertions
    expect.extend(matchers);
 
-   export default createStencilPlaywrightConfig({
+   export default createConfig({
      // Overwrite Playwright config options here
    });
    ```
 
-   The `createStencilPlaywrightConfig()` is a utility that will create a default Playwright configuration based on your project's Stencil config. Read
-   more about how to use this utility in the [API docs](./03-api.md#createstencilplaywrightconfig-function).
+   The `createConfig()` is a utility that will create a default Playwright configuration based on your project's Stencil config. Read
+   more about how to use this utility in the [API docs](./03-api.md#createConfig-function).
 
 1. update your project's `tsconfig.json` to add the `ESNext.Disposable` option to the `lib` array:
 
@@ -67,7 +67,7 @@ To install the Stencil Playwright adapter in an existing Stencil project, follow
    :::
 
 1. Ensure the Stencil project has a [`www` output target](../../output-targets/www.md). Playwright relies on pre-compiled output running in a dev server
-   to run tests against. When using the `createStencilPlaywrightConfig()` helper, a configuration for the dev server will be automatically created based on
+   to run tests against. When using the `createConfig()` helper, a configuration for the dev server will be automatically created based on
    the Stencil project's `www` output target config and [dev server config](../../config/dev-server.md). If no `www` output target is specified,
    tests will not be able to run.
 
@@ -107,7 +107,7 @@ options:
 - **Option 1:** Update the Playwright config to match a different test file pattern:
 
   ```ts title="playwright.config.ts"
-  export default createStencilPlaywrightConfig({
+  export default createConfig({
     // Example: match all test files with the 'e2e.playwright.ts' naming convention
     testMatch: '*.e2e.playwright.ts',
   });

--- a/versioned_docs/version-v4.16/testing/playwright/02-e2e-testing.md
+++ b/versioned_docs/version-v4.16/testing/playwright/02-e2e-testing.md
@@ -143,7 +143,7 @@ Playwright command.
 
 By default, the adapter will execute all tests in a project with a `.e2e.ts` file suffix. This can be modified by passing the
 [`testDir`](https://playwright.dev/docs/api/class-testproject#test-project-test-dir) and/or [`testMatch`](https://playwright.dev/docs/api/class-testproject#test-project-test-match)
-configuration options as overrides to `createStencilPlaywrightConfig()`.
+configuration options as overrides to `createConfig()`.
 
 ## Debugging
 

--- a/versioned_docs/version-v4.16/testing/playwright/03-api.md
+++ b/versioned_docs/version-v4.16/testing/playwright/03-api.md
@@ -3,9 +3,9 @@ title: Playwright Adapter API
 sidebar_label: API
 ---
 
-## `createStencilPlaywrightConfig` Function
+## `createConfig` Function
 
-**Signature:** `createStencilPlaywrightConfig(overrides?: CreateStencilPlaywrightConfigOptions): Promise<PlaywrightTestConfig>`
+**Signature:** `createConfig(overrides?: CreateStencilPlaywrightConfigOptions): Promise<PlaywrightTestConfig>`
 
 Returns a [Playwright test configuration](https://playwright.dev/docs/test-configuration#introduction).
 
@@ -17,11 +17,11 @@ as some options to override specific values in the config options related to the
 
 ```ts title="playwright.config.ts"
 import { expect } from '@playwright/test';
-import { matchers, createStencilPlaywrightConfig } from '@stencil/playwright';
+import { matchers, createConfig } from '@stencil/playwright';
 
 expect.extend(matchers);
 
-export default createStencilPlaywrightConfig({
+export default createConfig({
   // Change which test files Playwright will execute
   testMatch: '*.spec.ts',
 

--- a/versioned_docs/version-v4.17/testing/playwright/01-overview.md
+++ b/versioned_docs/version-v4.17/testing/playwright/01-overview.md
@@ -47,7 +47,7 @@ To install the Stencil Playwright adapter in an existing Stencil project, follow
    ```
 
    The `createConfig()` is a utility that will create a default Playwright configuration based on your project's Stencil config. Read
-   more about how to use this utility in the [API docs](./03-api.md#createConfig-function).
+   more about how to use this utility in the [API docs](./03-api.md#createconfig-function).
 
 1. update your project's `tsconfig.json` to add the `ESNext.Disposable` option to the `lib` array:
 

--- a/versioned_docs/version-v4.17/testing/playwright/01-overview.md
+++ b/versioned_docs/version-v4.17/testing/playwright/01-overview.md
@@ -36,18 +36,18 @@ To install the Stencil Playwright adapter in an existing Stencil project, follow
 
    ```ts title="playwright.config.ts"
    import { expect } from '@playwright/test';
-   import { matchers, createStencilPlaywrightConfig } from '@stencil/playwright';
+   import { matchers, createConfig } from '@stencil/playwright';
 
    // Add custom Stencil matchers to Playwright assertions
    expect.extend(matchers);
 
-   export default createStencilPlaywrightConfig({
+   export default createConfig({
      // Overwrite Playwright config options here
    });
    ```
 
-   The `createStencilPlaywrightConfig()` is a utility that will create a default Playwright configuration based on your project's Stencil config. Read
-   more about how to use this utility in the [API docs](./03-api.md#createstencilplaywrightconfig-function).
+   The `createConfig()` is a utility that will create a default Playwright configuration based on your project's Stencil config. Read
+   more about how to use this utility in the [API docs](./03-api.md#createConfig-function).
 
 1. update your project's `tsconfig.json` to add the `ESNext.Disposable` option to the `lib` array:
 
@@ -67,7 +67,7 @@ To install the Stencil Playwright adapter in an existing Stencil project, follow
    :::
 
 1. Ensure the Stencil project has a [`www` output target](../../output-targets/www.md). Playwright relies on pre-compiled output running in a dev server
-   to run tests against. When using the `createStencilPlaywrightConfig()` helper, a configuration for the dev server will be automatically created based on
+   to run tests against. When using the `createConfig()` helper, a configuration for the dev server will be automatically created based on
    the Stencil project's `www` output target config and [dev server config](../../config/dev-server.md). If no `www` output target is specified,
    tests will not be able to run.
 
@@ -107,7 +107,7 @@ options:
 - **Option 1:** Update the Playwright config to match a different test file pattern:
 
   ```ts title="playwright.config.ts"
-  export default createStencilPlaywrightConfig({
+  export default createConfig({
     // Example: match all test files with the 'e2e.playwright.ts' naming convention
     testMatch: '*.e2e.playwright.ts',
   });

--- a/versioned_docs/version-v4.17/testing/playwright/02-e2e-testing.md
+++ b/versioned_docs/version-v4.17/testing/playwright/02-e2e-testing.md
@@ -143,7 +143,7 @@ Playwright command.
 
 By default, the adapter will execute all tests in a project with a `.e2e.ts` file suffix. This can be modified by passing the
 [`testDir`](https://playwright.dev/docs/api/class-testproject#test-project-test-dir) and/or [`testMatch`](https://playwright.dev/docs/api/class-testproject#test-project-test-match)
-configuration options as overrides to `createStencilPlaywrightConfig()`.
+configuration options as overrides to `createConfig()`.
 
 ## Debugging
 

--- a/versioned_docs/version-v4.17/testing/playwright/03-api.md
+++ b/versioned_docs/version-v4.17/testing/playwright/03-api.md
@@ -3,9 +3,9 @@ title: Playwright Adapter API
 sidebar_label: API
 ---
 
-## `createStencilPlaywrightConfig` Function
+## `createConfig` Function
 
-**Signature:** `createStencilPlaywrightConfig(overrides?: CreateStencilPlaywrightConfigOptions): Promise<PlaywrightTestConfig>`
+**Signature:** `createConfig(overrides?: CreateStencilPlaywrightConfigOptions): Promise<PlaywrightTestConfig>`
 
 Returns a [Playwright test configuration](https://playwright.dev/docs/test-configuration#introduction).
 
@@ -17,11 +17,11 @@ as some options to override specific values in the config options related to the
 
 ```ts title="playwright.config.ts"
 import { expect } from '@playwright/test';
-import { matchers, createStencilPlaywrightConfig } from '@stencil/playwright';
+import { matchers, createConfig } from '@stencil/playwright';
 
 expect.extend(matchers);
 
-export default createStencilPlaywrightConfig({
+export default createConfig({
   // Change which test files Playwright will execute
   testMatch: '*.spec.ts',
 


### PR DESCRIPTION
Updates the Playwright adapter config creation helper from `createStencilPlaywrightConfig` to `createConfig`.

Documentation changes for associated change in the Playwright adapter: https://github.com/ionic-team/stencil-playwright/pull/37