### PR TITLE
docs(json): add mode to docs-json docs

### DIFF
--- a/docs/documentation-generation/docs-json.md
+++ b/docs/documentation-generation/docs-json.md
@@ -124,7 +124,7 @@ If the style sheet is configured to be used with [a specific mode](../components
 the CSS property will be provided as well:
 
 ```diff title="Example docs-json Output with Mode"
-"styles": [
+[
   {
     "name": "--background",
     "annotation": "prop",

--- a/docs/documentation-generation/docs-json.md
+++ b/docs/documentation-generation/docs-json.md
@@ -100,7 +100,7 @@ CSS file like the following:
 
 Then you'd get the following in the JSON output:
 
-```json
+```json title="Example docs-json Output"
 "styles": [
   {
     "name": "--background",
@@ -116,6 +116,32 @@ Then you'd get the following in the JSON output:
     "name": "--background-focused",
     "annotation": "prop",
     "docs": "Background of the button when focused"
+  }
+]
+```
+
+If the style sheet is configured to be used with [a specific mode](../components/styling.md), the mode associated with
+the CSS property will be provided as well:
+
+```diff title="Example docs-json Output with Mode"
+"styles": [
+  {
+    "name": "--background",
+    "annotation": "prop",
+    "docs": "Background of the button"
++   "mode": "ios",    
+  },
+  {
+    "name": "--background-activated",
+    "annotation": "prop",
+    "docs": "Background of the button when activated"
++   "mode": "ios",    
+  },
+  {
+    "name": "--background-focused",
+    "annotation": "prop",
+    "docs": "Background of the button when focused"
++   "mode": "ios",    
   }
 ]
 ```

--- a/docs/documentation-generation/docs-json.md
+++ b/docs/documentation-generation/docs-json.md
@@ -101,7 +101,7 @@ CSS file like the following:
 Then you'd get the following in the JSON output:
 
 ```json title="Example docs-json Output"
-"styles": [
+[
   {
     "name": "--background",
     "annotation": "prop",


### PR DESCRIPTION
add an example of the output for modes associated with a stylesheet.

associated with https://github.com/ionic-team/stencil/pull/5718

STENCIL-1269