### PR TITLE
fix(docs): minor improvement to import comment

### DIFF
--- a/versioned_docs/version-v4.0/output-targets/dist.md
+++ b/versioned_docs/version-v4.0/output-targets/dist.md
@@ -129,13 +129,13 @@ Each output target's form of bundling and distribution has its own pros and cons
 ### Importing the `dist` library using a bundler
 
 - Run `npm install my-name --save`
-- Add an `import` within the root component: `import my-component`;
+- Add an `import` within the root component: e.g. `import { MyComponent } from "my-component";`
 - Stencil will automatically setup the lazy-loading capabilities for the Stencil library.
 - Then you can use the element anywhere in your template, JSX, HTML etc.
 
 ### Importing the `dist` library into another Stencil app
 
 - Run `npm install my-name --save`
-- Add an `import` within the root component: `import my-component`;
+- Add an `import` within the root component: e.g. `import { MyComponent } from "my-component";`
 - Stencil will automatically setup the lazy-loading capabilities for the Stencil library.
 - Then you can use the element anywhere in your template, JSX, HTML etc.

--- a/versioned_docs/version-v4.1/output-targets/dist.md
+++ b/versioned_docs/version-v4.1/output-targets/dist.md
@@ -129,13 +129,13 @@ Each output target's form of bundling and distribution has its own pros and cons
 ### Importing the `dist` library using a bundler
 
 - Run `npm install my-name --save`
-- Add an `import` within the root component: `import my-component`;
+- Add an `import` within the root component: e.g. `import { MyComponent } from "my-component";`
 - Stencil will automatically setup the lazy-loading capabilities for the Stencil library.
 - Then you can use the element anywhere in your template, JSX, HTML etc.
 
 ### Importing the `dist` library into another Stencil app
 
 - Run `npm install my-name --save`
-- Add an `import` within the root component: `import my-component`;
+- Add an `import` within the root component: e.g. `import { MyComponent } from "my-component";`
 - Stencil will automatically setup the lazy-loading capabilities for the Stencil library.
 - Then you can use the element anywhere in your template, JSX, HTML etc.

--- a/versioned_docs/version-v4.10/output-targets/dist.md
+++ b/versioned_docs/version-v4.10/output-targets/dist.md
@@ -129,13 +129,13 @@ Each output target's form of bundling and distribution has its own pros and cons
 ### Importing the `dist` library using a bundler
 
 - Run `npm install my-name --save`
-- Add an `import` within the root component: `import my-component`;
+- Add an `import` within the root component: e.g. `import { MyComponent } from "my-component";`
 - Stencil will automatically setup the lazy-loading capabilities for the Stencil library.
 - Then you can use the element anywhere in your template, JSX, HTML etc.
 
 ### Importing the `dist` library into another Stencil app
 
 - Run `npm install my-name --save`
-- Add an `import` within the root component: `import my-component`;
+- Add an `import` within the root component: e.g. `import { MyComponent } from "my-component";`
 - Stencil will automatically setup the lazy-loading capabilities for the Stencil library.
 - Then you can use the element anywhere in your template, JSX, HTML etc.

--- a/versioned_docs/version-v4.11/output-targets/dist.md
+++ b/versioned_docs/version-v4.11/output-targets/dist.md
@@ -129,13 +129,13 @@ Each output target's form of bundling and distribution has its own pros and cons
 ### Importing the `dist` library using a bundler
 
 - Run `npm install my-name --save`
-- Add an `import` within the root component: `import my-component`;
+- Add an `import` within the root component: e.g. `import { MyComponent } from "my-component";`
 - Stencil will automatically setup the lazy-loading capabilities for the Stencil library.
 - Then you can use the element anywhere in your template, JSX, HTML etc.
 
 ### Importing the `dist` library into another Stencil app
 
 - Run `npm install my-name --save`
-- Add an `import` within the root component: `import my-component`;
+- Add an `import` within the root component: e.g. `import { MyComponent } from "my-component";`
 - Stencil will automatically setup the lazy-loading capabilities for the Stencil library.
 - Then you can use the element anywhere in your template, JSX, HTML etc.

--- a/versioned_docs/version-v4.12/output-targets/dist.md
+++ b/versioned_docs/version-v4.12/output-targets/dist.md
@@ -129,13 +129,13 @@ Each output target's form of bundling and distribution has its own pros and cons
 ### Importing the `dist` library using a bundler
 
 - Run `npm install my-name --save`
-- Add an `import` within the root component: `import my-component`;
+- Add an `import` within the root component: e.g. `import { MyComponent } from "my-component";`
 - Stencil will automatically setup the lazy-loading capabilities for the Stencil library.
 - Then you can use the element anywhere in your template, JSX, HTML etc.
 
 ### Importing the `dist` library into another Stencil app
 
 - Run `npm install my-name --save`
-- Add an `import` within the root component: `import my-component`;
+- Add an `import` within the root component: e.g. `import { MyComponent } from "my-component";`
 - Stencil will automatically setup the lazy-loading capabilities for the Stencil library.
 - Then you can use the element anywhere in your template, JSX, HTML etc.

--- a/versioned_docs/version-v4.2/output-targets/dist.md
+++ b/versioned_docs/version-v4.2/output-targets/dist.md
@@ -129,13 +129,13 @@ Each output target's form of bundling and distribution has its own pros and cons
 ### Importing the `dist` library using a bundler
 
 - Run `npm install my-name --save`
-- Add an `import` within the root component: `import my-component`;
+- Add an `import` within the root component: e.g. `import { MyComponent } from "my-component";`
 - Stencil will automatically setup the lazy-loading capabilities for the Stencil library.
 - Then you can use the element anywhere in your template, JSX, HTML etc.
 
 ### Importing the `dist` library into another Stencil app
 
 - Run `npm install my-name --save`
-- Add an `import` within the root component: `import my-component`;
+- Add an `import` within the root component: e.g. `import { MyComponent } from "my-component";`
 - Stencil will automatically setup the lazy-loading capabilities for the Stencil library.
 - Then you can use the element anywhere in your template, JSX, HTML etc.

--- a/versioned_docs/version-v4.3/output-targets/dist.md
+++ b/versioned_docs/version-v4.3/output-targets/dist.md
@@ -129,13 +129,13 @@ Each output target's form of bundling and distribution has its own pros and cons
 ### Importing the `dist` library using a bundler
 
 - Run `npm install my-name --save`
-- Add an `import` within the root component: `import my-component`;
+- Add an `import` within the root component: e.g. `import { MyComponent } from "my-component";`
 - Stencil will automatically setup the lazy-loading capabilities for the Stencil library.
 - Then you can use the element anywhere in your template, JSX, HTML etc.
 
 ### Importing the `dist` library into another Stencil app
 
 - Run `npm install my-name --save`
-- Add an `import` within the root component: `import my-component`;
+- Add an `import` within the root component: e.g. `import { MyComponent } from "my-component";`
 - Stencil will automatically setup the lazy-loading capabilities for the Stencil library.
 - Then you can use the element anywhere in your template, JSX, HTML etc.

--- a/versioned_docs/version-v4.4/output-targets/dist.md
+++ b/versioned_docs/version-v4.4/output-targets/dist.md
@@ -129,13 +129,13 @@ Each output target's form of bundling and distribution has its own pros and cons
 ### Importing the `dist` library using a bundler
 
 - Run `npm install my-name --save`
-- Add an `import` within the root component: `import my-component`;
+- Add an `import` within the root component: e.g. `import { MyComponent } from "my-component";`
 - Stencil will automatically setup the lazy-loading capabilities for the Stencil library.
 - Then you can use the element anywhere in your template, JSX, HTML etc.
 
 ### Importing the `dist` library into another Stencil app
 
 - Run `npm install my-name --save`
-- Add an `import` within the root component: `import my-component`;
+- Add an `import` within the root component: e.g. `import { MyComponent } from "my-component";`
 - Stencil will automatically setup the lazy-loading capabilities for the Stencil library.
 - Then you can use the element anywhere in your template, JSX, HTML etc.

--- a/versioned_docs/version-v4.5/output-targets/dist.md
+++ b/versioned_docs/version-v4.5/output-targets/dist.md
@@ -129,13 +129,13 @@ Each output target's form of bundling and distribution has its own pros and cons
 ### Importing the `dist` library using a bundler
 
 - Run `npm install my-name --save`
-- Add an `import` within the root component: `import my-component`;
+- Add an `import` within the root component: e.g. `import { MyComponent } from "my-component";`
 - Stencil will automatically setup the lazy-loading capabilities for the Stencil library.
 - Then you can use the element anywhere in your template, JSX, HTML etc.
 
 ### Importing the `dist` library into another Stencil app
 
 - Run `npm install my-name --save`
-- Add an `import` within the root component: `import my-component`;
+- Add an `import` within the root component: e.g. `import { MyComponent } from "my-component";`
 - Stencil will automatically setup the lazy-loading capabilities for the Stencil library.
 - Then you can use the element anywhere in your template, JSX, HTML etc.

--- a/versioned_docs/version-v4.6/output-targets/dist.md
+++ b/versioned_docs/version-v4.6/output-targets/dist.md
@@ -129,13 +129,13 @@ Each output target's form of bundling and distribution has its own pros and cons
 ### Importing the `dist` library using a bundler
 
 - Run `npm install my-name --save`
-- Add an `import` within the root component: `import my-component`;
+- Add an `import` within the root component: e.g. `import { MyComponent } from "my-component";`
 - Stencil will automatically setup the lazy-loading capabilities for the Stencil library.
 - Then you can use the element anywhere in your template, JSX, HTML etc.
 
 ### Importing the `dist` library into another Stencil app
 
 - Run `npm install my-name --save`
-- Add an `import` within the root component: `import my-component`;
+- Add an `import` within the root component: e.g. `import { MyComponent } from "my-component";`
 - Stencil will automatically setup the lazy-loading capabilities for the Stencil library.
 - Then you can use the element anywhere in your template, JSX, HTML etc.

--- a/versioned_docs/version-v4.7/output-targets/dist.md
+++ b/versioned_docs/version-v4.7/output-targets/dist.md
@@ -129,13 +129,13 @@ Each output target's form of bundling and distribution has its own pros and cons
 ### Importing the `dist` library using a bundler
 
 - Run `npm install my-name --save`
-- Add an `import` within the root component: `import my-component`;
+- Add an `import` within the root component: e.g. `import { MyComponent } from "my-component";`
 - Stencil will automatically setup the lazy-loading capabilities for the Stencil library.
 - Then you can use the element anywhere in your template, JSX, HTML etc.
 
 ### Importing the `dist` library into another Stencil app
 
 - Run `npm install my-name --save`
-- Add an `import` within the root component: `import my-component`;
+- Add an `import` within the root component: e.g. `import { MyComponent } from "my-component";`
 - Stencil will automatically setup the lazy-loading capabilities for the Stencil library.
 - Then you can use the element anywhere in your template, JSX, HTML etc.

--- a/versioned_docs/version-v4.8/output-targets/dist.md
+++ b/versioned_docs/version-v4.8/output-targets/dist.md
@@ -129,13 +129,13 @@ Each output target's form of bundling and distribution has its own pros and cons
 ### Importing the `dist` library using a bundler
 
 - Run `npm install my-name --save`
-- Add an `import` within the root component: `import my-component`;
+- Add an `import` within the root component: e.g. `import { MyComponent } from "my-component";`
 - Stencil will automatically setup the lazy-loading capabilities for the Stencil library.
 - Then you can use the element anywhere in your template, JSX, HTML etc.
 
 ### Importing the `dist` library into another Stencil app
 
 - Run `npm install my-name --save`
-- Add an `import` within the root component: `import my-component`;
+- Add an `import` within the root component: e.g. `import { MyComponent } from "my-component";`
 - Stencil will automatically setup the lazy-loading capabilities for the Stencil library.
 - Then you can use the element anywhere in your template, JSX, HTML etc.

--- a/versioned_docs/version-v4.9/output-targets/dist.md
+++ b/versioned_docs/version-v4.9/output-targets/dist.md
@@ -129,13 +129,13 @@ Each output target's form of bundling and distribution has its own pros and cons
 ### Importing the `dist` library using a bundler
 
 - Run `npm install my-name --save`
-- Add an `import` within the root component: `import my-component`;
+- Add an `import` within the root component: e.g. `import { MyComponent } from "my-component";`
 - Stencil will automatically setup the lazy-loading capabilities for the Stencil library.
 - Then you can use the element anywhere in your template, JSX, HTML etc.
 
 ### Importing the `dist` library into another Stencil app
 
 - Run `npm install my-name --save`
-- Add an `import` within the root component: `import my-component`;
+- Add an `import` within the root component: e.g. `import { MyComponent } from "my-component";`
 - Stencil will automatically setup the lazy-loading capabilities for the Stencil library.
 - Then you can use the element anywhere in your template, JSX, HTML etc.


### PR DESCRIPTION
We use this import example in one of the comments in earlier Stencil versions, this patch improves that comment with a more concrete example on how to import.

This takes the proposal from #1067 and applies it on all documentation versions.