### PR TITLE
docs(playwright): add note for Stencil config naming limitation

### DIFF
--- a/docs/testing/playwright/01-overview.md
+++ b/docs/testing/playwright/01-overview.md
@@ -46,8 +46,12 @@ To install the Stencil Playwright adapter in an existing Stencil project, follow
    });
    ```
 
-   The `createConfig()` is a utility that will create a default Playwright configuration based on your project's Stencil config. Read
+   The `createConfig()` function is a utility that will create a default Playwright configuration based on your project's Stencil config. Read
    more about how to use this utility in the [API docs](./03-api.md#createconfig-function).
+
+   :::note
+   For `createConfig()` to work correctly, your Stencil config must be named either `stencil.config.ts` or `stencil.config.js`.
+   :::
 
 1. update your project's `tsconfig.json` to add the `ESNext.Disposable` option to the `lib` array:
 

--- a/versioned_docs/version-v4.13.0/testing/playwright/01-overview.md
+++ b/versioned_docs/version-v4.13.0/testing/playwright/01-overview.md
@@ -46,8 +46,12 @@ To install the Stencil Playwright adapter in an existing Stencil project, follow
    });
    ```
 
-   The `createConfig()` is a utility that will create a default Playwright configuration based on your project's Stencil config. Read
+   The `createConfig()` function is a utility that will create a default Playwright configuration based on your project's Stencil config. Read
    more about how to use this utility in the [API docs](./03-api.md#createconfig-function).
+
+   :::note
+   For `createConfig()` to work correctly, your Stencil config must be named either `stencil.config.ts` or `stencil.config.js`.
+   :::
 
 1. update your project's `tsconfig.json` to add the `ESNext.Disposable` option to the `lib` array:
 

--- a/versioned_docs/version-v4.14/testing/playwright/01-overview.md
+++ b/versioned_docs/version-v4.14/testing/playwright/01-overview.md
@@ -46,8 +46,12 @@ To install the Stencil Playwright adapter in an existing Stencil project, follow
    });
    ```
 
-   The `createConfig()` is a utility that will create a default Playwright configuration based on your project's Stencil config. Read
+   The `createConfig()` function is a utility that will create a default Playwright configuration based on your project's Stencil config. Read
    more about how to use this utility in the [API docs](./03-api.md#createconfig-function).
+
+   :::note
+   For `createConfig()` to work correctly, your Stencil config must be named either `stencil.config.ts` or `stencil.config.js`.
+   :::
 
 1. update your project's `tsconfig.json` to add the `ESNext.Disposable` option to the `lib` array:
 

--- a/versioned_docs/version-v4.15/testing/playwright/01-overview.md
+++ b/versioned_docs/version-v4.15/testing/playwright/01-overview.md
@@ -46,8 +46,12 @@ To install the Stencil Playwright adapter in an existing Stencil project, follow
    });
    ```
 
-   The `createConfig()` is a utility that will create a default Playwright configuration based on your project's Stencil config. Read
+   The `createConfig()` function is a utility that will create a default Playwright configuration based on your project's Stencil config. Read
    more about how to use this utility in the [API docs](./03-api.md#createconfig-function).
+
+   :::note
+   For `createConfig()` to work correctly, your Stencil config must be named either `stencil.config.ts` or `stencil.config.js`.
+   :::
 
 1. update your project's `tsconfig.json` to add the `ESNext.Disposable` option to the `lib` array:
 

--- a/versioned_docs/version-v4.16/testing/playwright/01-overview.md
+++ b/versioned_docs/version-v4.16/testing/playwright/01-overview.md
@@ -46,8 +46,12 @@ To install the Stencil Playwright adapter in an existing Stencil project, follow
    });
    ```
 
-   The `createConfig()` is a utility that will create a default Playwright configuration based on your project's Stencil config. Read
+   The `createConfig()` function is a utility that will create a default Playwright configuration based on your project's Stencil config. Read
    more about how to use this utility in the [API docs](./03-api.md#createconfig-function).
+
+   :::note
+   For `createConfig()` to work correctly, your Stencil config must be named either `stencil.config.ts` or `stencil.config.js`.
+   :::
 
 1. update your project's `tsconfig.json` to add the `ESNext.Disposable` option to the `lib` array:
 

--- a/versioned_docs/version-v4.17/testing/playwright/01-overview.md
+++ b/versioned_docs/version-v4.17/testing/playwright/01-overview.md
@@ -46,8 +46,12 @@ To install the Stencil Playwright adapter in an existing Stencil project, follow
    });
    ```
 
-   The `createConfig()` is a utility that will create a default Playwright configuration based on your project's Stencil config. Read
+   The `createConfig()` function is a utility that will create a default Playwright configuration based on your project's Stencil config. Read
    more about how to use this utility in the [API docs](./03-api.md#createconfig-function).
+
+   :::note
+   For `createConfig()` to work correctly, your Stencil config must be named either `stencil.config.ts` or `stencil.config.js`.
+   :::
 
 1. update your project's `tsconfig.json` to add the `ESNext.Disposable` option to the `lib` array:
 


### PR DESCRIPTION
Adds a note admonition to the Playwright adapter docs for the naming limitation around the Stencil config. This note already exists in the adapter readme, so just porting it over here as well.