### PR TITLE
docs(readme-output): add docs for readme diagram color configs

### DIFF
--- a/docs/documentation-generation/docs-readme.md
+++ b/docs/documentation-generation/docs-readme.md
@@ -563,3 +563,28 @@ When strict mode is enabled, the following items are checked:
 2. `@Method()` usages must be documented, unless the method is marked as `@deprecated`
 3. `@Event()` usages must be documented, unless the event is marked as `@deprecated`
 4. CSS Part usages must be documented
+
+### Diagram Colors
+
+**Optional**
+
+**Default: `{ text: '#333', background: '#f9f' }`**
+
+This option allows you to change the colors used when generating the dependency graph mermaid diagrams for components. Any hex color string is a valid
+value.
+
+```tsx title="stencil.config.ts"
+import { Config } from '@stencil/core';
+
+export const config: Config = {
+  outputTargets: [
+    {
+      type: 'docs-readme',
+      colors: {
+        text: '#fff',
+        background: '#000'
+      }
+    }
+  ]
+};
+```


### PR DESCRIPTION
Adds documentation to the `docs-readme` output target for customizing the mermaid diagram colors 

Associated Stencil PR: https://github.com/ionic-team/stencil/pull/5988