### PR TITLE
components(api): document 'setAssetPath' API within component section

### DIFF
--- a/docs/components/api.md
+++ b/docs/components/api.md
@@ -157,8 +157,8 @@ The following primitives can be imported from the `@stencil/core` package and us
   __Type:__ `(path: string) => string`<br />
   __Example:__
   ```ts
-  import { setAssetPath } from '@stencil/core'
-  setAssetPath(import.meta.url)
+  import { setAssetPath } from '@stencil/core';
+  setAssetPath(`{window.location.origin}/`)
   ```
 
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.

--- a/docs/components/api.md
+++ b/docs/components/api.md
@@ -158,7 +158,7 @@ The following primitives can be imported from the `@stencil/core` package and us
   __Example:__
   ```ts
   import { setAssetPath } from '@stencil/core';
-  setAssetPath(`{window.location.origin}/`)
+  setAssetPath(`{window.location.origin}/`);
   ```
 
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.

--- a/docs/components/api.md
+++ b/docs/components/api.md
@@ -152,6 +152,15 @@ The following primitives can be imported from the `@stencil/core` package and us
   }
   ```
 
+- **setAssetPath()**: Sets the path for Stencil to resolve local assets. Refer to the [Assets](../guides/assets.md#setassetpath) page for usage info.
+
+  __Type:__ `(path: string) => string`<br />
+  __Example:__
+  ```ts
+  import { setAssetPath } from '@stencil/core'
+  setAssetPath(import.meta.url)
+  ```
+
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.
 
   __Type:__ `(ref: HTMLElement) => string`<br />

--- a/docs/guides/assets.md
+++ b/docs/guides/assets.md
@@ -244,7 +244,7 @@ export declare function setAssetPath(path: string): string;
 
 Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime. As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects when using a component.
 
-Make sure as component author to export this function as part of your module in order to give the consumer of your component the chance to change it, e.g. in your package entry file export the function via:
+Make sure as component author to export this function as part of your module in order to also make it accessible to the consumer of your component, e.g. in your package entry file export the function via:
 
 ```ts
 export { setAssetPath } from '@stencil/core';

--- a/docs/guides/assets.md
+++ b/docs/guides/assets.md
@@ -262,7 +262,7 @@ asset base path. This configuration depends on how your script is bundled, (or l
 
 :::note
 
-If your component library exports components compiled with [`dist-output-target`](custom-elements) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
+If your component library exports components compiled with [`dist-output-target`](/output-targets/custom-elements.md) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
 
 :::
 

--- a/docs/guides/assets.md
+++ b/docs/guides/assets.md
@@ -231,7 +231,7 @@ getAssetPath('/assets/my-image.png');
 
 ### setAssetPath
 
-`setAssetPath` is an API provided by Stencil to manually set the asset base path where assets can be found.
+`setAssetPath` is an API provided by Stencil's runtime to manually set the asset base path where assets can be found. If you are using `getAssetPath` to compose the path for your component assets, `setAssetPath` allows you or the consumer of the component to change that path.
 
 ```ts
 /**
@@ -242,28 +242,38 @@ getAssetPath('/assets/my-image.png');
 export declare function setAssetPath(path: string): string;
 ```
 
-Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime.
-As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
-when using a component.
+Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime. As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects when using a component.
 
-If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use:
+Make sure as component author to export this function as part of your module in order to give the consumer of your component the chance to change it, e.g. in your package entry file export the function via:
 
 ```ts
-import { setAssetPath } from '@stencil/core';
-setAssetPath(`${window.location.origin}/`);
+export { setAssetPath } from '@stencil/core';
+```
+
+Now your users can import it directly from your component library, e.g.:
+
+```ts
+import { setAssetPath } from 'my-component-library';
+setAssetPath(`${window.location.protocol}//assets.${window.location.host}/`);
 ```
 
 Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript) when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the
 asset base path. This configuration depends on how your script is bundled, (or lack of bundling), and where your assets can be loaded from.
 
-For example, in case you import a component directly via script tag, this would look like:
+:::note
+
+If your component library exports components compiled with [`dist-output-target`](custom-elements) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
+
+:::
+
+In case you import a component directly via script tag, this would look like:
 
 ```html
 <html>
   <head>
-    <script src="https://cdn.jsdelivr.net/npm/@ionic/core/dist/ionic.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/my-component-library/dist/my-component-library.js"></script>
     <script type="module">
-      import { setAssetPath } from 'https://cdn.jsdelivr.net/npm/@ionic/core/dist/ionic.js';
+      import { setAssetPath } from 'https://cdn.jsdelivr.net/npm/my-component-library/dist/my-component-library.js';
       setAssetPath(`${window.location.origin}/`);
     </script>
   </head>

--- a/docs/guides/assets.md
+++ b/docs/guides/assets.md
@@ -246,7 +246,7 @@ Calling this API will set the asset base path for all Stencil components attache
 
 Make sure as component author to export this function as part of your module in order to also make it accessible to the consumer of your component, e.g. in your package entry file export the function via:
 
-```ts
+```ts title="/src/index.ts"
 export { setAssetPath } from '@stencil/core';
 ```
 

--- a/docs/guides/assets.md
+++ b/docs/guides/assets.md
@@ -62,6 +62,8 @@ When using `getAssetPath`, the assets in the directory structure above are resol
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments.
 The return value is a path that Stencil has built to retrieve the asset on the filesystem.
 ```ts
+import { getAssetPath } from '@stencil/core';
+
 // with an asset base path of "/build/":
 
 // '/build/assets/logo.png'

--- a/docs/guides/assets.md
+++ b/docs/guides/assets.md
@@ -242,7 +242,7 @@ Calling this API will set the asset base path for all Stencil components attache
 As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
 when using a component.
 
-If the file calling `setAssetPath` is a module, it's recommended to use `import.meta.url`.
+If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use: `setAssetPath('${window.location.origin}/');`
 
 Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
 when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the

--- a/docs/guides/assets.md
+++ b/docs/guides/assets.md
@@ -242,7 +242,12 @@ Calling this API will set the asset base path for all Stencil components attache
 As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
 when using a component.
 
-If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use: `setAssetPath('${window.location.origin}/');`
+If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use:
+
+```ts
+import { setAssetPath } from '@stencil/core';
+setAssetPath(`${window.location.origin}/`);
+```
 
 Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
 when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the

--- a/docs/guides/assets.md
+++ b/docs/guides/assets.md
@@ -212,6 +212,8 @@ declare function getAssetPath(path: string): string;
 
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments, when an asset base path of `/build/` has been set.
 ```ts
+import { getAssetPath } from '@stencil/core';
+
 // with an asset base path of "/build/":
 // "/build/"
 getAssetPath('');
@@ -251,7 +253,22 @@ import { setAssetPath } from '@stencil/core';
 setAssetPath(`${window.location.origin}/`);
 ```
 
-Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
-when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the
-asset base path. 
-This configuration depends on how your script is bundled, (or lack of bundling), and where your assets can be loaded from.
+Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript) when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the
+asset base path. This configuration depends on how your script is bundled, (or lack of bundling), and where your assets can be loaded from.
+
+For example, in case you import a component directly via script tag, this would look like:
+
+```html
+<html>
+  <head>
+    <script src="https://cdn.jsdelivr.net/npm/@ionic/core/dist/ionic.js"></script>
+    <script type="module">
+      import { setAssetPath } from 'https://cdn.jsdelivr.net/npm/@ionic/core/dist/ionic.js';
+      setAssetPath(`${window.location.origin}/`);
+    </script>
+  </head>
+  <body>
+    <ion-toggle></ion-toggle>
+  </body>
+</html>
+```

--- a/versioned_docs/version-v2/guides/assets.md
+++ b/versioned_docs/version-v2/guides/assets.md
@@ -242,7 +242,7 @@ Calling this API will set the asset base path for all Stencil components attache
 As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
 when using a component.
 
-If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use: `setAssetPath('${window.location.origin}/');`
+If the file calling `setAssetPath` is a module, it's recommended to use `import.meta.url`.
 
 Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
 when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the

--- a/versioned_docs/version-v2/guides/assets.md
+++ b/versioned_docs/version-v2/guides/assets.md
@@ -242,7 +242,7 @@ Calling this API will set the asset base path for all Stencil components attache
 As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
 when using a component.
 
-If the file calling `setAssetPath` is a module, it's recommended to use `import.meta.url`.
+If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use: `setAssetPath('${window.location.origin}/');`
 
 Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
 when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the

--- a/versioned_docs/version-v3/components/api.md
+++ b/versioned_docs/version-v3/components/api.md
@@ -152,15 +152,6 @@ The following primitives can be imported from the `@stencil/core` package and us
   }
   ```
 
-- **setAssetPath()**: Sets the path for Stencil to resolve local assets. Refer to the [Assets](../guides/assets.md#setassetpath) page for usage info.
-
-  __Type:__ `(path: string) => string`<br />
-  __Example:__
-  ```ts
-  import { setAssetPath } from '@stencil/core'
-  setAssetPath(import.meta.url)
-  ```
-
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.
 
   __Type:__ `(ref: HTMLElement) => string`<br />

--- a/versioned_docs/version-v3/components/api.md
+++ b/versioned_docs/version-v3/components/api.md
@@ -152,6 +152,15 @@ The following primitives can be imported from the `@stencil/core` package and us
   }
   ```
 
+- **setAssetPath()**: Sets the path for Stencil to resolve local assets. Refer to the [Assets](../guides/assets.md#setassetpath) page for usage info.
+
+  __Type:__ `(path: string) => string`<br />
+  __Example:__
+  ```ts
+  import { setAssetPath } from '@stencil/core'
+  setAssetPath(import.meta.url)
+  ```
+
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.
 
   __Type:__ `(ref: HTMLElement) => string`<br />

--- a/versioned_docs/version-v3/guides/assets.md
+++ b/versioned_docs/version-v3/guides/assets.md
@@ -62,8 +62,6 @@ When using `getAssetPath`, the assets in the directory structure above are resol
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments.
 The return value is a path that Stencil has built to retrieve the asset on the filesystem.
 ```ts
-import { getAssetPath } from '@stencil/core';
-
 // with an asset base path of "/build/":
 
 // '/build/assets/logo.png'
@@ -211,6 +209,8 @@ declare function getAssetPath(path: string): string;
 ```
 
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments, when an asset base path of `/build/` has been set.
+
+```ts
 import { getAssetPath } from '@stencil/core';
 
 // with an asset base path of "/build/":
@@ -245,12 +245,7 @@ Calling this API will set the asset base path for all Stencil components attache
 As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
 when using a component.
 
-If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use:
-
-```ts
-import { setAssetPath } from '@stencil/core';
-setAssetPath(`${window.location.origin}/`);
-```
+If the file calling `setAssetPath` is a module, it's recommended to use `import.meta.url`.
 
 Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
 when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the

--- a/versioned_docs/version-v3/guides/assets.md
+++ b/versioned_docs/version-v3/guides/assets.md
@@ -209,10 +209,7 @@ declare function getAssetPath(path: string): string;
 ```
 
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments, when an asset base path of `/build/` has been set.
-
 ```ts
-import { getAssetPath } from '@stencil/core';
-
 // with an asset base path of "/build/":
 // "/build/"
 getAssetPath('');

--- a/versioned_docs/version-v3/guides/assets.md
+++ b/versioned_docs/version-v3/guides/assets.md
@@ -62,6 +62,8 @@ When using `getAssetPath`, the assets in the directory structure above are resol
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments.
 The return value is a path that Stencil has built to retrieve the asset on the filesystem.
 ```ts
+import { getAssetPath } from '@stencil/core';
+
 // with an asset base path of "/build/":
 
 // '/build/assets/logo.png'
@@ -209,7 +211,8 @@ declare function getAssetPath(path: string): string;
 ```
 
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments, when an asset base path of `/build/` has been set.
-```ts
+import { getAssetPath } from '@stencil/core';
+
 // with an asset base path of "/build/":
 // "/build/"
 getAssetPath('');

--- a/versioned_docs/version-v3/guides/assets.md
+++ b/versioned_docs/version-v3/guides/assets.md
@@ -242,7 +242,7 @@ Calling this API will set the asset base path for all Stencil components attache
 As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
 when using a component.
 
-If the file calling `setAssetPath` is a module, it's recommended to use `import.meta.url`.
+If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use: `setAssetPath('${window.location.origin}/');`
 
 Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
 when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the

--- a/versioned_docs/version-v3/guides/assets.md
+++ b/versioned_docs/version-v3/guides/assets.md
@@ -242,7 +242,12 @@ Calling this API will set the asset base path for all Stencil components attache
 As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
 when using a component.
 
-If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use: `setAssetPath('${window.location.origin}/');`
+If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use:
+
+```ts
+import { setAssetPath } from '@stencil/core';
+setAssetPath(`${window.location.origin}/`);
+```
 
 Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
 when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the

--- a/versioned_docs/version-v4.0/components/api.md
+++ b/versioned_docs/version-v4.0/components/api.md
@@ -157,8 +157,8 @@ The following primitives can be imported from the `@stencil/core` package and us
   __Type:__ `(path: string) => string`<br />
   __Example:__
   ```ts
-  import { setAssetPath } from '@stencil/core'
-  setAssetPath(import.meta.url)
+  import { setAssetPath } from '@stencil/core';
+  setAssetPath(`{window.location.origin}/`)
   ```
 
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.

--- a/versioned_docs/version-v4.0/components/api.md
+++ b/versioned_docs/version-v4.0/components/api.md
@@ -158,7 +158,7 @@ The following primitives can be imported from the `@stencil/core` package and us
   __Example:__
   ```ts
   import { setAssetPath } from '@stencil/core';
-  setAssetPath(`{window.location.origin}/`)
+  setAssetPath(`{window.location.origin}/`);
   ```
 
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.

--- a/versioned_docs/version-v4.0/components/api.md
+++ b/versioned_docs/version-v4.0/components/api.md
@@ -152,6 +152,15 @@ The following primitives can be imported from the `@stencil/core` package and us
   }
   ```
 
+- **setAssetPath()**: Sets the path for Stencil to resolve local assets. Refer to the [Assets](../guides/assets.md#setassetpath) page for usage info.
+
+  __Type:__ `(path: string) => string`<br />
+  __Example:__
+  ```ts
+  import { setAssetPath } from '@stencil/core'
+  setAssetPath(import.meta.url)
+  ```
+
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.
 
   __Type:__ `(ref: HTMLElement) => string`<br />

--- a/versioned_docs/version-v4.0/guides/assets.md
+++ b/versioned_docs/version-v4.0/guides/assets.md
@@ -263,7 +263,7 @@ asset base path. This configuration depends on how your script is bundled, (or l
 
 :::note
 
-If your component library exports components compiled with [`dist-output-target`](custom-elements) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
+If your component library exports components compiled with [`dist-output-target`](/output-targets/custom-elements.md) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
 
 :::
 

--- a/versioned_docs/version-v4.0/guides/assets.md
+++ b/versioned_docs/version-v4.0/guides/assets.md
@@ -232,7 +232,7 @@ getAssetPath('/assets/my-image.png');
 
 ### setAssetPath
 
-`setAssetPath` is an API provided by Stencil to manually set the asset base path where assets can be found.
+`setAssetPath` is an API provided by Stencil's runtime to manually set the asset base path where assets can be found. If you are using `getAssetPath` to compose the path for your component assets, `setAssetPath` allows you or the consumer of the component to change that path.
 
 ```ts
 /**
@@ -243,18 +243,43 @@ getAssetPath('/assets/my-image.png');
 export declare function setAssetPath(path: string): string;
 ```
 
-Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime.
-As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
-when using a component.
+Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime. As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects when using a component.
 
-If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use:
+Make sure as component author to export this function as part of your module in order to give the consumer of your component the chance to change it, e.g. in your package entry file export the function via:
 
 ```ts
-import { setAssetPath } from '@stencil/core';
-setAssetPath(`${window.location.origin}/`);
+export { setAssetPath } from '@stencil/core';
 ```
 
-Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
-when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the
-asset base path. 
-This configuration depends on how your script is bundled, (or lack of bundling), and where your assets can be loaded from.
+Now your users can import it directly from your component library, e.g.:
+
+```ts
+import { setAssetPath } from 'my-component-library';
+setAssetPath(`${window.location.protocol}//assets.${window.location.host}/`);
+```
+
+Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript) when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the
+asset base path. This configuration depends on how your script is bundled, (or lack of bundling), and where your assets can be loaded from.
+
+:::note
+
+If your component library exports components compiled with [`dist-output-target`](custom-elements) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
+
+:::
+
+In case you import a component directly via script tag, this would look like:
+
+```html
+<html>
+  <head>
+    <script src="https://cdn.jsdelivr.net/npm/my-component-library/dist/my-component-library.js"></script>
+    <script type="module">
+      import { setAssetPath } from 'https://cdn.jsdelivr.net/npm/my-component-library/dist/my-component-library.js';
+      setAssetPath(`${window.location.origin}/`);
+    </script>
+  </head>
+  <body>
+    <ion-toggle></ion-toggle>
+  </body>
+</html>
+```

--- a/versioned_docs/version-v4.0/guides/assets.md
+++ b/versioned_docs/version-v4.0/guides/assets.md
@@ -247,7 +247,7 @@ Calling this API will set the asset base path for all Stencil components attache
 
 Make sure as component author to export this function as part of your module in order to also make it accessible to the consumer of your component, e.g. in your package entry file export the function via:
 
-```ts
+```ts title="/src/index.ts"
 export { setAssetPath } from '@stencil/core';
 ```
 

--- a/versioned_docs/version-v4.0/guides/assets.md
+++ b/versioned_docs/version-v4.0/guides/assets.md
@@ -211,6 +211,8 @@ declare function getAssetPath(path: string): string;
 ```
 
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments, when an asset base path of `/build/` has been set.
+
+```ts
 import { getAssetPath } from '@stencil/core';
 
 // with an asset base path of "/build/":

--- a/versioned_docs/version-v4.0/guides/assets.md
+++ b/versioned_docs/version-v4.0/guides/assets.md
@@ -62,6 +62,8 @@ When using `getAssetPath`, the assets in the directory structure above are resol
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments.
 The return value is a path that Stencil has built to retrieve the asset on the filesystem.
 ```ts
+import { getAssetPath } from '@stencil/core';
+
 // with an asset base path of "/build/":
 
 // '/build/assets/logo.png'
@@ -209,7 +211,8 @@ declare function getAssetPath(path: string): string;
 ```
 
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments, when an asset base path of `/build/` has been set.
-```ts
+import { getAssetPath } from '@stencil/core';
+
 // with an asset base path of "/build/":
 // "/build/"
 getAssetPath('');

--- a/versioned_docs/version-v4.0/guides/assets.md
+++ b/versioned_docs/version-v4.0/guides/assets.md
@@ -242,7 +242,7 @@ Calling this API will set the asset base path for all Stencil components attache
 As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
 when using a component.
 
-If the file calling `setAssetPath` is a module, it's recommended to use `import.meta.url`.
+If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use: `setAssetPath('${window.location.origin}/');`
 
 Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
 when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the

--- a/versioned_docs/version-v4.0/guides/assets.md
+++ b/versioned_docs/version-v4.0/guides/assets.md
@@ -245,7 +245,7 @@ export declare function setAssetPath(path: string): string;
 
 Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime. As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects when using a component.
 
-Make sure as component author to export this function as part of your module in order to give the consumer of your component the chance to change it, e.g. in your package entry file export the function via:
+Make sure as component author to export this function as part of your module in order to also make it accessible to the consumer of your component, e.g. in your package entry file export the function via:
 
 ```ts
 export { setAssetPath } from '@stencil/core';

--- a/versioned_docs/version-v4.0/guides/assets.md
+++ b/versioned_docs/version-v4.0/guides/assets.md
@@ -242,7 +242,12 @@ Calling this API will set the asset base path for all Stencil components attache
 As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
 when using a component.
 
-If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use: `setAssetPath('${window.location.origin}/');`
+If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use:
+
+```ts
+import { setAssetPath } from '@stencil/core';
+setAssetPath(`${window.location.origin}/`);
+```
 
 Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
 when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the

--- a/versioned_docs/version-v4.1/components/api.md
+++ b/versioned_docs/version-v4.1/components/api.md
@@ -157,8 +157,8 @@ The following primitives can be imported from the `@stencil/core` package and us
   __Type:__ `(path: string) => string`<br />
   __Example:__
   ```ts
-  import { setAssetPath } from '@stencil/core'
-  setAssetPath(import.meta.url)
+  import { setAssetPath } from '@stencil/core';
+  setAssetPath(`{window.location.origin}/`)
   ```
 
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.

--- a/versioned_docs/version-v4.1/components/api.md
+++ b/versioned_docs/version-v4.1/components/api.md
@@ -158,7 +158,7 @@ The following primitives can be imported from the `@stencil/core` package and us
   __Example:__
   ```ts
   import { setAssetPath } from '@stencil/core';
-  setAssetPath(`{window.location.origin}/`)
+  setAssetPath(`{window.location.origin}/`);
   ```
 
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.

--- a/versioned_docs/version-v4.1/components/api.md
+++ b/versioned_docs/version-v4.1/components/api.md
@@ -152,6 +152,15 @@ The following primitives can be imported from the `@stencil/core` package and us
   }
   ```
 
+- **setAssetPath()**: Sets the path for Stencil to resolve local assets. Refer to the [Assets](../guides/assets.md#setassetpath) page for usage info.
+
+  __Type:__ `(path: string) => string`<br />
+  __Example:__
+  ```ts
+  import { setAssetPath } from '@stencil/core'
+  setAssetPath(import.meta.url)
+  ```
+
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.
 
   __Type:__ `(ref: HTMLElement) => string`<br />

--- a/versioned_docs/version-v4.1/guides/assets.md
+++ b/versioned_docs/version-v4.1/guides/assets.md
@@ -263,7 +263,7 @@ asset base path. This configuration depends on how your script is bundled, (or l
 
 :::note
 
-If your component library exports components compiled with [`dist-output-target`](custom-elements) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
+If your component library exports components compiled with [`dist-output-target`](/output-targets/custom-elements.md) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
 
 :::
 

--- a/versioned_docs/version-v4.1/guides/assets.md
+++ b/versioned_docs/version-v4.1/guides/assets.md
@@ -232,7 +232,7 @@ getAssetPath('/assets/my-image.png');
 
 ### setAssetPath
 
-`setAssetPath` is an API provided by Stencil to manually set the asset base path where assets can be found.
+`setAssetPath` is an API provided by Stencil's runtime to manually set the asset base path where assets can be found. If you are using `getAssetPath` to compose the path for your component assets, `setAssetPath` allows you or the consumer of the component to change that path.
 
 ```ts
 /**
@@ -243,18 +243,43 @@ getAssetPath('/assets/my-image.png');
 export declare function setAssetPath(path: string): string;
 ```
 
-Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime.
-As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
-when using a component.
+Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime. As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects when using a component.
 
-If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use:
+Make sure as component author to export this function as part of your module in order to give the consumer of your component the chance to change it, e.g. in your package entry file export the function via:
 
 ```ts
-import { setAssetPath } from '@stencil/core';
-setAssetPath(`${window.location.origin}/`);
+export { setAssetPath } from '@stencil/core';
 ```
 
-Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
-when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the
-asset base path. 
-This configuration depends on how your script is bundled, (or lack of bundling), and where your assets can be loaded from.
+Now your users can import it directly from your component library, e.g.:
+
+```ts
+import { setAssetPath } from 'my-component-library';
+setAssetPath(`${window.location.protocol}//assets.${window.location.host}/`);
+```
+
+Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript) when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the
+asset base path. This configuration depends on how your script is bundled, (or lack of bundling), and where your assets can be loaded from.
+
+:::note
+
+If your component library exports components compiled with [`dist-output-target`](custom-elements) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
+
+:::
+
+In case you import a component directly via script tag, this would look like:
+
+```html
+<html>
+  <head>
+    <script src="https://cdn.jsdelivr.net/npm/my-component-library/dist/my-component-library.js"></script>
+    <script type="module">
+      import { setAssetPath } from 'https://cdn.jsdelivr.net/npm/my-component-library/dist/my-component-library.js';
+      setAssetPath(`${window.location.origin}/`);
+    </script>
+  </head>
+  <body>
+    <ion-toggle></ion-toggle>
+  </body>
+</html>
+```

--- a/versioned_docs/version-v4.1/guides/assets.md
+++ b/versioned_docs/version-v4.1/guides/assets.md
@@ -247,7 +247,7 @@ Calling this API will set the asset base path for all Stencil components attache
 
 Make sure as component author to export this function as part of your module in order to also make it accessible to the consumer of your component, e.g. in your package entry file export the function via:
 
-```ts
+```ts title="/src/index.ts"
 export { setAssetPath } from '@stencil/core';
 ```
 

--- a/versioned_docs/version-v4.1/guides/assets.md
+++ b/versioned_docs/version-v4.1/guides/assets.md
@@ -211,6 +211,8 @@ declare function getAssetPath(path: string): string;
 ```
 
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments, when an asset base path of `/build/` has been set.
+
+```ts
 import { getAssetPath } from '@stencil/core';
 
 // with an asset base path of "/build/":

--- a/versioned_docs/version-v4.1/guides/assets.md
+++ b/versioned_docs/version-v4.1/guides/assets.md
@@ -62,6 +62,8 @@ When using `getAssetPath`, the assets in the directory structure above are resol
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments.
 The return value is a path that Stencil has built to retrieve the asset on the filesystem.
 ```ts
+import { getAssetPath } from '@stencil/core';
+
 // with an asset base path of "/build/":
 
 // '/build/assets/logo.png'
@@ -209,7 +211,8 @@ declare function getAssetPath(path: string): string;
 ```
 
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments, when an asset base path of `/build/` has been set.
-```ts
+import { getAssetPath } from '@stencil/core';
+
 // with an asset base path of "/build/":
 // "/build/"
 getAssetPath('');

--- a/versioned_docs/version-v4.1/guides/assets.md
+++ b/versioned_docs/version-v4.1/guides/assets.md
@@ -242,7 +242,7 @@ Calling this API will set the asset base path for all Stencil components attache
 As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
 when using a component.
 
-If the file calling `setAssetPath` is a module, it's recommended to use `import.meta.url`.
+If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use: `setAssetPath('${window.location.origin}/');`
 
 Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
 when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the

--- a/versioned_docs/version-v4.1/guides/assets.md
+++ b/versioned_docs/version-v4.1/guides/assets.md
@@ -245,7 +245,7 @@ export declare function setAssetPath(path: string): string;
 
 Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime. As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects when using a component.
 
-Make sure as component author to export this function as part of your module in order to give the consumer of your component the chance to change it, e.g. in your package entry file export the function via:
+Make sure as component author to export this function as part of your module in order to also make it accessible to the consumer of your component, e.g. in your package entry file export the function via:
 
 ```ts
 export { setAssetPath } from '@stencil/core';

--- a/versioned_docs/version-v4.1/guides/assets.md
+++ b/versioned_docs/version-v4.1/guides/assets.md
@@ -242,7 +242,12 @@ Calling this API will set the asset base path for all Stencil components attache
 As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
 when using a component.
 
-If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use: `setAssetPath('${window.location.origin}/');`
+If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use:
+
+```ts
+import { setAssetPath } from '@stencil/core';
+setAssetPath(`${window.location.origin}/`);
+```
 
 Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
 when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the

--- a/versioned_docs/version-v4.10/components/api.md
+++ b/versioned_docs/version-v4.10/components/api.md
@@ -157,8 +157,8 @@ The following primitives can be imported from the `@stencil/core` package and us
   __Type:__ `(path: string) => string`<br />
   __Example:__
   ```ts
-  import { setAssetPath } from '@stencil/core'
-  setAssetPath(import.meta.url)
+  import { setAssetPath } from '@stencil/core';
+  setAssetPath(`{window.location.origin}/`)
   ```
 
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.

--- a/versioned_docs/version-v4.10/components/api.md
+++ b/versioned_docs/version-v4.10/components/api.md
@@ -158,7 +158,7 @@ The following primitives can be imported from the `@stencil/core` package and us
   __Example:__
   ```ts
   import { setAssetPath } from '@stencil/core';
-  setAssetPath(`{window.location.origin}/`)
+  setAssetPath(`{window.location.origin}/`);
   ```
 
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.

--- a/versioned_docs/version-v4.10/components/api.md
+++ b/versioned_docs/version-v4.10/components/api.md
@@ -152,6 +152,15 @@ The following primitives can be imported from the `@stencil/core` package and us
   }
   ```
 
+- **setAssetPath()**: Sets the path for Stencil to resolve local assets. Refer to the [Assets](../guides/assets.md#setassetpath) page for usage info.
+
+  __Type:__ `(path: string) => string`<br />
+  __Example:__
+  ```ts
+  import { setAssetPath } from '@stencil/core'
+  setAssetPath(import.meta.url)
+  ```
+
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.
 
   __Type:__ `(ref: HTMLElement) => string`<br />

--- a/versioned_docs/version-v4.10/guides/assets.md
+++ b/versioned_docs/version-v4.10/guides/assets.md
@@ -263,7 +263,7 @@ asset base path. This configuration depends on how your script is bundled, (or l
 
 :::note
 
-If your component library exports components compiled with [`dist-output-target`](custom-elements) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
+If your component library exports components compiled with [`dist-output-target`](/output-targets/custom-elements.md) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
 
 :::
 

--- a/versioned_docs/version-v4.10/guides/assets.md
+++ b/versioned_docs/version-v4.10/guides/assets.md
@@ -232,7 +232,7 @@ getAssetPath('/assets/my-image.png');
 
 ### setAssetPath
 
-`setAssetPath` is an API provided by Stencil to manually set the asset base path where assets can be found.
+`setAssetPath` is an API provided by Stencil's runtime to manually set the asset base path where assets can be found. If you are using `getAssetPath` to compose the path for your component assets, `setAssetPath` allows you or the consumer of the component to change that path.
 
 ```ts
 /**
@@ -243,18 +243,43 @@ getAssetPath('/assets/my-image.png');
 export declare function setAssetPath(path: string): string;
 ```
 
-Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime.
-As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
-when using a component.
+Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime. As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects when using a component.
 
-If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use:
+Make sure as component author to export this function as part of your module in order to give the consumer of your component the chance to change it, e.g. in your package entry file export the function via:
 
 ```ts
-import { setAssetPath } from '@stencil/core';
-setAssetPath(`${window.location.origin}/`);
+export { setAssetPath } from '@stencil/core';
 ```
 
-Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
-when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the
-asset base path. 
-This configuration depends on how your script is bundled, (or lack of bundling), and where your assets can be loaded from.
+Now your users can import it directly from your component library, e.g.:
+
+```ts
+import { setAssetPath } from 'my-component-library';
+setAssetPath(`${window.location.protocol}//assets.${window.location.host}/`);
+```
+
+Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript) when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the
+asset base path. This configuration depends on how your script is bundled, (or lack of bundling), and where your assets can be loaded from.
+
+:::note
+
+If your component library exports components compiled with [`dist-output-target`](custom-elements) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
+
+:::
+
+In case you import a component directly via script tag, this would look like:
+
+```html
+<html>
+  <head>
+    <script src="https://cdn.jsdelivr.net/npm/my-component-library/dist/my-component-library.js"></script>
+    <script type="module">
+      import { setAssetPath } from 'https://cdn.jsdelivr.net/npm/my-component-library/dist/my-component-library.js';
+      setAssetPath(`${window.location.origin}/`);
+    </script>
+  </head>
+  <body>
+    <ion-toggle></ion-toggle>
+  </body>
+</html>
+```

--- a/versioned_docs/version-v4.10/guides/assets.md
+++ b/versioned_docs/version-v4.10/guides/assets.md
@@ -247,7 +247,7 @@ Calling this API will set the asset base path for all Stencil components attache
 
 Make sure as component author to export this function as part of your module in order to also make it accessible to the consumer of your component, e.g. in your package entry file export the function via:
 
-```ts
+```ts title="/src/index.ts"
 export { setAssetPath } from '@stencil/core';
 ```
 

--- a/versioned_docs/version-v4.10/guides/assets.md
+++ b/versioned_docs/version-v4.10/guides/assets.md
@@ -211,6 +211,8 @@ declare function getAssetPath(path: string): string;
 ```
 
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments, when an asset base path of `/build/` has been set.
+
+```ts
 import { getAssetPath } from '@stencil/core';
 
 // with an asset base path of "/build/":

--- a/versioned_docs/version-v4.10/guides/assets.md
+++ b/versioned_docs/version-v4.10/guides/assets.md
@@ -62,6 +62,8 @@ When using `getAssetPath`, the assets in the directory structure above are resol
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments.
 The return value is a path that Stencil has built to retrieve the asset on the filesystem.
 ```ts
+import { getAssetPath } from '@stencil/core';
+
 // with an asset base path of "/build/":
 
 // '/build/assets/logo.png'
@@ -209,7 +211,8 @@ declare function getAssetPath(path: string): string;
 ```
 
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments, when an asset base path of `/build/` has been set.
-```ts
+import { getAssetPath } from '@stencil/core';
+
 // with an asset base path of "/build/":
 // "/build/"
 getAssetPath('');

--- a/versioned_docs/version-v4.10/guides/assets.md
+++ b/versioned_docs/version-v4.10/guides/assets.md
@@ -242,7 +242,7 @@ Calling this API will set the asset base path for all Stencil components attache
 As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
 when using a component.
 
-If the file calling `setAssetPath` is a module, it's recommended to use `import.meta.url`.
+If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use: `setAssetPath('${window.location.origin}/');`
 
 Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
 when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the

--- a/versioned_docs/version-v4.10/guides/assets.md
+++ b/versioned_docs/version-v4.10/guides/assets.md
@@ -245,7 +245,7 @@ export declare function setAssetPath(path: string): string;
 
 Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime. As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects when using a component.
 
-Make sure as component author to export this function as part of your module in order to give the consumer of your component the chance to change it, e.g. in your package entry file export the function via:
+Make sure as component author to export this function as part of your module in order to also make it accessible to the consumer of your component, e.g. in your package entry file export the function via:
 
 ```ts
 export { setAssetPath } from '@stencil/core';

--- a/versioned_docs/version-v4.10/guides/assets.md
+++ b/versioned_docs/version-v4.10/guides/assets.md
@@ -242,7 +242,12 @@ Calling this API will set the asset base path for all Stencil components attache
 As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
 when using a component.
 
-If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use: `setAssetPath('${window.location.origin}/');`
+If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use:
+
+```ts
+import { setAssetPath } from '@stencil/core';
+setAssetPath(`${window.location.origin}/`);
+```
 
 Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
 when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the

--- a/versioned_docs/version-v4.11/components/api.md
+++ b/versioned_docs/version-v4.11/components/api.md
@@ -157,8 +157,8 @@ The following primitives can be imported from the `@stencil/core` package and us
   __Type:__ `(path: string) => string`<br />
   __Example:__
   ```ts
-  import { setAssetPath } from '@stencil/core'
-  setAssetPath(import.meta.url)
+  import { setAssetPath } from '@stencil/core';
+  setAssetPath(`{window.location.origin}/`)
   ```
 
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.

--- a/versioned_docs/version-v4.11/components/api.md
+++ b/versioned_docs/version-v4.11/components/api.md
@@ -158,7 +158,7 @@ The following primitives can be imported from the `@stencil/core` package and us
   __Example:__
   ```ts
   import { setAssetPath } from '@stencil/core';
-  setAssetPath(`{window.location.origin}/`)
+  setAssetPath(`{window.location.origin}/`);
   ```
 
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.

--- a/versioned_docs/version-v4.11/components/api.md
+++ b/versioned_docs/version-v4.11/components/api.md
@@ -152,6 +152,15 @@ The following primitives can be imported from the `@stencil/core` package and us
   }
   ```
 
+- **setAssetPath()**: Sets the path for Stencil to resolve local assets. Refer to the [Assets](../guides/assets.md#setassetpath) page for usage info.
+
+  __Type:__ `(path: string) => string`<br />
+  __Example:__
+  ```ts
+  import { setAssetPath } from '@stencil/core'
+  setAssetPath(import.meta.url)
+  ```
+
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.
 
   __Type:__ `(ref: HTMLElement) => string`<br />

--- a/versioned_docs/version-v4.11/guides/assets.md
+++ b/versioned_docs/version-v4.11/guides/assets.md
@@ -263,7 +263,7 @@ asset base path. This configuration depends on how your script is bundled, (or l
 
 :::note
 
-If your component library exports components compiled with [`dist-output-target`](custom-elements) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
+If your component library exports components compiled with [`dist-output-target`](/output-targets/custom-elements.md) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
 
 :::
 

--- a/versioned_docs/version-v4.11/guides/assets.md
+++ b/versioned_docs/version-v4.11/guides/assets.md
@@ -232,7 +232,7 @@ getAssetPath('/assets/my-image.png');
 
 ### setAssetPath
 
-`setAssetPath` is an API provided by Stencil to manually set the asset base path where assets can be found.
+`setAssetPath` is an API provided by Stencil's runtime to manually set the asset base path where assets can be found. If you are using `getAssetPath` to compose the path for your component assets, `setAssetPath` allows you or the consumer of the component to change that path.
 
 ```ts
 /**
@@ -243,18 +243,43 @@ getAssetPath('/assets/my-image.png');
 export declare function setAssetPath(path: string): string;
 ```
 
-Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime.
-As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
-when using a component.
+Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime. As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects when using a component.
 
-If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use:
+Make sure as component author to export this function as part of your module in order to give the consumer of your component the chance to change it, e.g. in your package entry file export the function via:
 
 ```ts
-import { setAssetPath } from '@stencil/core';
-setAssetPath(`${window.location.origin}/`);
+export { setAssetPath } from '@stencil/core';
 ```
 
-Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
-when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the
-asset base path. 
-This configuration depends on how your script is bundled, (or lack of bundling), and where your assets can be loaded from.
+Now your users can import it directly from your component library, e.g.:
+
+```ts
+import { setAssetPath } from 'my-component-library';
+setAssetPath(`${window.location.protocol}//assets.${window.location.host}/`);
+```
+
+Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript) when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the
+asset base path. This configuration depends on how your script is bundled, (or lack of bundling), and where your assets can be loaded from.
+
+:::note
+
+If your component library exports components compiled with [`dist-output-target`](custom-elements) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
+
+:::
+
+In case you import a component directly via script tag, this would look like:
+
+```html
+<html>
+  <head>
+    <script src="https://cdn.jsdelivr.net/npm/my-component-library/dist/my-component-library.js"></script>
+    <script type="module">
+      import { setAssetPath } from 'https://cdn.jsdelivr.net/npm/my-component-library/dist/my-component-library.js';
+      setAssetPath(`${window.location.origin}/`);
+    </script>
+  </head>
+  <body>
+    <ion-toggle></ion-toggle>
+  </body>
+</html>
+```

--- a/versioned_docs/version-v4.11/guides/assets.md
+++ b/versioned_docs/version-v4.11/guides/assets.md
@@ -247,7 +247,7 @@ Calling this API will set the asset base path for all Stencil components attache
 
 Make sure as component author to export this function as part of your module in order to also make it accessible to the consumer of your component, e.g. in your package entry file export the function via:
 
-```ts
+```ts title="/src/index.ts"
 export { setAssetPath } from '@stencil/core';
 ```
 

--- a/versioned_docs/version-v4.11/guides/assets.md
+++ b/versioned_docs/version-v4.11/guides/assets.md
@@ -211,6 +211,8 @@ declare function getAssetPath(path: string): string;
 ```
 
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments, when an asset base path of `/build/` has been set.
+
+```ts
 import { getAssetPath } from '@stencil/core';
 
 // with an asset base path of "/build/":

--- a/versioned_docs/version-v4.11/guides/assets.md
+++ b/versioned_docs/version-v4.11/guides/assets.md
@@ -62,6 +62,8 @@ When using `getAssetPath`, the assets in the directory structure above are resol
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments.
 The return value is a path that Stencil has built to retrieve the asset on the filesystem.
 ```ts
+import { getAssetPath } from '@stencil/core';
+
 // with an asset base path of "/build/":
 
 // '/build/assets/logo.png'
@@ -209,7 +211,8 @@ declare function getAssetPath(path: string): string;
 ```
 
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments, when an asset base path of `/build/` has been set.
-```ts
+import { getAssetPath } from '@stencil/core';
+
 // with an asset base path of "/build/":
 // "/build/"
 getAssetPath('');

--- a/versioned_docs/version-v4.11/guides/assets.md
+++ b/versioned_docs/version-v4.11/guides/assets.md
@@ -242,7 +242,7 @@ Calling this API will set the asset base path for all Stencil components attache
 As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
 when using a component.
 
-If the file calling `setAssetPath` is a module, it's recommended to use `import.meta.url`.
+If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use: `setAssetPath('${window.location.origin}/');`
 
 Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
 when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the

--- a/versioned_docs/version-v4.11/guides/assets.md
+++ b/versioned_docs/version-v4.11/guides/assets.md
@@ -245,7 +245,7 @@ export declare function setAssetPath(path: string): string;
 
 Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime. As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects when using a component.
 
-Make sure as component author to export this function as part of your module in order to give the consumer of your component the chance to change it, e.g. in your package entry file export the function via:
+Make sure as component author to export this function as part of your module in order to also make it accessible to the consumer of your component, e.g. in your package entry file export the function via:
 
 ```ts
 export { setAssetPath } from '@stencil/core';

--- a/versioned_docs/version-v4.11/guides/assets.md
+++ b/versioned_docs/version-v4.11/guides/assets.md
@@ -242,7 +242,12 @@ Calling this API will set the asset base path for all Stencil components attache
 As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
 when using a component.
 
-If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use: `setAssetPath('${window.location.origin}/');`
+If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use:
+
+```ts
+import { setAssetPath } from '@stencil/core';
+setAssetPath(`${window.location.origin}/`);
+```
 
 Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
 when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the

--- a/versioned_docs/version-v4.12/components/api.md
+++ b/versioned_docs/version-v4.12/components/api.md
@@ -157,8 +157,8 @@ The following primitives can be imported from the `@stencil/core` package and us
   __Type:__ `(path: string) => string`<br />
   __Example:__
   ```ts
-  import { setAssetPath } from '@stencil/core'
-  setAssetPath(import.meta.url)
+  import { setAssetPath } from '@stencil/core';
+  setAssetPath(`{window.location.origin}/`)
   ```
 
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.

--- a/versioned_docs/version-v4.12/components/api.md
+++ b/versioned_docs/version-v4.12/components/api.md
@@ -158,7 +158,7 @@ The following primitives can be imported from the `@stencil/core` package and us
   __Example:__
   ```ts
   import { setAssetPath } from '@stencil/core';
-  setAssetPath(`{window.location.origin}/`)
+  setAssetPath(`{window.location.origin}/`);
   ```
 
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.

--- a/versioned_docs/version-v4.12/components/api.md
+++ b/versioned_docs/version-v4.12/components/api.md
@@ -152,6 +152,15 @@ The following primitives can be imported from the `@stencil/core` package and us
   }
   ```
 
+- **setAssetPath()**: Sets the path for Stencil to resolve local assets. Refer to the [Assets](../guides/assets.md#setassetpath) page for usage info.
+
+  __Type:__ `(path: string) => string`<br />
+  __Example:__
+  ```ts
+  import { setAssetPath } from '@stencil/core'
+  setAssetPath(import.meta.url)
+  ```
+
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.
 
   __Type:__ `(ref: HTMLElement) => string`<br />

--- a/versioned_docs/version-v4.12/guides/assets.md
+++ b/versioned_docs/version-v4.12/guides/assets.md
@@ -263,7 +263,7 @@ asset base path. This configuration depends on how your script is bundled, (or l
 
 :::note
 
-If your component library exports components compiled with [`dist-output-target`](custom-elements) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
+If your component library exports components compiled with [`dist-output-target`](/output-targets/custom-elements.md) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
 
 :::
 

--- a/versioned_docs/version-v4.12/guides/assets.md
+++ b/versioned_docs/version-v4.12/guides/assets.md
@@ -232,7 +232,7 @@ getAssetPath('/assets/my-image.png');
 
 ### setAssetPath
 
-`setAssetPath` is an API provided by Stencil to manually set the asset base path where assets can be found.
+`setAssetPath` is an API provided by Stencil's runtime to manually set the asset base path where assets can be found. If you are using `getAssetPath` to compose the path for your component assets, `setAssetPath` allows you or the consumer of the component to change that path.
 
 ```ts
 /**
@@ -243,18 +243,43 @@ getAssetPath('/assets/my-image.png');
 export declare function setAssetPath(path: string): string;
 ```
 
-Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime.
-As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
-when using a component.
+Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime. As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects when using a component.
 
-If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use:
+Make sure as component author to export this function as part of your module in order to give the consumer of your component the chance to change it, e.g. in your package entry file export the function via:
 
 ```ts
-import { setAssetPath } from '@stencil/core';
-setAssetPath(`${window.location.origin}/`);
+export { setAssetPath } from '@stencil/core';
 ```
 
-Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
-when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the
-asset base path. 
-This configuration depends on how your script is bundled, (or lack of bundling), and where your assets can be loaded from.
+Now your users can import it directly from your component library, e.g.:
+
+```ts
+import { setAssetPath } from 'my-component-library';
+setAssetPath(`${window.location.protocol}//assets.${window.location.host}/`);
+```
+
+Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript) when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the
+asset base path. This configuration depends on how your script is bundled, (or lack of bundling), and where your assets can be loaded from.
+
+:::note
+
+If your component library exports components compiled with [`dist-output-target`](custom-elements) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
+
+:::
+
+In case you import a component directly via script tag, this would look like:
+
+```html
+<html>
+  <head>
+    <script src="https://cdn.jsdelivr.net/npm/my-component-library/dist/my-component-library.js"></script>
+    <script type="module">
+      import { setAssetPath } from 'https://cdn.jsdelivr.net/npm/my-component-library/dist/my-component-library.js';
+      setAssetPath(`${window.location.origin}/`);
+    </script>
+  </head>
+  <body>
+    <ion-toggle></ion-toggle>
+  </body>
+</html>
+```

--- a/versioned_docs/version-v4.12/guides/assets.md
+++ b/versioned_docs/version-v4.12/guides/assets.md
@@ -247,7 +247,7 @@ Calling this API will set the asset base path for all Stencil components attache
 
 Make sure as component author to export this function as part of your module in order to also make it accessible to the consumer of your component, e.g. in your package entry file export the function via:
 
-```ts
+```ts title="/src/index.ts"
 export { setAssetPath } from '@stencil/core';
 ```
 

--- a/versioned_docs/version-v4.12/guides/assets.md
+++ b/versioned_docs/version-v4.12/guides/assets.md
@@ -211,6 +211,8 @@ declare function getAssetPath(path: string): string;
 ```
 
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments, when an asset base path of `/build/` has been set.
+
+```ts
 import { getAssetPath } from '@stencil/core';
 
 // with an asset base path of "/build/":

--- a/versioned_docs/version-v4.12/guides/assets.md
+++ b/versioned_docs/version-v4.12/guides/assets.md
@@ -62,6 +62,8 @@ When using `getAssetPath`, the assets in the directory structure above are resol
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments.
 The return value is a path that Stencil has built to retrieve the asset on the filesystem.
 ```ts
+import { getAssetPath } from '@stencil/core';
+
 // with an asset base path of "/build/":
 
 // '/build/assets/logo.png'
@@ -209,7 +211,8 @@ declare function getAssetPath(path: string): string;
 ```
 
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments, when an asset base path of `/build/` has been set.
-```ts
+import { getAssetPath } from '@stencil/core';
+
 // with an asset base path of "/build/":
 // "/build/"
 getAssetPath('');

--- a/versioned_docs/version-v4.12/guides/assets.md
+++ b/versioned_docs/version-v4.12/guides/assets.md
@@ -242,7 +242,7 @@ Calling this API will set the asset base path for all Stencil components attache
 As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
 when using a component.
 
-If the file calling `setAssetPath` is a module, it's recommended to use `import.meta.url`.
+If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use: `setAssetPath('${window.location.origin}/');`
 
 Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
 when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the

--- a/versioned_docs/version-v4.12/guides/assets.md
+++ b/versioned_docs/version-v4.12/guides/assets.md
@@ -245,7 +245,7 @@ export declare function setAssetPath(path: string): string;
 
 Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime. As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects when using a component.
 
-Make sure as component author to export this function as part of your module in order to give the consumer of your component the chance to change it, e.g. in your package entry file export the function via:
+Make sure as component author to export this function as part of your module in order to also make it accessible to the consumer of your component, e.g. in your package entry file export the function via:
 
 ```ts
 export { setAssetPath } from '@stencil/core';

--- a/versioned_docs/version-v4.12/guides/assets.md
+++ b/versioned_docs/version-v4.12/guides/assets.md
@@ -242,7 +242,12 @@ Calling this API will set the asset base path for all Stencil components attache
 As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
 when using a component.
 
-If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use: `setAssetPath('${window.location.origin}/');`
+If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use:
+
+```ts
+import { setAssetPath } from '@stencil/core';
+setAssetPath(`${window.location.origin}/`);
+```
 
 Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
 when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the

--- a/versioned_docs/version-v4.13.0/components/api.md
+++ b/versioned_docs/version-v4.13.0/components/api.md
@@ -157,8 +157,8 @@ The following primitives can be imported from the `@stencil/core` package and us
   __Type:__ `(path: string) => string`<br />
   __Example:__
   ```ts
-  import { setAssetPath } from '@stencil/core'
-  setAssetPath(import.meta.url)
+  import { setAssetPath } from '@stencil/core';
+  setAssetPath(`{window.location.origin}/`)
   ```
 
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.

--- a/versioned_docs/version-v4.13.0/components/api.md
+++ b/versioned_docs/version-v4.13.0/components/api.md
@@ -158,7 +158,7 @@ The following primitives can be imported from the `@stencil/core` package and us
   __Example:__
   ```ts
   import { setAssetPath } from '@stencil/core';
-  setAssetPath(`{window.location.origin}/`)
+  setAssetPath(`{window.location.origin}/`);
   ```
 
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.

--- a/versioned_docs/version-v4.13.0/components/api.md
+++ b/versioned_docs/version-v4.13.0/components/api.md
@@ -152,6 +152,15 @@ The following primitives can be imported from the `@stencil/core` package and us
   }
   ```
 
+- **setAssetPath()**: Sets the path for Stencil to resolve local assets. Refer to the [Assets](../guides/assets.md#setassetpath) page for usage info.
+
+  __Type:__ `(path: string) => string`<br />
+  __Example:__
+  ```ts
+  import { setAssetPath } from '@stencil/core'
+  setAssetPath(import.meta.url)
+  ```
+
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.
 
   __Type:__ `(ref: HTMLElement) => string`<br />

--- a/versioned_docs/version-v4.13.0/guides/assets.md
+++ b/versioned_docs/version-v4.13.0/guides/assets.md
@@ -263,7 +263,7 @@ asset base path. This configuration depends on how your script is bundled, (or l
 
 :::note
 
-If your component library exports components compiled with [`dist-output-target`](custom-elements) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
+If your component library exports components compiled with [`dist-output-target`](/output-targets/custom-elements.md) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
 
 :::
 

--- a/versioned_docs/version-v4.13.0/guides/assets.md
+++ b/versioned_docs/version-v4.13.0/guides/assets.md
@@ -232,7 +232,7 @@ getAssetPath('/assets/my-image.png');
 
 ### setAssetPath
 
-`setAssetPath` is an API provided by Stencil to manually set the asset base path where assets can be found.
+`setAssetPath` is an API provided by Stencil's runtime to manually set the asset base path where assets can be found. If you are using `getAssetPath` to compose the path for your component assets, `setAssetPath` allows you or the consumer of the component to change that path.
 
 ```ts
 /**
@@ -243,18 +243,43 @@ getAssetPath('/assets/my-image.png');
 export declare function setAssetPath(path: string): string;
 ```
 
-Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime.
-As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
-when using a component.
+Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime. As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects when using a component.
 
-If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use:
+Make sure as component author to export this function as part of your module in order to give the consumer of your component the chance to change it, e.g. in your package entry file export the function via:
 
 ```ts
-import { setAssetPath } from '@stencil/core';
-setAssetPath(`${window.location.origin}/`);
+export { setAssetPath } from '@stencil/core';
 ```
 
-Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
-when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the
-asset base path. 
-This configuration depends on how your script is bundled, (or lack of bundling), and where your assets can be loaded from.
+Now your users can import it directly from your component library, e.g.:
+
+```ts
+import { setAssetPath } from 'my-component-library';
+setAssetPath(`${window.location.protocol}//assets.${window.location.host}/`);
+```
+
+Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript) when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the
+asset base path. This configuration depends on how your script is bundled, (or lack of bundling), and where your assets can be loaded from.
+
+:::note
+
+If your component library exports components compiled with [`dist-output-target`](custom-elements) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
+
+:::
+
+In case you import a component directly via script tag, this would look like:
+
+```html
+<html>
+  <head>
+    <script src="https://cdn.jsdelivr.net/npm/my-component-library/dist/my-component-library.js"></script>
+    <script type="module">
+      import { setAssetPath } from 'https://cdn.jsdelivr.net/npm/my-component-library/dist/my-component-library.js';
+      setAssetPath(`${window.location.origin}/`);
+    </script>
+  </head>
+  <body>
+    <ion-toggle></ion-toggle>
+  </body>
+</html>
+```

--- a/versioned_docs/version-v4.13.0/guides/assets.md
+++ b/versioned_docs/version-v4.13.0/guides/assets.md
@@ -247,7 +247,7 @@ Calling this API will set the asset base path for all Stencil components attache
 
 Make sure as component author to export this function as part of your module in order to also make it accessible to the consumer of your component, e.g. in your package entry file export the function via:
 
-```ts
+```ts title="/src/index.ts"
 export { setAssetPath } from '@stencil/core';
 ```
 

--- a/versioned_docs/version-v4.13.0/guides/assets.md
+++ b/versioned_docs/version-v4.13.0/guides/assets.md
@@ -211,6 +211,8 @@ declare function getAssetPath(path: string): string;
 ```
 
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments, when an asset base path of `/build/` has been set.
+
+```ts
 import { getAssetPath } from '@stencil/core';
 
 // with an asset base path of "/build/":

--- a/versioned_docs/version-v4.13.0/guides/assets.md
+++ b/versioned_docs/version-v4.13.0/guides/assets.md
@@ -62,6 +62,8 @@ When using `getAssetPath`, the assets in the directory structure above are resol
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments.
 The return value is a path that Stencil has built to retrieve the asset on the filesystem.
 ```ts
+import { getAssetPath } from '@stencil/core';
+
 // with an asset base path of "/build/":
 
 // '/build/assets/logo.png'
@@ -209,7 +211,8 @@ declare function getAssetPath(path: string): string;
 ```
 
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments, when an asset base path of `/build/` has been set.
-```ts
+import { getAssetPath } from '@stencil/core';
+
 // with an asset base path of "/build/":
 // "/build/"
 getAssetPath('');

--- a/versioned_docs/version-v4.13.0/guides/assets.md
+++ b/versioned_docs/version-v4.13.0/guides/assets.md
@@ -242,7 +242,7 @@ Calling this API will set the asset base path for all Stencil components attache
 As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
 when using a component.
 
-If the file calling `setAssetPath` is a module, it's recommended to use `import.meta.url`.
+If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use: `setAssetPath('${window.location.origin}/');`
 
 Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
 when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the

--- a/versioned_docs/version-v4.13.0/guides/assets.md
+++ b/versioned_docs/version-v4.13.0/guides/assets.md
@@ -245,7 +245,7 @@ export declare function setAssetPath(path: string): string;
 
 Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime. As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects when using a component.
 
-Make sure as component author to export this function as part of your module in order to give the consumer of your component the chance to change it, e.g. in your package entry file export the function via:
+Make sure as component author to export this function as part of your module in order to also make it accessible to the consumer of your component, e.g. in your package entry file export the function via:
 
 ```ts
 export { setAssetPath } from '@stencil/core';

--- a/versioned_docs/version-v4.13.0/guides/assets.md
+++ b/versioned_docs/version-v4.13.0/guides/assets.md
@@ -242,7 +242,12 @@ Calling this API will set the asset base path for all Stencil components attache
 As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
 when using a component.
 
-If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use: `setAssetPath('${window.location.origin}/');`
+If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use:
+
+```ts
+import { setAssetPath } from '@stencil/core';
+setAssetPath(`${window.location.origin}/`);
+```
 
 Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
 when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the

--- a/versioned_docs/version-v4.14/components/api.md
+++ b/versioned_docs/version-v4.14/components/api.md
@@ -157,8 +157,8 @@ The following primitives can be imported from the `@stencil/core` package and us
   __Type:__ `(path: string) => string`<br />
   __Example:__
   ```ts
-  import { setAssetPath } from '@stencil/core'
-  setAssetPath(import.meta.url)
+  import { setAssetPath } from '@stencil/core';
+  setAssetPath(`{window.location.origin}/`)
   ```
 
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.

--- a/versioned_docs/version-v4.14/components/api.md
+++ b/versioned_docs/version-v4.14/components/api.md
@@ -158,7 +158,7 @@ The following primitives can be imported from the `@stencil/core` package and us
   __Example:__
   ```ts
   import { setAssetPath } from '@stencil/core';
-  setAssetPath(`{window.location.origin}/`)
+  setAssetPath(`{window.location.origin}/`);
   ```
 
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.

--- a/versioned_docs/version-v4.14/components/api.md
+++ b/versioned_docs/version-v4.14/components/api.md
@@ -152,6 +152,15 @@ The following primitives can be imported from the `@stencil/core` package and us
   }
   ```
 
+- **setAssetPath()**: Sets the path for Stencil to resolve local assets. Refer to the [Assets](../guides/assets.md#setassetpath) page for usage info.
+
+  __Type:__ `(path: string) => string`<br />
+  __Example:__
+  ```ts
+  import { setAssetPath } from '@stencil/core'
+  setAssetPath(import.meta.url)
+  ```
+
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.
 
   __Type:__ `(ref: HTMLElement) => string`<br />

--- a/versioned_docs/version-v4.14/guides/assets.md
+++ b/versioned_docs/version-v4.14/guides/assets.md
@@ -263,7 +263,7 @@ asset base path. This configuration depends on how your script is bundled, (or l
 
 :::note
 
-If your component library exports components compiled with [`dist-output-target`](custom-elements) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
+If your component library exports components compiled with [`dist-output-target`](/output-targets/custom-elements.md) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
 
 :::
 

--- a/versioned_docs/version-v4.14/guides/assets.md
+++ b/versioned_docs/version-v4.14/guides/assets.md
@@ -232,7 +232,7 @@ getAssetPath('/assets/my-image.png');
 
 ### setAssetPath
 
-`setAssetPath` is an API provided by Stencil to manually set the asset base path where assets can be found.
+`setAssetPath` is an API provided by Stencil's runtime to manually set the asset base path where assets can be found. If you are using `getAssetPath` to compose the path for your component assets, `setAssetPath` allows you or the consumer of the component to change that path.
 
 ```ts
 /**
@@ -243,18 +243,43 @@ getAssetPath('/assets/my-image.png');
 export declare function setAssetPath(path: string): string;
 ```
 
-Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime.
-As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
-when using a component.
+Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime. As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects when using a component.
 
-If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use:
+Make sure as component author to export this function as part of your module in order to give the consumer of your component the chance to change it, e.g. in your package entry file export the function via:
 
 ```ts
-import { setAssetPath } from '@stencil/core';
-setAssetPath(`${window.location.origin}/`);
+export { setAssetPath } from '@stencil/core';
 ```
 
-Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
-when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the
-asset base path. 
-This configuration depends on how your script is bundled, (or lack of bundling), and where your assets can be loaded from.
+Now your users can import it directly from your component library, e.g.:
+
+```ts
+import { setAssetPath } from 'my-component-library';
+setAssetPath(`${window.location.protocol}//assets.${window.location.host}/`);
+```
+
+Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript) when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the
+asset base path. This configuration depends on how your script is bundled, (or lack of bundling), and where your assets can be loaded from.
+
+:::note
+
+If your component library exports components compiled with [`dist-output-target`](custom-elements) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
+
+:::
+
+In case you import a component directly via script tag, this would look like:
+
+```html
+<html>
+  <head>
+    <script src="https://cdn.jsdelivr.net/npm/my-component-library/dist/my-component-library.js"></script>
+    <script type="module">
+      import { setAssetPath } from 'https://cdn.jsdelivr.net/npm/my-component-library/dist/my-component-library.js';
+      setAssetPath(`${window.location.origin}/`);
+    </script>
+  </head>
+  <body>
+    <ion-toggle></ion-toggle>
+  </body>
+</html>
+```

--- a/versioned_docs/version-v4.14/guides/assets.md
+++ b/versioned_docs/version-v4.14/guides/assets.md
@@ -247,7 +247,7 @@ Calling this API will set the asset base path for all Stencil components attache
 
 Make sure as component author to export this function as part of your module in order to also make it accessible to the consumer of your component, e.g. in your package entry file export the function via:
 
-```ts
+```ts title="/src/index.ts"
 export { setAssetPath } from '@stencil/core';
 ```
 

--- a/versioned_docs/version-v4.14/guides/assets.md
+++ b/versioned_docs/version-v4.14/guides/assets.md
@@ -211,6 +211,8 @@ declare function getAssetPath(path: string): string;
 ```
 
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments, when an asset base path of `/build/` has been set.
+
+```ts
 import { getAssetPath } from '@stencil/core';
 
 // with an asset base path of "/build/":

--- a/versioned_docs/version-v4.14/guides/assets.md
+++ b/versioned_docs/version-v4.14/guides/assets.md
@@ -62,6 +62,8 @@ When using `getAssetPath`, the assets in the directory structure above are resol
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments.
 The return value is a path that Stencil has built to retrieve the asset on the filesystem.
 ```ts
+import { getAssetPath } from '@stencil/core';
+
 // with an asset base path of "/build/":
 
 // '/build/assets/logo.png'
@@ -209,7 +211,8 @@ declare function getAssetPath(path: string): string;
 ```
 
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments, when an asset base path of `/build/` has been set.
-```ts
+import { getAssetPath } from '@stencil/core';
+
 // with an asset base path of "/build/":
 // "/build/"
 getAssetPath('');

--- a/versioned_docs/version-v4.14/guides/assets.md
+++ b/versioned_docs/version-v4.14/guides/assets.md
@@ -242,7 +242,7 @@ Calling this API will set the asset base path for all Stencil components attache
 As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
 when using a component.
 
-If the file calling `setAssetPath` is a module, it's recommended to use `import.meta.url`.
+If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use: `setAssetPath('${window.location.origin}/');`
 
 Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
 when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the

--- a/versioned_docs/version-v4.14/guides/assets.md
+++ b/versioned_docs/version-v4.14/guides/assets.md
@@ -245,7 +245,7 @@ export declare function setAssetPath(path: string): string;
 
 Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime. As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects when using a component.
 
-Make sure as component author to export this function as part of your module in order to give the consumer of your component the chance to change it, e.g. in your package entry file export the function via:
+Make sure as component author to export this function as part of your module in order to also make it accessible to the consumer of your component, e.g. in your package entry file export the function via:
 
 ```ts
 export { setAssetPath } from '@stencil/core';

--- a/versioned_docs/version-v4.14/guides/assets.md
+++ b/versioned_docs/version-v4.14/guides/assets.md
@@ -242,7 +242,12 @@ Calling this API will set the asset base path for all Stencil components attache
 As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
 when using a component.
 
-If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use: `setAssetPath('${window.location.origin}/');`
+If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use:
+
+```ts
+import { setAssetPath } from '@stencil/core';
+setAssetPath(`${window.location.origin}/`);
+```
 
 Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
 when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the

--- a/versioned_docs/version-v4.15/components/api.md
+++ b/versioned_docs/version-v4.15/components/api.md
@@ -157,8 +157,8 @@ The following primitives can be imported from the `@stencil/core` package and us
   __Type:__ `(path: string) => string`<br />
   __Example:__
   ```ts
-  import { setAssetPath } from '@stencil/core'
-  setAssetPath(import.meta.url)
+  import { setAssetPath } from '@stencil/core';
+  setAssetPath(`{window.location.origin}/`)
   ```
 
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.

--- a/versioned_docs/version-v4.15/components/api.md
+++ b/versioned_docs/version-v4.15/components/api.md
@@ -158,7 +158,7 @@ The following primitives can be imported from the `@stencil/core` package and us
   __Example:__
   ```ts
   import { setAssetPath } from '@stencil/core';
-  setAssetPath(`{window.location.origin}/`)
+  setAssetPath(`{window.location.origin}/`);
   ```
 
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.

--- a/versioned_docs/version-v4.15/components/api.md
+++ b/versioned_docs/version-v4.15/components/api.md
@@ -152,6 +152,15 @@ The following primitives can be imported from the `@stencil/core` package and us
   }
   ```
 
+- **setAssetPath()**: Sets the path for Stencil to resolve local assets. Refer to the [Assets](../guides/assets.md#setassetpath) page for usage info.
+
+  __Type:__ `(path: string) => string`<br />
+  __Example:__
+  ```ts
+  import { setAssetPath } from '@stencil/core'
+  setAssetPath(import.meta.url)
+  ```
+
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.
 
   __Type:__ `(ref: HTMLElement) => string`<br />

--- a/versioned_docs/version-v4.15/guides/assets.md
+++ b/versioned_docs/version-v4.15/guides/assets.md
@@ -263,7 +263,7 @@ asset base path. This configuration depends on how your script is bundled, (or l
 
 :::note
 
-If your component library exports components compiled with [`dist-output-target`](custom-elements) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
+If your component library exports components compiled with [`dist-output-target`](/output-targets/custom-elements.md) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
 
 :::
 

--- a/versioned_docs/version-v4.15/guides/assets.md
+++ b/versioned_docs/version-v4.15/guides/assets.md
@@ -232,7 +232,7 @@ getAssetPath('/assets/my-image.png');
 
 ### setAssetPath
 
-`setAssetPath` is an API provided by Stencil to manually set the asset base path where assets can be found.
+`setAssetPath` is an API provided by Stencil's runtime to manually set the asset base path where assets can be found. If you are using `getAssetPath` to compose the path for your component assets, `setAssetPath` allows you or the consumer of the component to change that path.
 
 ```ts
 /**
@@ -243,18 +243,43 @@ getAssetPath('/assets/my-image.png');
 export declare function setAssetPath(path: string): string;
 ```
 
-Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime.
-As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
-when using a component.
+Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime. As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects when using a component.
 
-If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use:
+Make sure as component author to export this function as part of your module in order to give the consumer of your component the chance to change it, e.g. in your package entry file export the function via:
 
 ```ts
-import { setAssetPath } from '@stencil/core';
-setAssetPath(`${window.location.origin}/`);
+export { setAssetPath } from '@stencil/core';
 ```
 
-Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
-when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the
-asset base path. 
-This configuration depends on how your script is bundled, (or lack of bundling), and where your assets can be loaded from.
+Now your users can import it directly from your component library, e.g.:
+
+```ts
+import { setAssetPath } from 'my-component-library';
+setAssetPath(`${window.location.protocol}//assets.${window.location.host}/`);
+```
+
+Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript) when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the
+asset base path. This configuration depends on how your script is bundled, (or lack of bundling), and where your assets can be loaded from.
+
+:::note
+
+If your component library exports components compiled with [`dist-output-target`](custom-elements) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
+
+:::
+
+In case you import a component directly via script tag, this would look like:
+
+```html
+<html>
+  <head>
+    <script src="https://cdn.jsdelivr.net/npm/my-component-library/dist/my-component-library.js"></script>
+    <script type="module">
+      import { setAssetPath } from 'https://cdn.jsdelivr.net/npm/my-component-library/dist/my-component-library.js';
+      setAssetPath(`${window.location.origin}/`);
+    </script>
+  </head>
+  <body>
+    <ion-toggle></ion-toggle>
+  </body>
+</html>
+```

--- a/versioned_docs/version-v4.15/guides/assets.md
+++ b/versioned_docs/version-v4.15/guides/assets.md
@@ -247,7 +247,7 @@ Calling this API will set the asset base path for all Stencil components attache
 
 Make sure as component author to export this function as part of your module in order to also make it accessible to the consumer of your component, e.g. in your package entry file export the function via:
 
-```ts
+```ts title="/src/index.ts"
 export { setAssetPath } from '@stencil/core';
 ```
 

--- a/versioned_docs/version-v4.15/guides/assets.md
+++ b/versioned_docs/version-v4.15/guides/assets.md
@@ -211,6 +211,8 @@ declare function getAssetPath(path: string): string;
 ```
 
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments, when an asset base path of `/build/` has been set.
+
+```ts
 import { getAssetPath } from '@stencil/core';
 
 // with an asset base path of "/build/":

--- a/versioned_docs/version-v4.15/guides/assets.md
+++ b/versioned_docs/version-v4.15/guides/assets.md
@@ -62,6 +62,8 @@ When using `getAssetPath`, the assets in the directory structure above are resol
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments.
 The return value is a path that Stencil has built to retrieve the asset on the filesystem.
 ```ts
+import { getAssetPath } from '@stencil/core';
+
 // with an asset base path of "/build/":
 
 // '/build/assets/logo.png'
@@ -209,7 +211,8 @@ declare function getAssetPath(path: string): string;
 ```
 
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments, when an asset base path of `/build/` has been set.
-```ts
+import { getAssetPath } from '@stencil/core';
+
 // with an asset base path of "/build/":
 // "/build/"
 getAssetPath('');

--- a/versioned_docs/version-v4.15/guides/assets.md
+++ b/versioned_docs/version-v4.15/guides/assets.md
@@ -242,7 +242,7 @@ Calling this API will set the asset base path for all Stencil components attache
 As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
 when using a component.
 
-If the file calling `setAssetPath` is a module, it's recommended to use `import.meta.url`.
+If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use: `setAssetPath('${window.location.origin}/');`
 
 Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
 when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the

--- a/versioned_docs/version-v4.15/guides/assets.md
+++ b/versioned_docs/version-v4.15/guides/assets.md
@@ -245,7 +245,7 @@ export declare function setAssetPath(path: string): string;
 
 Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime. As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects when using a component.
 
-Make sure as component author to export this function as part of your module in order to give the consumer of your component the chance to change it, e.g. in your package entry file export the function via:
+Make sure as component author to export this function as part of your module in order to also make it accessible to the consumer of your component, e.g. in your package entry file export the function via:
 
 ```ts
 export { setAssetPath } from '@stencil/core';

--- a/versioned_docs/version-v4.15/guides/assets.md
+++ b/versioned_docs/version-v4.15/guides/assets.md
@@ -242,7 +242,12 @@ Calling this API will set the asset base path for all Stencil components attache
 As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
 when using a component.
 
-If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use: `setAssetPath('${window.location.origin}/');`
+If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use:
+
+```ts
+import { setAssetPath } from '@stencil/core';
+setAssetPath(`${window.location.origin}/`);
+```
 
 Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
 when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the

--- a/versioned_docs/version-v4.16/components/api.md
+++ b/versioned_docs/version-v4.16/components/api.md
@@ -157,8 +157,8 @@ The following primitives can be imported from the `@stencil/core` package and us
   __Type:__ `(path: string) => string`<br />
   __Example:__
   ```ts
-  import { setAssetPath } from '@stencil/core'
-  setAssetPath(import.meta.url)
+  import { setAssetPath } from '@stencil/core';
+  setAssetPath(`{window.location.origin}/`)
   ```
 
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.

--- a/versioned_docs/version-v4.16/components/api.md
+++ b/versioned_docs/version-v4.16/components/api.md
@@ -158,7 +158,7 @@ The following primitives can be imported from the `@stencil/core` package and us
   __Example:__
   ```ts
   import { setAssetPath } from '@stencil/core';
-  setAssetPath(`{window.location.origin}/`)
+  setAssetPath(`{window.location.origin}/`);
   ```
 
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.

--- a/versioned_docs/version-v4.16/components/api.md
+++ b/versioned_docs/version-v4.16/components/api.md
@@ -152,6 +152,15 @@ The following primitives can be imported from the `@stencil/core` package and us
   }
   ```
 
+- **setAssetPath()**: Sets the path for Stencil to resolve local assets. Refer to the [Assets](../guides/assets.md#setassetpath) page for usage info.
+
+  __Type:__ `(path: string) => string`<br />
+  __Example:__
+  ```ts
+  import { setAssetPath } from '@stencil/core'
+  setAssetPath(import.meta.url)
+  ```
+
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.
 
   __Type:__ `(ref: HTMLElement) => string`<br />

--- a/versioned_docs/version-v4.16/guides/assets.md
+++ b/versioned_docs/version-v4.16/guides/assets.md
@@ -263,7 +263,7 @@ asset base path. This configuration depends on how your script is bundled, (or l
 
 :::note
 
-If your component library exports components compiled with [`dist-output-target`](custom-elements) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
+If your component library exports components compiled with [`dist-output-target`](/output-targets/custom-elements.md) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
 
 :::
 

--- a/versioned_docs/version-v4.16/guides/assets.md
+++ b/versioned_docs/version-v4.16/guides/assets.md
@@ -232,7 +232,7 @@ getAssetPath('/assets/my-image.png');
 
 ### setAssetPath
 
-`setAssetPath` is an API provided by Stencil to manually set the asset base path where assets can be found.
+`setAssetPath` is an API provided by Stencil's runtime to manually set the asset base path where assets can be found. If you are using `getAssetPath` to compose the path for your component assets, `setAssetPath` allows you or the consumer of the component to change that path.
 
 ```ts
 /**
@@ -243,18 +243,43 @@ getAssetPath('/assets/my-image.png');
 export declare function setAssetPath(path: string): string;
 ```
 
-Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime.
-As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
-when using a component.
+Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime. As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects when using a component.
 
-If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use:
+Make sure as component author to export this function as part of your module in order to give the consumer of your component the chance to change it, e.g. in your package entry file export the function via:
 
 ```ts
-import { setAssetPath } from '@stencil/core';
-setAssetPath(`${window.location.origin}/`);
+export { setAssetPath } from '@stencil/core';
 ```
 
-Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
-when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the
-asset base path. 
-This configuration depends on how your script is bundled, (or lack of bundling), and where your assets can be loaded from.
+Now your users can import it directly from your component library, e.g.:
+
+```ts
+import { setAssetPath } from 'my-component-library';
+setAssetPath(`${window.location.protocol}//assets.${window.location.host}/`);
+```
+
+Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript) when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the
+asset base path. This configuration depends on how your script is bundled, (or lack of bundling), and where your assets can be loaded from.
+
+:::note
+
+If your component library exports components compiled with [`dist-output-target`](custom-elements) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
+
+:::
+
+In case you import a component directly via script tag, this would look like:
+
+```html
+<html>
+  <head>
+    <script src="https://cdn.jsdelivr.net/npm/my-component-library/dist/my-component-library.js"></script>
+    <script type="module">
+      import { setAssetPath } from 'https://cdn.jsdelivr.net/npm/my-component-library/dist/my-component-library.js';
+      setAssetPath(`${window.location.origin}/`);
+    </script>
+  </head>
+  <body>
+    <ion-toggle></ion-toggle>
+  </body>
+</html>
+```

--- a/versioned_docs/version-v4.16/guides/assets.md
+++ b/versioned_docs/version-v4.16/guides/assets.md
@@ -247,7 +247,7 @@ Calling this API will set the asset base path for all Stencil components attache
 
 Make sure as component author to export this function as part of your module in order to also make it accessible to the consumer of your component, e.g. in your package entry file export the function via:
 
-```ts
+```ts title="/src/index.ts"
 export { setAssetPath } from '@stencil/core';
 ```
 

--- a/versioned_docs/version-v4.16/guides/assets.md
+++ b/versioned_docs/version-v4.16/guides/assets.md
@@ -211,6 +211,8 @@ declare function getAssetPath(path: string): string;
 ```
 
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments, when an asset base path of `/build/` has been set.
+
+```ts
 import { getAssetPath } from '@stencil/core';
 
 // with an asset base path of "/build/":

--- a/versioned_docs/version-v4.16/guides/assets.md
+++ b/versioned_docs/version-v4.16/guides/assets.md
@@ -242,7 +242,12 @@ Calling this API will set the asset base path for all Stencil components attache
 As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
 when using a component.
 
-If the file calling `setAssetPath` is a module, it's recommended to use `import.meta.url`.
+If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use:
+
+```ts
+import { setAssetPath } from '@stencil/core';
+setAssetPath(`${window.location.origin}/`);
+```
 
 Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
 when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the

--- a/versioned_docs/version-v4.16/guides/assets.md
+++ b/versioned_docs/version-v4.16/guides/assets.md
@@ -62,6 +62,8 @@ When using `getAssetPath`, the assets in the directory structure above are resol
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments.
 The return value is a path that Stencil has built to retrieve the asset on the filesystem.
 ```ts
+import { getAssetPath } from '@stencil/core';
+
 // with an asset base path of "/build/":
 
 // '/build/assets/logo.png'
@@ -209,7 +211,8 @@ declare function getAssetPath(path: string): string;
 ```
 
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments, when an asset base path of `/build/` has been set.
-```ts
+import { getAssetPath } from '@stencil/core';
+
 // with an asset base path of "/build/":
 // "/build/"
 getAssetPath('');

--- a/versioned_docs/version-v4.16/guides/assets.md
+++ b/versioned_docs/version-v4.16/guides/assets.md
@@ -245,7 +245,7 @@ export declare function setAssetPath(path: string): string;
 
 Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime. As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects when using a component.
 
-Make sure as component author to export this function as part of your module in order to give the consumer of your component the chance to change it, e.g. in your package entry file export the function via:
+Make sure as component author to export this function as part of your module in order to also make it accessible to the consumer of your component, e.g. in your package entry file export the function via:
 
 ```ts
 export { setAssetPath } from '@stencil/core';

--- a/versioned_docs/version-v4.17/guides/assets.md
+++ b/versioned_docs/version-v4.17/guides/assets.md
@@ -263,7 +263,7 @@ asset base path. This configuration depends on how your script is bundled, (or l
 
 :::note
 
-If your component library exports components compiled with [`dist-output-target`](custom-elements) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
+If your component library exports components compiled with [`dist-output-target`](/output-targets/custom-elements.md) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
 
 :::
 

--- a/versioned_docs/version-v4.17/guides/assets.md
+++ b/versioned_docs/version-v4.17/guides/assets.md
@@ -232,7 +232,7 @@ getAssetPath('/assets/my-image.png');
 
 ### setAssetPath
 
-`setAssetPath` is an API provided by Stencil to manually set the asset base path where assets can be found.
+`setAssetPath` is an API provided by Stencil's runtime to manually set the asset base path where assets can be found. If you are using `getAssetPath` to compose the path for your component assets, `setAssetPath` allows you or the consumer of the component to change that path.
 
 ```ts
 /**
@@ -243,13 +243,43 @@ getAssetPath('/assets/my-image.png');
 export declare function setAssetPath(path: string): string;
 ```
 
-Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime.
-As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
-when using a component.
+Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime. As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects when using a component.
 
-If the file calling `setAssetPath` is a module, it's recommended to use `import.meta.url`.
+Make sure as component author to export this function as part of your module in order to give the consumer of your component the chance to change it, e.g. in your package entry file export the function via:
 
-Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
-when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the
-asset base path. 
-This configuration depends on how your script is bundled, (or lack of bundling), and where your assets can be loaded from.
+```ts
+export { setAssetPath } from '@stencil/core';
+```
+
+Now your users can import it directly from your component library, e.g.:
+
+```ts
+import { setAssetPath } from 'my-component-library';
+setAssetPath(`${window.location.protocol}//assets.${window.location.host}/`);
+```
+
+Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript) when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the
+asset base path. This configuration depends on how your script is bundled, (or lack of bundling), and where your assets can be loaded from.
+
+:::note
+
+If your component library exports components compiled with [`dist-output-target`](custom-elements) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
+
+:::
+
+In case you import a component directly via script tag, this would look like:
+
+```html
+<html>
+  <head>
+    <script src="https://cdn.jsdelivr.net/npm/my-component-library/dist/my-component-library.js"></script>
+    <script type="module">
+      import { setAssetPath } from 'https://cdn.jsdelivr.net/npm/my-component-library/dist/my-component-library.js';
+      setAssetPath(`${window.location.origin}/`);
+    </script>
+  </head>
+  <body>
+    <ion-toggle></ion-toggle>
+  </body>
+</html>
+```

--- a/versioned_docs/version-v4.17/guides/assets.md
+++ b/versioned_docs/version-v4.17/guides/assets.md
@@ -247,7 +247,7 @@ Calling this API will set the asset base path for all Stencil components attache
 
 Make sure as component author to export this function as part of your module in order to also make it accessible to the consumer of your component, e.g. in your package entry file export the function via:
 
-```ts
+```ts title="/src/index.ts"
 export { setAssetPath } from '@stencil/core';
 ```
 

--- a/versioned_docs/version-v4.17/guides/assets.md
+++ b/versioned_docs/version-v4.17/guides/assets.md
@@ -211,6 +211,8 @@ declare function getAssetPath(path: string): string;
 ```
 
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments, when an asset base path of `/build/` has been set.
+
+```ts
 import { getAssetPath } from '@stencil/core';
 
 // with an asset base path of "/build/":

--- a/versioned_docs/version-v4.17/guides/assets.md
+++ b/versioned_docs/version-v4.17/guides/assets.md
@@ -62,6 +62,8 @@ When using `getAssetPath`, the assets in the directory structure above are resol
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments.
 The return value is a path that Stencil has built to retrieve the asset on the filesystem.
 ```ts
+import { getAssetPath } from '@stencil/core';
+
 // with an asset base path of "/build/":
 
 // '/build/assets/logo.png'
@@ -209,7 +211,8 @@ declare function getAssetPath(path: string): string;
 ```
 
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments, when an asset base path of `/build/` has been set.
-```ts
+import { getAssetPath } from '@stencil/core';
+
 // with an asset base path of "/build/":
 // "/build/"
 getAssetPath('');

--- a/versioned_docs/version-v4.17/guides/assets.md
+++ b/versioned_docs/version-v4.17/guides/assets.md
@@ -245,7 +245,7 @@ export declare function setAssetPath(path: string): string;
 
 Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime. As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects when using a component.
 
-Make sure as component author to export this function as part of your module in order to give the consumer of your component the chance to change it, e.g. in your package entry file export the function via:
+Make sure as component author to export this function as part of your module in order to also make it accessible to the consumer of your component, e.g. in your package entry file export the function via:
 
 ```ts
 export { setAssetPath } from '@stencil/core';

--- a/versioned_docs/version-v4.2/components/api.md
+++ b/versioned_docs/version-v4.2/components/api.md
@@ -157,8 +157,8 @@ The following primitives can be imported from the `@stencil/core` package and us
   __Type:__ `(path: string) => string`<br />
   __Example:__
   ```ts
-  import { setAssetPath } from '@stencil/core'
-  setAssetPath(import.meta.url)
+  import { setAssetPath } from '@stencil/core';
+  setAssetPath(`{window.location.origin}/`)
   ```
 
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.

--- a/versioned_docs/version-v4.2/components/api.md
+++ b/versioned_docs/version-v4.2/components/api.md
@@ -158,7 +158,7 @@ The following primitives can be imported from the `@stencil/core` package and us
   __Example:__
   ```ts
   import { setAssetPath } from '@stencil/core';
-  setAssetPath(`{window.location.origin}/`)
+  setAssetPath(`{window.location.origin}/`);
   ```
 
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.

--- a/versioned_docs/version-v4.2/components/api.md
+++ b/versioned_docs/version-v4.2/components/api.md
@@ -152,6 +152,15 @@ The following primitives can be imported from the `@stencil/core` package and us
   }
   ```
 
+- **setAssetPath()**: Sets the path for Stencil to resolve local assets. Refer to the [Assets](../guides/assets.md#setassetpath) page for usage info.
+
+  __Type:__ `(path: string) => string`<br />
+  __Example:__
+  ```ts
+  import { setAssetPath } from '@stencil/core'
+  setAssetPath(import.meta.url)
+  ```
+
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.
 
   __Type:__ `(ref: HTMLElement) => string`<br />

--- a/versioned_docs/version-v4.2/guides/assets.md
+++ b/versioned_docs/version-v4.2/guides/assets.md
@@ -263,7 +263,7 @@ asset base path. This configuration depends on how your script is bundled, (or l
 
 :::note
 
-If your component library exports components compiled with [`dist-output-target`](custom-elements) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
+If your component library exports components compiled with [`dist-output-target`](/output-targets/custom-elements.md) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
 
 :::
 

--- a/versioned_docs/version-v4.2/guides/assets.md
+++ b/versioned_docs/version-v4.2/guides/assets.md
@@ -232,7 +232,7 @@ getAssetPath('/assets/my-image.png');
 
 ### setAssetPath
 
-`setAssetPath` is an API provided by Stencil to manually set the asset base path where assets can be found.
+`setAssetPath` is an API provided by Stencil's runtime to manually set the asset base path where assets can be found. If you are using `getAssetPath` to compose the path for your component assets, `setAssetPath` allows you or the consumer of the component to change that path.
 
 ```ts
 /**
@@ -243,18 +243,43 @@ getAssetPath('/assets/my-image.png');
 export declare function setAssetPath(path: string): string;
 ```
 
-Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime.
-As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
-when using a component.
+Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime. As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects when using a component.
 
-If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use:
+Make sure as component author to export this function as part of your module in order to give the consumer of your component the chance to change it, e.g. in your package entry file export the function via:
 
 ```ts
-import { setAssetPath } from '@stencil/core';
-setAssetPath(`${window.location.origin}/`);
+export { setAssetPath } from '@stencil/core';
 ```
 
-Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
-when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the
-asset base path. 
-This configuration depends on how your script is bundled, (or lack of bundling), and where your assets can be loaded from.
+Now your users can import it directly from your component library, e.g.:
+
+```ts
+import { setAssetPath } from 'my-component-library';
+setAssetPath(`${window.location.protocol}//assets.${window.location.host}/`);
+```
+
+Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript) when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the
+asset base path. This configuration depends on how your script is bundled, (or lack of bundling), and where your assets can be loaded from.
+
+:::note
+
+If your component library exports components compiled with [`dist-output-target`](custom-elements) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
+
+:::
+
+In case you import a component directly via script tag, this would look like:
+
+```html
+<html>
+  <head>
+    <script src="https://cdn.jsdelivr.net/npm/my-component-library/dist/my-component-library.js"></script>
+    <script type="module">
+      import { setAssetPath } from 'https://cdn.jsdelivr.net/npm/my-component-library/dist/my-component-library.js';
+      setAssetPath(`${window.location.origin}/`);
+    </script>
+  </head>
+  <body>
+    <ion-toggle></ion-toggle>
+  </body>
+</html>
+```

--- a/versioned_docs/version-v4.2/guides/assets.md
+++ b/versioned_docs/version-v4.2/guides/assets.md
@@ -247,7 +247,7 @@ Calling this API will set the asset base path for all Stencil components attache
 
 Make sure as component author to export this function as part of your module in order to also make it accessible to the consumer of your component, e.g. in your package entry file export the function via:
 
-```ts
+```ts title="/src/index.ts"
 export { setAssetPath } from '@stencil/core';
 ```
 

--- a/versioned_docs/version-v4.2/guides/assets.md
+++ b/versioned_docs/version-v4.2/guides/assets.md
@@ -211,6 +211,8 @@ declare function getAssetPath(path: string): string;
 ```
 
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments, when an asset base path of `/build/` has been set.
+
+```ts
 import { getAssetPath } from '@stencil/core';
 
 // with an asset base path of "/build/":

--- a/versioned_docs/version-v4.2/guides/assets.md
+++ b/versioned_docs/version-v4.2/guides/assets.md
@@ -62,6 +62,8 @@ When using `getAssetPath`, the assets in the directory structure above are resol
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments.
 The return value is a path that Stencil has built to retrieve the asset on the filesystem.
 ```ts
+import { getAssetPath } from '@stencil/core';
+
 // with an asset base path of "/build/":
 
 // '/build/assets/logo.png'
@@ -209,7 +211,8 @@ declare function getAssetPath(path: string): string;
 ```
 
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments, when an asset base path of `/build/` has been set.
-```ts
+import { getAssetPath } from '@stencil/core';
+
 // with an asset base path of "/build/":
 // "/build/"
 getAssetPath('');

--- a/versioned_docs/version-v4.2/guides/assets.md
+++ b/versioned_docs/version-v4.2/guides/assets.md
@@ -242,7 +242,7 @@ Calling this API will set the asset base path for all Stencil components attache
 As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
 when using a component.
 
-If the file calling `setAssetPath` is a module, it's recommended to use `import.meta.url`.
+If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use: `setAssetPath('${window.location.origin}/');`
 
 Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
 when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the

--- a/versioned_docs/version-v4.2/guides/assets.md
+++ b/versioned_docs/version-v4.2/guides/assets.md
@@ -245,7 +245,7 @@ export declare function setAssetPath(path: string): string;
 
 Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime. As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects when using a component.
 
-Make sure as component author to export this function as part of your module in order to give the consumer of your component the chance to change it, e.g. in your package entry file export the function via:
+Make sure as component author to export this function as part of your module in order to also make it accessible to the consumer of your component, e.g. in your package entry file export the function via:
 
 ```ts
 export { setAssetPath } from '@stencil/core';

--- a/versioned_docs/version-v4.2/guides/assets.md
+++ b/versioned_docs/version-v4.2/guides/assets.md
@@ -242,7 +242,12 @@ Calling this API will set the asset base path for all Stencil components attache
 As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
 when using a component.
 
-If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use: `setAssetPath('${window.location.origin}/');`
+If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use:
+
+```ts
+import { setAssetPath } from '@stencil/core';
+setAssetPath(`${window.location.origin}/`);
+```
 
 Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
 when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the

--- a/versioned_docs/version-v4.3/components/api.md
+++ b/versioned_docs/version-v4.3/components/api.md
@@ -157,8 +157,8 @@ The following primitives can be imported from the `@stencil/core` package and us
   __Type:__ `(path: string) => string`<br />
   __Example:__
   ```ts
-  import { setAssetPath } from '@stencil/core'
-  setAssetPath(import.meta.url)
+  import { setAssetPath } from '@stencil/core';
+  setAssetPath(`{window.location.origin}/`)
   ```
 
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.

--- a/versioned_docs/version-v4.3/components/api.md
+++ b/versioned_docs/version-v4.3/components/api.md
@@ -158,7 +158,7 @@ The following primitives can be imported from the `@stencil/core` package and us
   __Example:__
   ```ts
   import { setAssetPath } from '@stencil/core';
-  setAssetPath(`{window.location.origin}/`)
+  setAssetPath(`{window.location.origin}/`);
   ```
 
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.

--- a/versioned_docs/version-v4.3/components/api.md
+++ b/versioned_docs/version-v4.3/components/api.md
@@ -152,6 +152,15 @@ The following primitives can be imported from the `@stencil/core` package and us
   }
   ```
 
+- **setAssetPath()**: Sets the path for Stencil to resolve local assets. Refer to the [Assets](../guides/assets.md#setassetpath) page for usage info.
+
+  __Type:__ `(path: string) => string`<br />
+  __Example:__
+  ```ts
+  import { setAssetPath } from '@stencil/core'
+  setAssetPath(import.meta.url)
+  ```
+
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.
 
   __Type:__ `(ref: HTMLElement) => string`<br />

--- a/versioned_docs/version-v4.3/guides/assets.md
+++ b/versioned_docs/version-v4.3/guides/assets.md
@@ -263,7 +263,7 @@ asset base path. This configuration depends on how your script is bundled, (or l
 
 :::note
 
-If your component library exports components compiled with [`dist-output-target`](custom-elements) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
+If your component library exports components compiled with [`dist-output-target`](/output-targets/custom-elements.md) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
 
 :::
 

--- a/versioned_docs/version-v4.3/guides/assets.md
+++ b/versioned_docs/version-v4.3/guides/assets.md
@@ -232,7 +232,7 @@ getAssetPath('/assets/my-image.png');
 
 ### setAssetPath
 
-`setAssetPath` is an API provided by Stencil to manually set the asset base path where assets can be found.
+`setAssetPath` is an API provided by Stencil's runtime to manually set the asset base path where assets can be found. If you are using `getAssetPath` to compose the path for your component assets, `setAssetPath` allows you or the consumer of the component to change that path.
 
 ```ts
 /**
@@ -243,18 +243,43 @@ getAssetPath('/assets/my-image.png');
 export declare function setAssetPath(path: string): string;
 ```
 
-Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime.
-As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
-when using a component.
+Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime. As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects when using a component.
 
-If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use:
+Make sure as component author to export this function as part of your module in order to give the consumer of your component the chance to change it, e.g. in your package entry file export the function via:
 
 ```ts
-import { setAssetPath } from '@stencil/core';
-setAssetPath(`${window.location.origin}/`);
+export { setAssetPath } from '@stencil/core';
 ```
 
-Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
-when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the
-asset base path. 
-This configuration depends on how your script is bundled, (or lack of bundling), and where your assets can be loaded from.
+Now your users can import it directly from your component library, e.g.:
+
+```ts
+import { setAssetPath } from 'my-component-library';
+setAssetPath(`${window.location.protocol}//assets.${window.location.host}/`);
+```
+
+Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript) when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the
+asset base path. This configuration depends on how your script is bundled, (or lack of bundling), and where your assets can be loaded from.
+
+:::note
+
+If your component library exports components compiled with [`dist-output-target`](custom-elements) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
+
+:::
+
+In case you import a component directly via script tag, this would look like:
+
+```html
+<html>
+  <head>
+    <script src="https://cdn.jsdelivr.net/npm/my-component-library/dist/my-component-library.js"></script>
+    <script type="module">
+      import { setAssetPath } from 'https://cdn.jsdelivr.net/npm/my-component-library/dist/my-component-library.js';
+      setAssetPath(`${window.location.origin}/`);
+    </script>
+  </head>
+  <body>
+    <ion-toggle></ion-toggle>
+  </body>
+</html>
+```

--- a/versioned_docs/version-v4.3/guides/assets.md
+++ b/versioned_docs/version-v4.3/guides/assets.md
@@ -247,7 +247,7 @@ Calling this API will set the asset base path for all Stencil components attache
 
 Make sure as component author to export this function as part of your module in order to also make it accessible to the consumer of your component, e.g. in your package entry file export the function via:
 
-```ts
+```ts title="/src/index.ts"
 export { setAssetPath } from '@stencil/core';
 ```
 

--- a/versioned_docs/version-v4.3/guides/assets.md
+++ b/versioned_docs/version-v4.3/guides/assets.md
@@ -211,6 +211,8 @@ declare function getAssetPath(path: string): string;
 ```
 
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments, when an asset base path of `/build/` has been set.
+
+```ts
 import { getAssetPath } from '@stencil/core';
 
 // with an asset base path of "/build/":

--- a/versioned_docs/version-v4.3/guides/assets.md
+++ b/versioned_docs/version-v4.3/guides/assets.md
@@ -62,6 +62,8 @@ When using `getAssetPath`, the assets in the directory structure above are resol
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments.
 The return value is a path that Stencil has built to retrieve the asset on the filesystem.
 ```ts
+import { getAssetPath } from '@stencil/core';
+
 // with an asset base path of "/build/":
 
 // '/build/assets/logo.png'
@@ -209,7 +211,8 @@ declare function getAssetPath(path: string): string;
 ```
 
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments, when an asset base path of `/build/` has been set.
-```ts
+import { getAssetPath } from '@stencil/core';
+
 // with an asset base path of "/build/":
 // "/build/"
 getAssetPath('');

--- a/versioned_docs/version-v4.3/guides/assets.md
+++ b/versioned_docs/version-v4.3/guides/assets.md
@@ -242,7 +242,7 @@ Calling this API will set the asset base path for all Stencil components attache
 As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
 when using a component.
 
-If the file calling `setAssetPath` is a module, it's recommended to use `import.meta.url`.
+If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use: `setAssetPath('${window.location.origin}/');`
 
 Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
 when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the

--- a/versioned_docs/version-v4.3/guides/assets.md
+++ b/versioned_docs/version-v4.3/guides/assets.md
@@ -245,7 +245,7 @@ export declare function setAssetPath(path: string): string;
 
 Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime. As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects when using a component.
 
-Make sure as component author to export this function as part of your module in order to give the consumer of your component the chance to change it, e.g. in your package entry file export the function via:
+Make sure as component author to export this function as part of your module in order to also make it accessible to the consumer of your component, e.g. in your package entry file export the function via:
 
 ```ts
 export { setAssetPath } from '@stencil/core';

--- a/versioned_docs/version-v4.3/guides/assets.md
+++ b/versioned_docs/version-v4.3/guides/assets.md
@@ -242,7 +242,12 @@ Calling this API will set the asset base path for all Stencil components attache
 As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
 when using a component.
 
-If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use: `setAssetPath('${window.location.origin}/');`
+If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use:
+
+```ts
+import { setAssetPath } from '@stencil/core';
+setAssetPath(`${window.location.origin}/`);
+```
 
 Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
 when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the

--- a/versioned_docs/version-v4.4/components/api.md
+++ b/versioned_docs/version-v4.4/components/api.md
@@ -157,8 +157,8 @@ The following primitives can be imported from the `@stencil/core` package and us
   __Type:__ `(path: string) => string`<br />
   __Example:__
   ```ts
-  import { setAssetPath } from '@stencil/core'
-  setAssetPath(import.meta.url)
+  import { setAssetPath } from '@stencil/core';
+  setAssetPath(`{window.location.origin}/`)
   ```
 
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.

--- a/versioned_docs/version-v4.4/components/api.md
+++ b/versioned_docs/version-v4.4/components/api.md
@@ -158,7 +158,7 @@ The following primitives can be imported from the `@stencil/core` package and us
   __Example:__
   ```ts
   import { setAssetPath } from '@stencil/core';
-  setAssetPath(`{window.location.origin}/`)
+  setAssetPath(`{window.location.origin}/`);
   ```
 
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.

--- a/versioned_docs/version-v4.4/components/api.md
+++ b/versioned_docs/version-v4.4/components/api.md
@@ -152,6 +152,15 @@ The following primitives can be imported from the `@stencil/core` package and us
   }
   ```
 
+- **setAssetPath()**: Sets the path for Stencil to resolve local assets. Refer to the [Assets](../guides/assets.md#setassetpath) page for usage info.
+
+  __Type:__ `(path: string) => string`<br />
+  __Example:__
+  ```ts
+  import { setAssetPath } from '@stencil/core'
+  setAssetPath(import.meta.url)
+  ```
+
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.
 
   __Type:__ `(ref: HTMLElement) => string`<br />

--- a/versioned_docs/version-v4.4/guides/assets.md
+++ b/versioned_docs/version-v4.4/guides/assets.md
@@ -263,7 +263,7 @@ asset base path. This configuration depends on how your script is bundled, (or l
 
 :::note
 
-If your component library exports components compiled with [`dist-output-target`](custom-elements) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
+If your component library exports components compiled with [`dist-output-target`](/output-targets/custom-elements.md) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
 
 :::
 

--- a/versioned_docs/version-v4.4/guides/assets.md
+++ b/versioned_docs/version-v4.4/guides/assets.md
@@ -232,7 +232,7 @@ getAssetPath('/assets/my-image.png');
 
 ### setAssetPath
 
-`setAssetPath` is an API provided by Stencil to manually set the asset base path where assets can be found.
+`setAssetPath` is an API provided by Stencil's runtime to manually set the asset base path where assets can be found. If you are using `getAssetPath` to compose the path for your component assets, `setAssetPath` allows you or the consumer of the component to change that path.
 
 ```ts
 /**
@@ -243,18 +243,43 @@ getAssetPath('/assets/my-image.png');
 export declare function setAssetPath(path: string): string;
 ```
 
-Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime.
-As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
-when using a component.
+Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime. As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects when using a component.
 
-If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use:
+Make sure as component author to export this function as part of your module in order to give the consumer of your component the chance to change it, e.g. in your package entry file export the function via:
 
 ```ts
-import { setAssetPath } from '@stencil/core';
-setAssetPath(`${window.location.origin}/`);
+export { setAssetPath } from '@stencil/core';
 ```
 
-Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
-when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the
-asset base path. 
-This configuration depends on how your script is bundled, (or lack of bundling), and where your assets can be loaded from.
+Now your users can import it directly from your component library, e.g.:
+
+```ts
+import { setAssetPath } from 'my-component-library';
+setAssetPath(`${window.location.protocol}//assets.${window.location.host}/`);
+```
+
+Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript) when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the
+asset base path. This configuration depends on how your script is bundled, (or lack of bundling), and where your assets can be loaded from.
+
+:::note
+
+If your component library exports components compiled with [`dist-output-target`](custom-elements) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
+
+:::
+
+In case you import a component directly via script tag, this would look like:
+
+```html
+<html>
+  <head>
+    <script src="https://cdn.jsdelivr.net/npm/my-component-library/dist/my-component-library.js"></script>
+    <script type="module">
+      import { setAssetPath } from 'https://cdn.jsdelivr.net/npm/my-component-library/dist/my-component-library.js';
+      setAssetPath(`${window.location.origin}/`);
+    </script>
+  </head>
+  <body>
+    <ion-toggle></ion-toggle>
+  </body>
+</html>
+```

--- a/versioned_docs/version-v4.4/guides/assets.md
+++ b/versioned_docs/version-v4.4/guides/assets.md
@@ -247,7 +247,7 @@ Calling this API will set the asset base path for all Stencil components attache
 
 Make sure as component author to export this function as part of your module in order to also make it accessible to the consumer of your component, e.g. in your package entry file export the function via:
 
-```ts
+```ts title="/src/index.ts"
 export { setAssetPath } from '@stencil/core';
 ```
 

--- a/versioned_docs/version-v4.4/guides/assets.md
+++ b/versioned_docs/version-v4.4/guides/assets.md
@@ -211,6 +211,8 @@ declare function getAssetPath(path: string): string;
 ```
 
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments, when an asset base path of `/build/` has been set.
+
+```ts
 import { getAssetPath } from '@stencil/core';
 
 // with an asset base path of "/build/":

--- a/versioned_docs/version-v4.4/guides/assets.md
+++ b/versioned_docs/version-v4.4/guides/assets.md
@@ -62,6 +62,8 @@ When using `getAssetPath`, the assets in the directory structure above are resol
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments.
 The return value is a path that Stencil has built to retrieve the asset on the filesystem.
 ```ts
+import { getAssetPath } from '@stencil/core';
+
 // with an asset base path of "/build/":
 
 // '/build/assets/logo.png'
@@ -209,7 +211,8 @@ declare function getAssetPath(path: string): string;
 ```
 
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments, when an asset base path of `/build/` has been set.
-```ts
+import { getAssetPath } from '@stencil/core';
+
 // with an asset base path of "/build/":
 // "/build/"
 getAssetPath('');

--- a/versioned_docs/version-v4.4/guides/assets.md
+++ b/versioned_docs/version-v4.4/guides/assets.md
@@ -242,7 +242,7 @@ Calling this API will set the asset base path for all Stencil components attache
 As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
 when using a component.
 
-If the file calling `setAssetPath` is a module, it's recommended to use `import.meta.url`.
+If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use: `setAssetPath('${window.location.origin}/');`
 
 Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
 when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the

--- a/versioned_docs/version-v4.4/guides/assets.md
+++ b/versioned_docs/version-v4.4/guides/assets.md
@@ -245,7 +245,7 @@ export declare function setAssetPath(path: string): string;
 
 Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime. As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects when using a component.
 
-Make sure as component author to export this function as part of your module in order to give the consumer of your component the chance to change it, e.g. in your package entry file export the function via:
+Make sure as component author to export this function as part of your module in order to also make it accessible to the consumer of your component, e.g. in your package entry file export the function via:
 
 ```ts
 export { setAssetPath } from '@stencil/core';

--- a/versioned_docs/version-v4.4/guides/assets.md
+++ b/versioned_docs/version-v4.4/guides/assets.md
@@ -242,7 +242,12 @@ Calling this API will set the asset base path for all Stencil components attache
 As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
 when using a component.
 
-If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use: `setAssetPath('${window.location.origin}/');`
+If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use:
+
+```ts
+import { setAssetPath } from '@stencil/core';
+setAssetPath(`${window.location.origin}/`);
+```
 
 Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
 when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the

--- a/versioned_docs/version-v4.5/components/api.md
+++ b/versioned_docs/version-v4.5/components/api.md
@@ -157,8 +157,8 @@ The following primitives can be imported from the `@stencil/core` package and us
   __Type:__ `(path: string) => string`<br />
   __Example:__
   ```ts
-  import { setAssetPath } from '@stencil/core'
-  setAssetPath(import.meta.url)
+  import { setAssetPath } from '@stencil/core';
+  setAssetPath(`{window.location.origin}/`)
   ```
 
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.

--- a/versioned_docs/version-v4.5/components/api.md
+++ b/versioned_docs/version-v4.5/components/api.md
@@ -158,7 +158,7 @@ The following primitives can be imported from the `@stencil/core` package and us
   __Example:__
   ```ts
   import { setAssetPath } from '@stencil/core';
-  setAssetPath(`{window.location.origin}/`)
+  setAssetPath(`{window.location.origin}/`);
   ```
 
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.

--- a/versioned_docs/version-v4.5/components/api.md
+++ b/versioned_docs/version-v4.5/components/api.md
@@ -152,6 +152,15 @@ The following primitives can be imported from the `@stencil/core` package and us
   }
   ```
 
+- **setAssetPath()**: Sets the path for Stencil to resolve local assets. Refer to the [Assets](../guides/assets.md#setassetpath) page for usage info.
+
+  __Type:__ `(path: string) => string`<br />
+  __Example:__
+  ```ts
+  import { setAssetPath } from '@stencil/core'
+  setAssetPath(import.meta.url)
+  ```
+
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.
 
   __Type:__ `(ref: HTMLElement) => string`<br />

--- a/versioned_docs/version-v4.5/guides/assets.md
+++ b/versioned_docs/version-v4.5/guides/assets.md
@@ -263,7 +263,7 @@ asset base path. This configuration depends on how your script is bundled, (or l
 
 :::note
 
-If your component library exports components compiled with [`dist-output-target`](custom-elements) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
+If your component library exports components compiled with [`dist-output-target`](/output-targets/custom-elements.md) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
 
 :::
 

--- a/versioned_docs/version-v4.5/guides/assets.md
+++ b/versioned_docs/version-v4.5/guides/assets.md
@@ -232,7 +232,7 @@ getAssetPath('/assets/my-image.png');
 
 ### setAssetPath
 
-`setAssetPath` is an API provided by Stencil to manually set the asset base path where assets can be found.
+`setAssetPath` is an API provided by Stencil's runtime to manually set the asset base path where assets can be found. If you are using `getAssetPath` to compose the path for your component assets, `setAssetPath` allows you or the consumer of the component to change that path.
 
 ```ts
 /**
@@ -243,18 +243,43 @@ getAssetPath('/assets/my-image.png');
 export declare function setAssetPath(path: string): string;
 ```
 
-Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime.
-As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
-when using a component.
+Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime. As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects when using a component.
 
-If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use:
+Make sure as component author to export this function as part of your module in order to give the consumer of your component the chance to change it, e.g. in your package entry file export the function via:
 
 ```ts
-import { setAssetPath } from '@stencil/core';
-setAssetPath(`${window.location.origin}/`);
+export { setAssetPath } from '@stencil/core';
 ```
 
-Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
-when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the
-asset base path. 
-This configuration depends on how your script is bundled, (or lack of bundling), and where your assets can be loaded from.
+Now your users can import it directly from your component library, e.g.:
+
+```ts
+import { setAssetPath } from 'my-component-library';
+setAssetPath(`${window.location.protocol}//assets.${window.location.host}/`);
+```
+
+Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript) when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the
+asset base path. This configuration depends on how your script is bundled, (or lack of bundling), and where your assets can be loaded from.
+
+:::note
+
+If your component library exports components compiled with [`dist-output-target`](custom-elements) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
+
+:::
+
+In case you import a component directly via script tag, this would look like:
+
+```html
+<html>
+  <head>
+    <script src="https://cdn.jsdelivr.net/npm/my-component-library/dist/my-component-library.js"></script>
+    <script type="module">
+      import { setAssetPath } from 'https://cdn.jsdelivr.net/npm/my-component-library/dist/my-component-library.js';
+      setAssetPath(`${window.location.origin}/`);
+    </script>
+  </head>
+  <body>
+    <ion-toggle></ion-toggle>
+  </body>
+</html>
+```

--- a/versioned_docs/version-v4.5/guides/assets.md
+++ b/versioned_docs/version-v4.5/guides/assets.md
@@ -247,7 +247,7 @@ Calling this API will set the asset base path for all Stencil components attache
 
 Make sure as component author to export this function as part of your module in order to also make it accessible to the consumer of your component, e.g. in your package entry file export the function via:
 
-```ts
+```ts title="/src/index.ts"
 export { setAssetPath } from '@stencil/core';
 ```
 

--- a/versioned_docs/version-v4.5/guides/assets.md
+++ b/versioned_docs/version-v4.5/guides/assets.md
@@ -211,6 +211,8 @@ declare function getAssetPath(path: string): string;
 ```
 
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments, when an asset base path of `/build/` has been set.
+
+```ts
 import { getAssetPath } from '@stencil/core';
 
 // with an asset base path of "/build/":

--- a/versioned_docs/version-v4.5/guides/assets.md
+++ b/versioned_docs/version-v4.5/guides/assets.md
@@ -62,6 +62,8 @@ When using `getAssetPath`, the assets in the directory structure above are resol
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments.
 The return value is a path that Stencil has built to retrieve the asset on the filesystem.
 ```ts
+import { getAssetPath } from '@stencil/core';
+
 // with an asset base path of "/build/":
 
 // '/build/assets/logo.png'
@@ -209,7 +211,8 @@ declare function getAssetPath(path: string): string;
 ```
 
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments, when an asset base path of `/build/` has been set.
-```ts
+import { getAssetPath } from '@stencil/core';
+
 // with an asset base path of "/build/":
 // "/build/"
 getAssetPath('');

--- a/versioned_docs/version-v4.5/guides/assets.md
+++ b/versioned_docs/version-v4.5/guides/assets.md
@@ -242,7 +242,7 @@ Calling this API will set the asset base path for all Stencil components attache
 As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
 when using a component.
 
-If the file calling `setAssetPath` is a module, it's recommended to use `import.meta.url`.
+If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use: `setAssetPath('${window.location.origin}/');`
 
 Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
 when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the

--- a/versioned_docs/version-v4.5/guides/assets.md
+++ b/versioned_docs/version-v4.5/guides/assets.md
@@ -245,7 +245,7 @@ export declare function setAssetPath(path: string): string;
 
 Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime. As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects when using a component.
 
-Make sure as component author to export this function as part of your module in order to give the consumer of your component the chance to change it, e.g. in your package entry file export the function via:
+Make sure as component author to export this function as part of your module in order to also make it accessible to the consumer of your component, e.g. in your package entry file export the function via:
 
 ```ts
 export { setAssetPath } from '@stencil/core';

--- a/versioned_docs/version-v4.5/guides/assets.md
+++ b/versioned_docs/version-v4.5/guides/assets.md
@@ -242,7 +242,12 @@ Calling this API will set the asset base path for all Stencil components attache
 As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
 when using a component.
 
-If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use: `setAssetPath('${window.location.origin}/');`
+If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use:
+
+```ts
+import { setAssetPath } from '@stencil/core';
+setAssetPath(`${window.location.origin}/`);
+```
 
 Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
 when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the

--- a/versioned_docs/version-v4.6/components/api.md
+++ b/versioned_docs/version-v4.6/components/api.md
@@ -157,8 +157,8 @@ The following primitives can be imported from the `@stencil/core` package and us
   __Type:__ `(path: string) => string`<br />
   __Example:__
   ```ts
-  import { setAssetPath } from '@stencil/core'
-  setAssetPath(import.meta.url)
+  import { setAssetPath } from '@stencil/core';
+  setAssetPath(`{window.location.origin}/`)
   ```
 
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.

--- a/versioned_docs/version-v4.6/components/api.md
+++ b/versioned_docs/version-v4.6/components/api.md
@@ -158,7 +158,7 @@ The following primitives can be imported from the `@stencil/core` package and us
   __Example:__
   ```ts
   import { setAssetPath } from '@stencil/core';
-  setAssetPath(`{window.location.origin}/`)
+  setAssetPath(`{window.location.origin}/`);
   ```
 
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.

--- a/versioned_docs/version-v4.6/components/api.md
+++ b/versioned_docs/version-v4.6/components/api.md
@@ -152,6 +152,15 @@ The following primitives can be imported from the `@stencil/core` package and us
   }
   ```
 
+- **setAssetPath()**: Sets the path for Stencil to resolve local assets. Refer to the [Assets](../guides/assets.md#setassetpath) page for usage info.
+
+  __Type:__ `(path: string) => string`<br />
+  __Example:__
+  ```ts
+  import { setAssetPath } from '@stencil/core'
+  setAssetPath(import.meta.url)
+  ```
+
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.
 
   __Type:__ `(ref: HTMLElement) => string`<br />

--- a/versioned_docs/version-v4.6/guides/assets.md
+++ b/versioned_docs/version-v4.6/guides/assets.md
@@ -263,7 +263,7 @@ asset base path. This configuration depends on how your script is bundled, (or l
 
 :::note
 
-If your component library exports components compiled with [`dist-output-target`](custom-elements) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
+If your component library exports components compiled with [`dist-output-target`](/output-targets/custom-elements.md) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
 
 :::
 

--- a/versioned_docs/version-v4.6/guides/assets.md
+++ b/versioned_docs/version-v4.6/guides/assets.md
@@ -232,7 +232,7 @@ getAssetPath('/assets/my-image.png');
 
 ### setAssetPath
 
-`setAssetPath` is an API provided by Stencil to manually set the asset base path where assets can be found.
+`setAssetPath` is an API provided by Stencil's runtime to manually set the asset base path where assets can be found. If you are using `getAssetPath` to compose the path for your component assets, `setAssetPath` allows you or the consumer of the component to change that path.
 
 ```ts
 /**
@@ -243,18 +243,43 @@ getAssetPath('/assets/my-image.png');
 export declare function setAssetPath(path: string): string;
 ```
 
-Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime.
-As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
-when using a component.
+Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime. As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects when using a component.
 
-If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use:
+Make sure as component author to export this function as part of your module in order to give the consumer of your component the chance to change it, e.g. in your package entry file export the function via:
 
 ```ts
-import { setAssetPath } from '@stencil/core';
-setAssetPath(`${window.location.origin}/`);
+export { setAssetPath } from '@stencil/core';
 ```
 
-Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
-when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the
-asset base path. 
-This configuration depends on how your script is bundled, (or lack of bundling), and where your assets can be loaded from.
+Now your users can import it directly from your component library, e.g.:
+
+```ts
+import { setAssetPath } from 'my-component-library';
+setAssetPath(`${window.location.protocol}//assets.${window.location.host}/`);
+```
+
+Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript) when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the
+asset base path. This configuration depends on how your script is bundled, (or lack of bundling), and where your assets can be loaded from.
+
+:::note
+
+If your component library exports components compiled with [`dist-output-target`](custom-elements) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
+
+:::
+
+In case you import a component directly via script tag, this would look like:
+
+```html
+<html>
+  <head>
+    <script src="https://cdn.jsdelivr.net/npm/my-component-library/dist/my-component-library.js"></script>
+    <script type="module">
+      import { setAssetPath } from 'https://cdn.jsdelivr.net/npm/my-component-library/dist/my-component-library.js';
+      setAssetPath(`${window.location.origin}/`);
+    </script>
+  </head>
+  <body>
+    <ion-toggle></ion-toggle>
+  </body>
+</html>
+```

--- a/versioned_docs/version-v4.6/guides/assets.md
+++ b/versioned_docs/version-v4.6/guides/assets.md
@@ -247,7 +247,7 @@ Calling this API will set the asset base path for all Stencil components attache
 
 Make sure as component author to export this function as part of your module in order to also make it accessible to the consumer of your component, e.g. in your package entry file export the function via:
 
-```ts
+```ts title="/src/index.ts"
 export { setAssetPath } from '@stencil/core';
 ```
 

--- a/versioned_docs/version-v4.6/guides/assets.md
+++ b/versioned_docs/version-v4.6/guides/assets.md
@@ -211,6 +211,8 @@ declare function getAssetPath(path: string): string;
 ```
 
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments, when an asset base path of `/build/` has been set.
+
+```ts
 import { getAssetPath } from '@stencil/core';
 
 // with an asset base path of "/build/":

--- a/versioned_docs/version-v4.6/guides/assets.md
+++ b/versioned_docs/version-v4.6/guides/assets.md
@@ -62,6 +62,8 @@ When using `getAssetPath`, the assets in the directory structure above are resol
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments.
 The return value is a path that Stencil has built to retrieve the asset on the filesystem.
 ```ts
+import { getAssetPath } from '@stencil/core';
+
 // with an asset base path of "/build/":
 
 // '/build/assets/logo.png'
@@ -209,7 +211,8 @@ declare function getAssetPath(path: string): string;
 ```
 
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments, when an asset base path of `/build/` has been set.
-```ts
+import { getAssetPath } from '@stencil/core';
+
 // with an asset base path of "/build/":
 // "/build/"
 getAssetPath('');

--- a/versioned_docs/version-v4.6/guides/assets.md
+++ b/versioned_docs/version-v4.6/guides/assets.md
@@ -242,7 +242,7 @@ Calling this API will set the asset base path for all Stencil components attache
 As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
 when using a component.
 
-If the file calling `setAssetPath` is a module, it's recommended to use `import.meta.url`.
+If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use: `setAssetPath('${window.location.origin}/');`
 
 Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
 when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the

--- a/versioned_docs/version-v4.6/guides/assets.md
+++ b/versioned_docs/version-v4.6/guides/assets.md
@@ -245,7 +245,7 @@ export declare function setAssetPath(path: string): string;
 
 Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime. As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects when using a component.
 
-Make sure as component author to export this function as part of your module in order to give the consumer of your component the chance to change it, e.g. in your package entry file export the function via:
+Make sure as component author to export this function as part of your module in order to also make it accessible to the consumer of your component, e.g. in your package entry file export the function via:
 
 ```ts
 export { setAssetPath } from '@stencil/core';

--- a/versioned_docs/version-v4.6/guides/assets.md
+++ b/versioned_docs/version-v4.6/guides/assets.md
@@ -242,7 +242,12 @@ Calling this API will set the asset base path for all Stencil components attache
 As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
 when using a component.
 
-If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use: `setAssetPath('${window.location.origin}/');`
+If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use:
+
+```ts
+import { setAssetPath } from '@stencil/core';
+setAssetPath(`${window.location.origin}/`);
+```
 
 Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
 when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the

--- a/versioned_docs/version-v4.7/components/api.md
+++ b/versioned_docs/version-v4.7/components/api.md
@@ -157,8 +157,8 @@ The following primitives can be imported from the `@stencil/core` package and us
   __Type:__ `(path: string) => string`<br />
   __Example:__
   ```ts
-  import { setAssetPath } from '@stencil/core'
-  setAssetPath(import.meta.url)
+  import { setAssetPath } from '@stencil/core';
+  setAssetPath(`{window.location.origin}/`)
   ```
 
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.

--- a/versioned_docs/version-v4.7/components/api.md
+++ b/versioned_docs/version-v4.7/components/api.md
@@ -158,7 +158,7 @@ The following primitives can be imported from the `@stencil/core` package and us
   __Example:__
   ```ts
   import { setAssetPath } from '@stencil/core';
-  setAssetPath(`{window.location.origin}/`)
+  setAssetPath(`{window.location.origin}/`);
   ```
 
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.

--- a/versioned_docs/version-v4.7/components/api.md
+++ b/versioned_docs/version-v4.7/components/api.md
@@ -152,6 +152,15 @@ The following primitives can be imported from the `@stencil/core` package and us
   }
   ```
 
+- **setAssetPath()**: Sets the path for Stencil to resolve local assets. Refer to the [Assets](../guides/assets.md#setassetpath) page for usage info.
+
+  __Type:__ `(path: string) => string`<br />
+  __Example:__
+  ```ts
+  import { setAssetPath } from '@stencil/core'
+  setAssetPath(import.meta.url)
+  ```
+
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.
 
   __Type:__ `(ref: HTMLElement) => string`<br />

--- a/versioned_docs/version-v4.7/guides/assets.md
+++ b/versioned_docs/version-v4.7/guides/assets.md
@@ -263,7 +263,7 @@ asset base path. This configuration depends on how your script is bundled, (or l
 
 :::note
 
-If your component library exports components compiled with [`dist-output-target`](custom-elements) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
+If your component library exports components compiled with [`dist-output-target`](/output-targets/custom-elements.md) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
 
 :::
 

--- a/versioned_docs/version-v4.7/guides/assets.md
+++ b/versioned_docs/version-v4.7/guides/assets.md
@@ -232,7 +232,7 @@ getAssetPath('/assets/my-image.png');
 
 ### setAssetPath
 
-`setAssetPath` is an API provided by Stencil to manually set the asset base path where assets can be found.
+`setAssetPath` is an API provided by Stencil's runtime to manually set the asset base path where assets can be found. If you are using `getAssetPath` to compose the path for your component assets, `setAssetPath` allows you or the consumer of the component to change that path.
 
 ```ts
 /**
@@ -243,18 +243,43 @@ getAssetPath('/assets/my-image.png');
 export declare function setAssetPath(path: string): string;
 ```
 
-Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime.
-As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
-when using a component.
+Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime. As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects when using a component.
 
-If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use:
+Make sure as component author to export this function as part of your module in order to give the consumer of your component the chance to change it, e.g. in your package entry file export the function via:
 
 ```ts
-import { setAssetPath } from '@stencil/core';
-setAssetPath(`${window.location.origin}/`);
+export { setAssetPath } from '@stencil/core';
 ```
 
-Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
-when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the
-asset base path. 
-This configuration depends on how your script is bundled, (or lack of bundling), and where your assets can be loaded from.
+Now your users can import it directly from your component library, e.g.:
+
+```ts
+import { setAssetPath } from 'my-component-library';
+setAssetPath(`${window.location.protocol}//assets.${window.location.host}/`);
+```
+
+Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript) when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the
+asset base path. This configuration depends on how your script is bundled, (or lack of bundling), and where your assets can be loaded from.
+
+:::note
+
+If your component library exports components compiled with [`dist-output-target`](custom-elements) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
+
+:::
+
+In case you import a component directly via script tag, this would look like:
+
+```html
+<html>
+  <head>
+    <script src="https://cdn.jsdelivr.net/npm/my-component-library/dist/my-component-library.js"></script>
+    <script type="module">
+      import { setAssetPath } from 'https://cdn.jsdelivr.net/npm/my-component-library/dist/my-component-library.js';
+      setAssetPath(`${window.location.origin}/`);
+    </script>
+  </head>
+  <body>
+    <ion-toggle></ion-toggle>
+  </body>
+</html>
+```

--- a/versioned_docs/version-v4.7/guides/assets.md
+++ b/versioned_docs/version-v4.7/guides/assets.md
@@ -247,7 +247,7 @@ Calling this API will set the asset base path for all Stencil components attache
 
 Make sure as component author to export this function as part of your module in order to also make it accessible to the consumer of your component, e.g. in your package entry file export the function via:
 
-```ts
+```ts title="/src/index.ts"
 export { setAssetPath } from '@stencil/core';
 ```
 

--- a/versioned_docs/version-v4.7/guides/assets.md
+++ b/versioned_docs/version-v4.7/guides/assets.md
@@ -211,6 +211,8 @@ declare function getAssetPath(path: string): string;
 ```
 
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments, when an asset base path of `/build/` has been set.
+
+```ts
 import { getAssetPath } from '@stencil/core';
 
 // with an asset base path of "/build/":

--- a/versioned_docs/version-v4.7/guides/assets.md
+++ b/versioned_docs/version-v4.7/guides/assets.md
@@ -62,6 +62,8 @@ When using `getAssetPath`, the assets in the directory structure above are resol
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments.
 The return value is a path that Stencil has built to retrieve the asset on the filesystem.
 ```ts
+import { getAssetPath } from '@stencil/core';
+
 // with an asset base path of "/build/":
 
 // '/build/assets/logo.png'
@@ -209,7 +211,8 @@ declare function getAssetPath(path: string): string;
 ```
 
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments, when an asset base path of `/build/` has been set.
-```ts
+import { getAssetPath } from '@stencil/core';
+
 // with an asset base path of "/build/":
 // "/build/"
 getAssetPath('');

--- a/versioned_docs/version-v4.7/guides/assets.md
+++ b/versioned_docs/version-v4.7/guides/assets.md
@@ -242,7 +242,7 @@ Calling this API will set the asset base path for all Stencil components attache
 As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
 when using a component.
 
-If the file calling `setAssetPath` is a module, it's recommended to use `import.meta.url`.
+If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use: `setAssetPath('${window.location.origin}/');`
 
 Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
 when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the

--- a/versioned_docs/version-v4.7/guides/assets.md
+++ b/versioned_docs/version-v4.7/guides/assets.md
@@ -245,7 +245,7 @@ export declare function setAssetPath(path: string): string;
 
 Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime. As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects when using a component.
 
-Make sure as component author to export this function as part of your module in order to give the consumer of your component the chance to change it, e.g. in your package entry file export the function via:
+Make sure as component author to export this function as part of your module in order to also make it accessible to the consumer of your component, e.g. in your package entry file export the function via:
 
 ```ts
 export { setAssetPath } from '@stencil/core';

--- a/versioned_docs/version-v4.7/guides/assets.md
+++ b/versioned_docs/version-v4.7/guides/assets.md
@@ -242,7 +242,12 @@ Calling this API will set the asset base path for all Stencil components attache
 As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
 when using a component.
 
-If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use: `setAssetPath('${window.location.origin}/');`
+If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use:
+
+```ts
+import { setAssetPath } from '@stencil/core';
+setAssetPath(`${window.location.origin}/`);
+```
 
 Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
 when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the

--- a/versioned_docs/version-v4.8/components/api.md
+++ b/versioned_docs/version-v4.8/components/api.md
@@ -157,8 +157,8 @@ The following primitives can be imported from the `@stencil/core` package and us
   __Type:__ `(path: string) => string`<br />
   __Example:__
   ```ts
-  import { setAssetPath } from '@stencil/core'
-  setAssetPath(import.meta.url)
+  import { setAssetPath } from '@stencil/core';
+  setAssetPath(`{window.location.origin}/`)
   ```
 
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.

--- a/versioned_docs/version-v4.8/components/api.md
+++ b/versioned_docs/version-v4.8/components/api.md
@@ -158,7 +158,7 @@ The following primitives can be imported from the `@stencil/core` package and us
   __Example:__
   ```ts
   import { setAssetPath } from '@stencil/core';
-  setAssetPath(`{window.location.origin}/`)
+  setAssetPath(`{window.location.origin}/`);
   ```
 
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.

--- a/versioned_docs/version-v4.8/components/api.md
+++ b/versioned_docs/version-v4.8/components/api.md
@@ -152,6 +152,15 @@ The following primitives can be imported from the `@stencil/core` package and us
   }
   ```
 
+- **setAssetPath()**: Sets the path for Stencil to resolve local assets. Refer to the [Assets](../guides/assets.md#setassetpath) page for usage info.
+
+  __Type:__ `(path: string) => string`<br />
+  __Example:__
+  ```ts
+  import { setAssetPath } from '@stencil/core'
+  setAssetPath(import.meta.url)
+  ```
+
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.
 
   __Type:__ `(ref: HTMLElement) => string`<br />

--- a/versioned_docs/version-v4.8/guides/assets.md
+++ b/versioned_docs/version-v4.8/guides/assets.md
@@ -263,7 +263,7 @@ asset base path. This configuration depends on how your script is bundled, (or l
 
 :::note
 
-If your component library exports components compiled with [`dist-output-target`](custom-elements) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
+If your component library exports components compiled with [`dist-output-target`](/output-targets/custom-elements.md) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
 
 :::
 

--- a/versioned_docs/version-v4.8/guides/assets.md
+++ b/versioned_docs/version-v4.8/guides/assets.md
@@ -232,7 +232,7 @@ getAssetPath('/assets/my-image.png');
 
 ### setAssetPath
 
-`setAssetPath` is an API provided by Stencil to manually set the asset base path where assets can be found.
+`setAssetPath` is an API provided by Stencil's runtime to manually set the asset base path where assets can be found. If you are using `getAssetPath` to compose the path for your component assets, `setAssetPath` allows you or the consumer of the component to change that path.
 
 ```ts
 /**
@@ -243,18 +243,43 @@ getAssetPath('/assets/my-image.png');
 export declare function setAssetPath(path: string): string;
 ```
 
-Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime.
-As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
-when using a component.
+Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime. As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects when using a component.
 
-If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use:
+Make sure as component author to export this function as part of your module in order to give the consumer of your component the chance to change it, e.g. in your package entry file export the function via:
 
 ```ts
-import { setAssetPath } from '@stencil/core';
-setAssetPath(`${window.location.origin}/`);
+export { setAssetPath } from '@stencil/core';
 ```
 
-Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
-when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the
-asset base path. 
-This configuration depends on how your script is bundled, (or lack of bundling), and where your assets can be loaded from.
+Now your users can import it directly from your component library, e.g.:
+
+```ts
+import { setAssetPath } from 'my-component-library';
+setAssetPath(`${window.location.protocol}//assets.${window.location.host}/`);
+```
+
+Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript) when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the
+asset base path. This configuration depends on how your script is bundled, (or lack of bundling), and where your assets can be loaded from.
+
+:::note
+
+If your component library exports components compiled with [`dist-output-target`](custom-elements) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
+
+:::
+
+In case you import a component directly via script tag, this would look like:
+
+```html
+<html>
+  <head>
+    <script src="https://cdn.jsdelivr.net/npm/my-component-library/dist/my-component-library.js"></script>
+    <script type="module">
+      import { setAssetPath } from 'https://cdn.jsdelivr.net/npm/my-component-library/dist/my-component-library.js';
+      setAssetPath(`${window.location.origin}/`);
+    </script>
+  </head>
+  <body>
+    <ion-toggle></ion-toggle>
+  </body>
+</html>
+```

--- a/versioned_docs/version-v4.8/guides/assets.md
+++ b/versioned_docs/version-v4.8/guides/assets.md
@@ -247,7 +247,7 @@ Calling this API will set the asset base path for all Stencil components attache
 
 Make sure as component author to export this function as part of your module in order to also make it accessible to the consumer of your component, e.g. in your package entry file export the function via:
 
-```ts
+```ts title="/src/index.ts"
 export { setAssetPath } from '@stencil/core';
 ```
 

--- a/versioned_docs/version-v4.8/guides/assets.md
+++ b/versioned_docs/version-v4.8/guides/assets.md
@@ -211,6 +211,8 @@ declare function getAssetPath(path: string): string;
 ```
 
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments, when an asset base path of `/build/` has been set.
+
+```ts
 import { getAssetPath } from '@stencil/core';
 
 // with an asset base path of "/build/":

--- a/versioned_docs/version-v4.8/guides/assets.md
+++ b/versioned_docs/version-v4.8/guides/assets.md
@@ -62,6 +62,8 @@ When using `getAssetPath`, the assets in the directory structure above are resol
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments.
 The return value is a path that Stencil has built to retrieve the asset on the filesystem.
 ```ts
+import { getAssetPath } from '@stencil/core';
+
 // with an asset base path of "/build/":
 
 // '/build/assets/logo.png'
@@ -209,7 +211,8 @@ declare function getAssetPath(path: string): string;
 ```
 
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments, when an asset base path of `/build/` has been set.
-```ts
+import { getAssetPath } from '@stencil/core';
+
 // with an asset base path of "/build/":
 // "/build/"
 getAssetPath('');

--- a/versioned_docs/version-v4.8/guides/assets.md
+++ b/versioned_docs/version-v4.8/guides/assets.md
@@ -242,7 +242,7 @@ Calling this API will set the asset base path for all Stencil components attache
 As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
 when using a component.
 
-If the file calling `setAssetPath` is a module, it's recommended to use `import.meta.url`.
+If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use: `setAssetPath('${window.location.origin}/');`
 
 Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
 when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the

--- a/versioned_docs/version-v4.8/guides/assets.md
+++ b/versioned_docs/version-v4.8/guides/assets.md
@@ -245,7 +245,7 @@ export declare function setAssetPath(path: string): string;
 
 Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime. As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects when using a component.
 
-Make sure as component author to export this function as part of your module in order to give the consumer of your component the chance to change it, e.g. in your package entry file export the function via:
+Make sure as component author to export this function as part of your module in order to also make it accessible to the consumer of your component, e.g. in your package entry file export the function via:
 
 ```ts
 export { setAssetPath } from '@stencil/core';

--- a/versioned_docs/version-v4.8/guides/assets.md
+++ b/versioned_docs/version-v4.8/guides/assets.md
@@ -242,7 +242,12 @@ Calling this API will set the asset base path for all Stencil components attache
 As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
 when using a component.
 
-If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use: `setAssetPath('${window.location.origin}/');`
+If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use:
+
+```ts
+import { setAssetPath } from '@stencil/core';
+setAssetPath(`${window.location.origin}/`);
+```
 
 Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
 when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the

--- a/versioned_docs/version-v4.9/components/api.md
+++ b/versioned_docs/version-v4.9/components/api.md
@@ -157,8 +157,8 @@ The following primitives can be imported from the `@stencil/core` package and us
   __Type:__ `(path: string) => string`<br />
   __Example:__
   ```ts
-  import { setAssetPath } from '@stencil/core'
-  setAssetPath(import.meta.url)
+  import { setAssetPath } from '@stencil/core';
+  setAssetPath(`{window.location.origin}/`)
   ```
 
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.

--- a/versioned_docs/version-v4.9/components/api.md
+++ b/versioned_docs/version-v4.9/components/api.md
@@ -158,7 +158,7 @@ The following primitives can be imported from the `@stencil/core` package and us
   __Example:__
   ```ts
   import { setAssetPath } from '@stencil/core';
-  setAssetPath(`{window.location.origin}/`)
+  setAssetPath(`{window.location.origin}/`);
   ```
 
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.

--- a/versioned_docs/version-v4.9/components/api.md
+++ b/versioned_docs/version-v4.9/components/api.md
@@ -152,6 +152,15 @@ The following primitives can be imported from the `@stencil/core` package and us
   }
   ```
 
+- **setAssetPath()**: Sets the path for Stencil to resolve local assets. Refer to the [Assets](../guides/assets.md#setassetpath) page for usage info.
+
+  __Type:__ `(path: string) => string`<br />
+  __Example:__
+  ```ts
+  import { setAssetPath } from '@stencil/core'
+  setAssetPath(import.meta.url)
+  ```
+
 - **setMode()**: Sets the style mode of a component. Refer to the [Styling](./styling.md#style-modes) page for usage info.
 
   __Type:__ `(ref: HTMLElement) => string`<br />

--- a/versioned_docs/version-v4.9/guides/assets.md
+++ b/versioned_docs/version-v4.9/guides/assets.md
@@ -263,7 +263,7 @@ asset base path. This configuration depends on how your script is bundled, (or l
 
 :::note
 
-If your component library exports components compiled with [`dist-output-target`](custom-elements) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
+If your component library exports components compiled with [`dist-output-target`](/output-targets/custom-elements.md) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
 
 :::
 

--- a/versioned_docs/version-v4.9/guides/assets.md
+++ b/versioned_docs/version-v4.9/guides/assets.md
@@ -232,7 +232,7 @@ getAssetPath('/assets/my-image.png');
 
 ### setAssetPath
 
-`setAssetPath` is an API provided by Stencil to manually set the asset base path where assets can be found.
+`setAssetPath` is an API provided by Stencil's runtime to manually set the asset base path where assets can be found. If you are using `getAssetPath` to compose the path for your component assets, `setAssetPath` allows you or the consumer of the component to change that path.
 
 ```ts
 /**
@@ -243,18 +243,43 @@ getAssetPath('/assets/my-image.png');
 export declare function setAssetPath(path: string): string;
 ```
 
-Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime.
-As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
-when using a component.
+Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime. As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects when using a component.
 
-If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use:
+Make sure as component author to export this function as part of your module in order to give the consumer of your component the chance to change it, e.g. in your package entry file export the function via:
 
 ```ts
-import { setAssetPath } from '@stencil/core';
-setAssetPath(`${window.location.origin}/`);
+export { setAssetPath } from '@stencil/core';
 ```
 
-Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
-when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the
-asset base path. 
-This configuration depends on how your script is bundled, (or lack of bundling), and where your assets can be loaded from.
+Now your users can import it directly from your component library, e.g.:
+
+```ts
+import { setAssetPath } from 'my-component-library';
+setAssetPath(`${window.location.protocol}//assets.${window.location.host}/`);
+```
+
+Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript) when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the
+asset base path. This configuration depends on how your script is bundled, (or lack of bundling), and where your assets can be loaded from.
+
+:::note
+
+If your component library exports components compiled with [`dist-output-target`](custom-elements) and `externalRuntime` set to `true`, then `setAssetPath` has to be imported from `@stencil/core` directly.
+
+:::
+
+In case you import a component directly via script tag, this would look like:
+
+```html
+<html>
+  <head>
+    <script src="https://cdn.jsdelivr.net/npm/my-component-library/dist/my-component-library.js"></script>
+    <script type="module">
+      import { setAssetPath } from 'https://cdn.jsdelivr.net/npm/my-component-library/dist/my-component-library.js';
+      setAssetPath(`${window.location.origin}/`);
+    </script>
+  </head>
+  <body>
+    <ion-toggle></ion-toggle>
+  </body>
+</html>
+```

--- a/versioned_docs/version-v4.9/guides/assets.md
+++ b/versioned_docs/version-v4.9/guides/assets.md
@@ -247,7 +247,7 @@ Calling this API will set the asset base path for all Stencil components attache
 
 Make sure as component author to export this function as part of your module in order to also make it accessible to the consumer of your component, e.g. in your package entry file export the function via:
 
-```ts
+```ts title="/src/index.ts"
 export { setAssetPath } from '@stencil/core';
 ```
 

--- a/versioned_docs/version-v4.9/guides/assets.md
+++ b/versioned_docs/version-v4.9/guides/assets.md
@@ -211,6 +211,8 @@ declare function getAssetPath(path: string): string;
 ```
 
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments, when an asset base path of `/build/` has been set.
+
+```ts
 import { getAssetPath } from '@stencil/core';
 
 // with an asset base path of "/build/":

--- a/versioned_docs/version-v4.9/guides/assets.md
+++ b/versioned_docs/version-v4.9/guides/assets.md
@@ -62,6 +62,8 @@ When using `getAssetPath`, the assets in the directory structure above are resol
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments.
 The return value is a path that Stencil has built to retrieve the asset on the filesystem.
 ```ts
+import { getAssetPath } from '@stencil/core';
+
 // with an asset base path of "/build/":
 
 // '/build/assets/logo.png'
@@ -209,7 +211,8 @@ declare function getAssetPath(path: string): string;
 ```
 
 The code sample below demonstrates the return value of `getAssetPath` for different `path` arguments, when an asset base path of `/build/` has been set.
-```ts
+import { getAssetPath } from '@stencil/core';
+
 // with an asset base path of "/build/":
 // "/build/"
 getAssetPath('');

--- a/versioned_docs/version-v4.9/guides/assets.md
+++ b/versioned_docs/version-v4.9/guides/assets.md
@@ -242,7 +242,7 @@ Calling this API will set the asset base path for all Stencil components attache
 As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
 when using a component.
 
-If the file calling `setAssetPath` is a module, it's recommended to use `import.meta.url`.
+If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use: `setAssetPath('${window.location.origin}/');`
 
 Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
 when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the

--- a/versioned_docs/version-v4.9/guides/assets.md
+++ b/versioned_docs/version-v4.9/guides/assets.md
@@ -245,7 +245,7 @@ export declare function setAssetPath(path: string): string;
 
 Calling this API will set the asset base path for all Stencil components attached to a Stencil runtime. As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects when using a component.
 
-Make sure as component author to export this function as part of your module in order to give the consumer of your component the chance to change it, e.g. in your package entry file export the function via:
+Make sure as component author to export this function as part of your module in order to also make it accessible to the consumer of your component, e.g. in your package entry file export the function via:
 
 ```ts
 export { setAssetPath } from '@stencil/core';

--- a/versioned_docs/version-v4.9/guides/assets.md
+++ b/versioned_docs/version-v4.9/guides/assets.md
@@ -242,7 +242,12 @@ Calling this API will set the asset base path for all Stencil components attache
 As a result, calling `setAssetPath` should not be done from within a component in order to prevent unwanted side effects
 when using a component.
 
-If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use: `setAssetPath('${window.location.origin}/');`
+If the file calling `setAssetPath` is a module and your compiler is able to resolve the file location at build time, based on where the application is being deployed, you can use `import.meta.url`. In most cases however we recommend to use:
+
+```ts
+import { setAssetPath } from '@stencil/core';
+setAssetPath(`${window.location.origin}/`);
+```
 
 Alternatively, one may use [`document.currentScript.src`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
 when working in the browser and not using modules or environment variables (e.g. `document.env.ASSET_PATH`) to set the


### PR DESCRIPTION
We are missing the `setAssetPath` function in the component docs. This patch adds this missing primitive.