### PR TITLE
doc(components/properties.md): update erroneous closing tags on components

### DIFF
--- a/docs/components/properties.md
+++ b/docs/components/properties.md
@@ -778,7 +778,7 @@ This component has **3 properties**, but the compiler will create **only 2 attri
 `thing-to-do`.
 
 ```html
-<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></my-cmp>
+<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></todo-list-item>
 ```
 
 Notice that the `httpService` type is not a primitive (e.g. not a `number`, `boolean`, or `string`). Since DOM
@@ -810,7 +810,7 @@ By using this option, we are being explicit about which properties have an assoc
 when using the component in HTML.
 
 ```html
-<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></my-cmp>
+<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></todo-list-item>
 ```
 
 ### Prop Mutability (`mutable`)

--- a/versioned_docs/version-v2/components/properties.md
+++ b/versioned_docs/version-v2/components/properties.md
@@ -714,7 +714,7 @@ This component has **3 properties**, but the compiler will create **only 2 attri
 `thing-to-do`.
 
 ```html
-<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></my-cmp>
+<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></todo-list-item>
 ```
 
 Notice that the `httpService` type is not a primitive (e.g. not a `number`, `boolean`, or `string`). Since DOM
@@ -746,7 +746,7 @@ By using this option, we are being explicit about which properties have an assoc
 when using the component in HTML.
 
 ```html
-<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" http-service="{}"></my-cmp>
+<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" http-service="{}"></todo-list-item>
 ```
 
 ### Prop Mutability (`mutable`)

--- a/versioned_docs/version-v3/components/properties.md
+++ b/versioned_docs/version-v3/components/properties.md
@@ -775,7 +775,7 @@ This component has **3 properties**, but the compiler will create **only 2 attri
 `thing-to-do`.
 
 ```html
-<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></my-cmp>
+<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></todo-list-item>
 ```
 
 Notice that the `httpService` type is not a primitive (e.g. not a `number`, `boolean`, or `string`). Since DOM
@@ -807,7 +807,7 @@ By using this option, we are being explicit about which properties have an assoc
 when using the component in HTML.
 
 ```html
-<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></my-cmp>
+<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></todo-list-item>
 ```
 
 ### Prop Mutability (`mutable`)

--- a/versioned_docs/version-v4.0/components/properties.md
+++ b/versioned_docs/version-v4.0/components/properties.md
@@ -714,7 +714,7 @@ This component has **3 properties**, but the compiler will create **only 2 attri
 `thing-to-do`.
 
 ```html
-<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></my-cmp>
+<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></todo-list-item>
 ```
 
 Notice that the `httpService` type is not a primitive (e.g. not a `number`, `boolean`, or `string`). Since DOM
@@ -746,7 +746,7 @@ By using this option, we are being explicit about which properties have an assoc
 when using the component in HTML.
 
 ```html
-<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></my-cmp>
+<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></todo-list-item>
 ```
 
 ### Prop Mutability (`mutable`)

--- a/versioned_docs/version-v4.1/components/properties.md
+++ b/versioned_docs/version-v4.1/components/properties.md
@@ -714,7 +714,7 @@ This component has **3 properties**, but the compiler will create **only 2 attri
 `thing-to-do`.
 
 ```html
-<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></my-cmp>
+<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></todo-list-item>
 ```
 
 Notice that the `httpService` type is not a primitive (e.g. not a `number`, `boolean`, or `string`). Since DOM
@@ -746,7 +746,7 @@ By using this option, we are being explicit about which properties have an assoc
 when using the component in HTML.
 
 ```html
-<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></my-cmp>
+<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></todo-list-item>
 ```
 
 ### Prop Mutability (`mutable`)

--- a/versioned_docs/version-v4.10/components/properties.md
+++ b/versioned_docs/version-v4.10/components/properties.md
@@ -714,7 +714,7 @@ This component has **3 properties**, but the compiler will create **only 2 attri
 `thing-to-do`.
 
 ```html
-<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></my-cmp>
+<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></todo-list-item>
 ```
 
 Notice that the `httpService` type is not a primitive (e.g. not a `number`, `boolean`, or `string`). Since DOM
@@ -746,7 +746,7 @@ By using this option, we are being explicit about which properties have an assoc
 when using the component in HTML.
 
 ```html
-<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></my-cmp>
+<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></todo-list-item>
 ```
 
 ### Prop Mutability (`mutable`)

--- a/versioned_docs/version-v4.11/components/properties.md
+++ b/versioned_docs/version-v4.11/components/properties.md
@@ -714,7 +714,7 @@ This component has **3 properties**, but the compiler will create **only 2 attri
 `thing-to-do`.
 
 ```html
-<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></my-cmp>
+<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></todo-list-item>
 ```
 
 Notice that the `httpService` type is not a primitive (e.g. not a `number`, `boolean`, or `string`). Since DOM
@@ -746,7 +746,7 @@ By using this option, we are being explicit about which properties have an assoc
 when using the component in HTML.
 
 ```html
-<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></my-cmp>
+<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></todo-list-item>
 ```
 
 ### Prop Mutability (`mutable`)

--- a/versioned_docs/version-v4.12/components/properties.md
+++ b/versioned_docs/version-v4.12/components/properties.md
@@ -714,7 +714,7 @@ This component has **3 properties**, but the compiler will create **only 2 attri
 `thing-to-do`.
 
 ```html
-<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></my-cmp>
+<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></todo-list-item>
 ```
 
 Notice that the `httpService` type is not a primitive (e.g. not a `number`, `boolean`, or `string`). Since DOM
@@ -746,7 +746,7 @@ By using this option, we are being explicit about which properties have an assoc
 when using the component in HTML.
 
 ```html
-<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></my-cmp>
+<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></todo-list-item>
 ```
 
 ### Prop Mutability (`mutable`)

--- a/versioned_docs/version-v4.13.0/components/properties.md
+++ b/versioned_docs/version-v4.13.0/components/properties.md
@@ -778,7 +778,7 @@ This component has **3 properties**, but the compiler will create **only 2 attri
 `thing-to-do`.
 
 ```html
-<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></my-cmp>
+<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></todo-list-item>
 ```
 
 Notice that the `httpService` type is not a primitive (e.g. not a `number`, `boolean`, or `string`). Since DOM
@@ -810,7 +810,7 @@ By using this option, we are being explicit about which properties have an assoc
 when using the component in HTML.
 
 ```html
-<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></my-cmp>
+<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></todo-list-item>
 ```
 
 ### Prop Mutability (`mutable`)

--- a/versioned_docs/version-v4.14/components/properties.md
+++ b/versioned_docs/version-v4.14/components/properties.md
@@ -778,7 +778,7 @@ This component has **3 properties**, but the compiler will create **only 2 attri
 `thing-to-do`.
 
 ```html
-<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></my-cmp>
+<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></todo-list-item>
 ```
 
 Notice that the `httpService` type is not a primitive (e.g. not a `number`, `boolean`, or `string`). Since DOM
@@ -810,7 +810,7 @@ By using this option, we are being explicit about which properties have an assoc
 when using the component in HTML.
 
 ```html
-<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></my-cmp>
+<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></todo-list-item>
 ```
 
 ### Prop Mutability (`mutable`)

--- a/versioned_docs/version-v4.15/components/properties.md
+++ b/versioned_docs/version-v4.15/components/properties.md
@@ -778,7 +778,7 @@ This component has **3 properties**, but the compiler will create **only 2 attri
 `thing-to-do`.
 
 ```html
-<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></my-cmp>
+<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></todo-list-item>
 ```
 
 Notice that the `httpService` type is not a primitive (e.g. not a `number`, `boolean`, or `string`). Since DOM
@@ -810,7 +810,7 @@ By using this option, we are being explicit about which properties have an assoc
 when using the component in HTML.
 
 ```html
-<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></my-cmp>
+<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></todo-list-item>
 ```
 
 ### Prop Mutability (`mutable`)

--- a/versioned_docs/version-v4.16/components/properties.md
+++ b/versioned_docs/version-v4.16/components/properties.md
@@ -778,7 +778,7 @@ This component has **3 properties**, but the compiler will create **only 2 attri
 `thing-to-do`.
 
 ```html
-<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></my-cmp>
+<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></todo-list-item>
 ```
 
 Notice that the `httpService` type is not a primitive (e.g. not a `number`, `boolean`, or `string`). Since DOM
@@ -810,7 +810,7 @@ By using this option, we are being explicit about which properties have an assoc
 when using the component in HTML.
 
 ```html
-<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></my-cmp>
+<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></todo-list-item>
 ```
 
 ### Prop Mutability (`mutable`)

--- a/versioned_docs/version-v4.17/components/properties.md
+++ b/versioned_docs/version-v4.17/components/properties.md
@@ -778,7 +778,7 @@ This component has **3 properties**, but the compiler will create **only 2 attri
 `thing-to-do`.
 
 ```html
-<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></my-cmp>
+<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></todo-list-item>
 ```
 
 Notice that the `httpService` type is not a primitive (e.g. not a `number`, `boolean`, or `string`). Since DOM
@@ -810,7 +810,7 @@ By using this option, we are being explicit about which properties have an assoc
 when using the component in HTML.
 
 ```html
-<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></my-cmp>
+<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></todo-list-item>
 ```
 
 ### Prop Mutability (`mutable`)

--- a/versioned_docs/version-v4.18/components/properties.md
+++ b/versioned_docs/version-v4.18/components/properties.md
@@ -778,7 +778,7 @@ This component has **3 properties**, but the compiler will create **only 2 attri
 `thing-to-do`.
 
 ```html
-<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></my-cmp>
+<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></todo-list-item>
 ```
 
 Notice that the `httpService` type is not a primitive (e.g. not a `number`, `boolean`, or `string`). Since DOM
@@ -810,7 +810,7 @@ By using this option, we are being explicit about which properties have an assoc
 when using the component in HTML.
 
 ```html
-<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></my-cmp>
+<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></todo-list-item>
 ```
 
 ### Prop Mutability (`mutable`)

--- a/versioned_docs/version-v4.19/components/properties.md
+++ b/versioned_docs/version-v4.19/components/properties.md
@@ -778,7 +778,7 @@ This component has **3 properties**, but the compiler will create **only 2 attri
 `thing-to-do`.
 
 ```html
-<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></my-cmp>
+<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></todo-list-item>
 ```
 
 Notice that the `httpService` type is not a primitive (e.g. not a `number`, `boolean`, or `string`). Since DOM
@@ -810,7 +810,7 @@ By using this option, we are being explicit about which properties have an assoc
 when using the component in HTML.
 
 ```html
-<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></my-cmp>
+<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></todo-list-item>
 ```
 
 ### Prop Mutability (`mutable`)

--- a/versioned_docs/version-v4.2/components/properties.md
+++ b/versioned_docs/version-v4.2/components/properties.md
@@ -714,7 +714,7 @@ This component has **3 properties**, but the compiler will create **only 2 attri
 `thing-to-do`.
 
 ```html
-<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></my-cmp>
+<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></todo-list-item>
 ```
 
 Notice that the `httpService` type is not a primitive (e.g. not a `number`, `boolean`, or `string`). Since DOM
@@ -746,7 +746,7 @@ By using this option, we are being explicit about which properties have an assoc
 when using the component in HTML.
 
 ```html
-<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></my-cmp>
+<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></todo-list-item>
 ```
 
 ### Prop Mutability (`mutable`)

--- a/versioned_docs/version-v4.20/components/properties.md
+++ b/versioned_docs/version-v4.20/components/properties.md
@@ -778,7 +778,7 @@ This component has **3 properties**, but the compiler will create **only 2 attri
 `thing-to-do`.
 
 ```html
-<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></my-cmp>
+<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></todo-list-item>
 ```
 
 Notice that the `httpService` type is not a primitive (e.g. not a `number`, `boolean`, or `string`). Since DOM
@@ -810,7 +810,7 @@ By using this option, we are being explicit about which properties have an assoc
 when using the component in HTML.
 
 ```html
-<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></my-cmp>
+<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></todo-list-item>
 ```
 
 ### Prop Mutability (`mutable`)

--- a/versioned_docs/version-v4.3/components/properties.md
+++ b/versioned_docs/version-v4.3/components/properties.md
@@ -714,7 +714,7 @@ This component has **3 properties**, but the compiler will create **only 2 attri
 `thing-to-do`.
 
 ```html
-<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></my-cmp>
+<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></todo-list-item>
 ```
 
 Notice that the `httpService` type is not a primitive (e.g. not a `number`, `boolean`, or `string`). Since DOM
@@ -746,7 +746,7 @@ By using this option, we are being explicit about which properties have an assoc
 when using the component in HTML.
 
 ```html
-<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></my-cmp>
+<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></todo-list-item>
 ```
 
 ### Prop Mutability (`mutable`)

--- a/versioned_docs/version-v4.4/components/properties.md
+++ b/versioned_docs/version-v4.4/components/properties.md
@@ -714,7 +714,7 @@ This component has **3 properties**, but the compiler will create **only 2 attri
 `thing-to-do`.
 
 ```html
-<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></my-cmp>
+<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></todo-list-item>
 ```
 
 Notice that the `httpService` type is not a primitive (e.g. not a `number`, `boolean`, or `string`). Since DOM
@@ -746,7 +746,7 @@ By using this option, we are being explicit about which properties have an assoc
 when using the component in HTML.
 
 ```html
-<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></my-cmp>
+<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></todo-list-item>
 ```
 
 ### Prop Mutability (`mutable`)

--- a/versioned_docs/version-v4.5/components/properties.md
+++ b/versioned_docs/version-v4.5/components/properties.md
@@ -714,7 +714,7 @@ This component has **3 properties**, but the compiler will create **only 2 attri
 `thing-to-do`.
 
 ```html
-<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></my-cmp>
+<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></todo-list-item>
 ```
 
 Notice that the `httpService` type is not a primitive (e.g. not a `number`, `boolean`, or `string`). Since DOM
@@ -746,7 +746,7 @@ By using this option, we are being explicit about which properties have an assoc
 when using the component in HTML.
 
 ```html
-<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></my-cmp>
+<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></todo-list-item>
 ```
 
 ### Prop Mutability (`mutable`)

--- a/versioned_docs/version-v4.6/components/properties.md
+++ b/versioned_docs/version-v4.6/components/properties.md
@@ -714,7 +714,7 @@ This component has **3 properties**, but the compiler will create **only 2 attri
 `thing-to-do`.
 
 ```html
-<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></my-cmp>
+<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></todo-list-item>
 ```
 
 Notice that the `httpService` type is not a primitive (e.g. not a `number`, `boolean`, or `string`). Since DOM
@@ -746,7 +746,7 @@ By using this option, we are being explicit about which properties have an assoc
 when using the component in HTML.
 
 ```html
-<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></my-cmp>
+<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></todo-list-item>
 ```
 
 ### Prop Mutability (`mutable`)

--- a/versioned_docs/version-v4.7/components/properties.md
+++ b/versioned_docs/version-v4.7/components/properties.md
@@ -714,7 +714,7 @@ This component has **3 properties**, but the compiler will create **only 2 attri
 `thing-to-do`.
 
 ```html
-<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></my-cmp>
+<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></todo-list-item>
 ```
 
 Notice that the `httpService` type is not a primitive (e.g. not a `number`, `boolean`, or `string`). Since DOM
@@ -746,7 +746,7 @@ By using this option, we are being explicit about which properties have an assoc
 when using the component in HTML.
 
 ```html
-<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></my-cmp>
+<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></todo-list-item>
 ```
 
 ### Prop Mutability (`mutable`)

--- a/versioned_docs/version-v4.8/components/properties.md
+++ b/versioned_docs/version-v4.8/components/properties.md
@@ -714,7 +714,7 @@ This component has **3 properties**, but the compiler will create **only 2 attri
 `thing-to-do`.
 
 ```html
-<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></my-cmp>
+<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></todo-list-item>
 ```
 
 Notice that the `httpService` type is not a primitive (e.g. not a `number`, `boolean`, or `string`). Since DOM
@@ -746,7 +746,7 @@ By using this option, we are being explicit about which properties have an assoc
 when using the component in HTML.
 
 ```html
-<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></my-cmp>
+<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></todo-list-item>
 ```
 
 ### Prop Mutability (`mutable`)

--- a/versioned_docs/version-v4.9/components/properties.md
+++ b/versioned_docs/version-v4.9/components/properties.md
@@ -714,7 +714,7 @@ This component has **3 properties**, but the compiler will create **only 2 attri
 `thing-to-do`.
 
 ```html
-<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></my-cmp>
+<todo-list-item is-complete="false" thing-to-do="Read Attribute Naming Section of Stencil Docs"></todo-list-item>
 ```
 
 Notice that the `httpService` type is not a primitive (e.g. not a `number`, `boolean`, or `string`). Since DOM
@@ -746,7 +746,7 @@ By using this option, we are being explicit about which properties have an assoc
 when using the component in HTML.
 
 ```html
-<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></my-cmp>
+<todo-list-item complete="false" thing="Read Attribute Naming Section of Stencil Docs" my-service="{}"></todo-list-item>
 ```
 
 ### Prop Mutability (`mutable`)


### PR DESCRIPTION
# Update components properties.md file:

Some of the components had different closing tags to the opening tags specified by the component creation.

Linked to issue #1471 