### PR TITLE
react: add docs for excludeServerSideRenderingFor option

### DIFF
--- a/docs/framework-integration/react.md
+++ b/docs/framework-integration/react.md
@@ -508,7 +508,7 @@ export const config: Config = {
 
 **Type: `string[]`**
 
-Allows user to exclude a list of components to be server side rendered by Next.js or other React
+Allows users to exclude a list of components from server side rendering by Next.js or other React
 frameworks. This may be useful if you would like to generally ignore some components from being
 rendered on the server or if you like roll out SSR support for your design system one component at
 a time.

--- a/docs/framework-integration/react.md
+++ b/docs/framework-integration/react.md
@@ -502,9 +502,16 @@ export const config: Config = {
 };
 ```
 
-:::note
-Next.js support is only available for applications that use the [Next.js App Router](https://nextjs.org/docs/app).
-:::
+### excludeServerSideRenderingFor
+
+**Optional**
+
+**Type: `string[]`**
+
+Allows user to exclude a list of components to be server side rendered by Next.js or other React
+frameworks. This may be useful if you would like to generally ignore some components from being
+rendered on the server or if you like roll out SSR support for your design system one component at
+a time.
 
 ## FAQ's
 


### PR DESCRIPTION
Companion PR for https://github.com/ionic-team/stencil-ds-output-targets/pull/540

I also removed the note saying that SSR support only works for Next.js App Router which is not true. The type of router shouldn't matter as long as the user uses Next.js v13 and above.