### PR TITLE
fix(versioning): remove timeline for major releases

### DIFF
--- a/docs/reference/versioning.md
+++ b/docs/reference/versioning.md
@@ -16,10 +16,9 @@ increment the <code>patch</code> version.
 
 ### Major Release
 
-A major release will be published when there is a breaking change introduced in the API. Major releases will occur
-roughly every **6 months** and may contain breaking changes. Release candidates will be published prior to a major
-release in order to get feedback before the final release. An outline of what is changing and why will be included with
-the release candidates.
+A major release will be published when there is a breaking change introduced in the API. Release candidates will
+be published prior to a major release in order to get feedback before the final release. An outline of what is
+changing and why will be included with the release candidates.
 
 ### Minor Release
 

--- a/versioned_docs/version-v2/reference/versioning.md
+++ b/versioned_docs/version-v2/reference/versioning.md
@@ -16,10 +16,9 @@ increment the <code>patch</code> version.
 
 ### Major Release
 
-A major release will be published when there is a breaking change introduced in the API. Major releases will occur
-roughly every **6 months** and may contain breaking changes. Release candidates will be published prior to a major
-release in order to get feedback before the final release. An outline of what is changing and why will be included with
-the release candidates.
+A major release will be published when there is a breaking change introduced in the API. Release candidates will
+be published prior to a major release in order to get feedback before the final release. An outline of what is
+changing and why will be included with the release candidates.
 
 ### Minor Release
 

--- a/versioned_docs/version-v3/reference/versioning.md
+++ b/versioned_docs/version-v3/reference/versioning.md
@@ -16,10 +16,9 @@ increment the <code>patch</code> version.
 
 ### Major Release
 
-A major release will be published when there is a breaking change introduced in the API. Major releases will occur
-roughly every **6 months** and may contain breaking changes. Release candidates will be published prior to a major
-release in order to get feedback before the final release. An outline of what is changing and why will be included with
-the release candidates.
+A major release will be published when there is a breaking change introduced in the API. Release candidates will
+be published prior to a major release in order to get feedback before the final release. An outline of what is
+changing and why will be included with the release candidates
 
 ### Minor Release
 

--- a/versioned_docs/version-v4.0/reference/versioning.md
+++ b/versioned_docs/version-v4.0/reference/versioning.md
@@ -16,10 +16,9 @@ increment the <code>patch</code> version.
 
 ### Major Release
 
-A major release will be published when there is a breaking change introduced in the API. Major releases will occur
-roughly every **6 months** and may contain breaking changes. Release candidates will be published prior to a major
-release in order to get feedback before the final release. An outline of what is changing and why will be included with
-the release candidates.
+A major release will be published when there is a breaking change introduced in the API. Release candidates will
+be published prior to a major release in order to get feedback before the final release. An outline of what is
+changing and why will be included with the release candidates
 
 ### Minor Release
 

--- a/versioned_docs/version-v4.1/reference/versioning.md
+++ b/versioned_docs/version-v4.1/reference/versioning.md
@@ -16,10 +16,9 @@ increment the <code>patch</code> version.
 
 ### Major Release
 
-A major release will be published when there is a breaking change introduced in the API. Major releases will occur
-roughly every **6 months** and may contain breaking changes. Release candidates will be published prior to a major
-release in order to get feedback before the final release. An outline of what is changing and why will be included with
-the release candidates.
+A major release will be published when there is a breaking change introduced in the API. Release candidates will
+be published prior to a major release in order to get feedback before the final release. An outline of what is
+changing and why will be included with the release candidates
 
 ### Minor Release
 

--- a/versioned_docs/version-v4.10/reference/versioning.md
+++ b/versioned_docs/version-v4.10/reference/versioning.md
@@ -16,10 +16,9 @@ increment the <code>patch</code> version.
 
 ### Major Release
 
-A major release will be published when there is a breaking change introduced in the API. Major releases will occur
-roughly every **6 months** and may contain breaking changes. Release candidates will be published prior to a major
-release in order to get feedback before the final release. An outline of what is changing and why will be included with
-the release candidates.
+A major release will be published when there is a breaking change introduced in the API. Release candidates will
+be published prior to a major release in order to get feedback before the final release. An outline of what is
+changing and why will be included with the release candidates
 
 ### Minor Release
 

--- a/versioned_docs/version-v4.11/reference/versioning.md
+++ b/versioned_docs/version-v4.11/reference/versioning.md
@@ -16,10 +16,9 @@ increment the <code>patch</code> version.
 
 ### Major Release
 
-A major release will be published when there is a breaking change introduced in the API. Major releases will occur
-roughly every **6 months** and may contain breaking changes. Release candidates will be published prior to a major
-release in order to get feedback before the final release. An outline of what is changing and why will be included with
-the release candidates.
+A major release will be published when there is a breaking change introduced in the API. Release candidates will
+be published prior to a major release in order to get feedback before the final release. An outline of what is
+changing and why will be included with the release candidates
 
 ### Minor Release
 

--- a/versioned_docs/version-v4.12/reference/versioning.md
+++ b/versioned_docs/version-v4.12/reference/versioning.md
@@ -16,10 +16,9 @@ increment the <code>patch</code> version.
 
 ### Major Release
 
-A major release will be published when there is a breaking change introduced in the API. Major releases will occur
-roughly every **6 months** and may contain breaking changes. Release candidates will be published prior to a major
-release in order to get feedback before the final release. An outline of what is changing and why will be included with
-the release candidates.
+A major release will be published when there is a breaking change introduced in the API. Release candidates will
+be published prior to a major release in order to get feedback before the final release. An outline of what is
+changing and why will be included with the release candidates
 
 ### Minor Release
 

--- a/versioned_docs/version-v4.13.0/reference/versioning.md
+++ b/versioned_docs/version-v4.13.0/reference/versioning.md
@@ -16,10 +16,9 @@ increment the <code>patch</code> version.
 
 ### Major Release
 
-A major release will be published when there is a breaking change introduced in the API. Major releases will occur
-roughly every **6 months** and may contain breaking changes. Release candidates will be published prior to a major
-release in order to get feedback before the final release. An outline of what is changing and why will be included with
-the release candidates.
+A major release will be published when there is a breaking change introduced in the API. Release candidates will
+be published prior to a major release in order to get feedback before the final release. An outline of what is
+changing and why will be included with the release candidates
 
 ### Minor Release
 

--- a/versioned_docs/version-v4.14/reference/versioning.md
+++ b/versioned_docs/version-v4.14/reference/versioning.md
@@ -16,10 +16,9 @@ increment the <code>patch</code> version.
 
 ### Major Release
 
-A major release will be published when there is a breaking change introduced in the API. Major releases will occur
-roughly every **6 months** and may contain breaking changes. Release candidates will be published prior to a major
-release in order to get feedback before the final release. An outline of what is changing and why will be included with
-the release candidates.
+A major release will be published when there is a breaking change introduced in the API. Release candidates will
+be published prior to a major release in order to get feedback before the final release. An outline of what is
+changing and why will be included with the release candidates
 
 ### Minor Release
 

--- a/versioned_docs/version-v4.15/reference/versioning.md
+++ b/versioned_docs/version-v4.15/reference/versioning.md
@@ -16,10 +16,9 @@ increment the <code>patch</code> version.
 
 ### Major Release
 
-A major release will be published when there is a breaking change introduced in the API. Major releases will occur
-roughly every **6 months** and may contain breaking changes. Release candidates will be published prior to a major
-release in order to get feedback before the final release. An outline of what is changing and why will be included with
-the release candidates.
+A major release will be published when there is a breaking change introduced in the API. Release candidates will
+be published prior to a major release in order to get feedback before the final release. An outline of what is
+changing and why will be included with the release candidates
 
 ### Minor Release
 

--- a/versioned_docs/version-v4.16/reference/versioning.md
+++ b/versioned_docs/version-v4.16/reference/versioning.md
@@ -16,10 +16,9 @@ increment the <code>patch</code> version.
 
 ### Major Release
 
-A major release will be published when there is a breaking change introduced in the API. Major releases will occur
-roughly every **6 months** and may contain breaking changes. Release candidates will be published prior to a major
-release in order to get feedback before the final release. An outline of what is changing and why will be included with
-the release candidates.
+A major release will be published when there is a breaking change introduced in the API. Release candidates will
+be published prior to a major release in order to get feedback before the final release. An outline of what is
+changing and why will be included with the release candidates
 
 ### Minor Release
 

--- a/versioned_docs/version-v4.17/reference/versioning.md
+++ b/versioned_docs/version-v4.17/reference/versioning.md
@@ -16,10 +16,9 @@ increment the <code>patch</code> version.
 
 ### Major Release
 
-A major release will be published when there is a breaking change introduced in the API. Major releases will occur
-roughly every **6 months** and may contain breaking changes. Release candidates will be published prior to a major
-release in order to get feedback before the final release. An outline of what is changing and why will be included with
-the release candidates.
+A major release will be published when there is a breaking change introduced in the API. Release candidates will
+be published prior to a major release in order to get feedback before the final release. An outline of what is
+changing and why will be included with the release candidates
 
 ### Minor Release
 

--- a/versioned_docs/version-v4.18/reference/versioning.md
+++ b/versioned_docs/version-v4.18/reference/versioning.md
@@ -16,10 +16,9 @@ increment the <code>patch</code> version.
 
 ### Major Release
 
-A major release will be published when there is a breaking change introduced in the API. Major releases will occur
-roughly every **6 months** and may contain breaking changes. Release candidates will be published prior to a major
-release in order to get feedback before the final release. An outline of what is changing and why will be included with
-the release candidates.
+A major release will be published when there is a breaking change introduced in the API. Release candidates will
+be published prior to a major release in order to get feedback before the final release. An outline of what is
+changing and why will be included with the release candidates
 
 ### Minor Release
 

--- a/versioned_docs/version-v4.19/reference/versioning.md
+++ b/versioned_docs/version-v4.19/reference/versioning.md
@@ -16,10 +16,9 @@ increment the <code>patch</code> version.
 
 ### Major Release
 
-A major release will be published when there is a breaking change introduced in the API. Major releases will occur
-roughly every **6 months** and may contain breaking changes. Release candidates will be published prior to a major
-release in order to get feedback before the final release. An outline of what is changing and why will be included with
-the release candidates.
+A major release will be published when there is a breaking change introduced in the API. Release candidates will
+be published prior to a major release in order to get feedback before the final release. An outline of what is
+changing and why will be included with the release candidates
 
 ### Minor Release
 

--- a/versioned_docs/version-v4.2/reference/versioning.md
+++ b/versioned_docs/version-v4.2/reference/versioning.md
@@ -16,10 +16,9 @@ increment the <code>patch</code> version.
 
 ### Major Release
 
-A major release will be published when there is a breaking change introduced in the API. Major releases will occur
-roughly every **6 months** and may contain breaking changes. Release candidates will be published prior to a major
-release in order to get feedback before the final release. An outline of what is changing and why will be included with
-the release candidates.
+A major release will be published when there is a breaking change introduced in the API. Release candidates will
+be published prior to a major release in order to get feedback before the final release. An outline of what is
+changing and why will be included with the release candidates
 
 ### Minor Release
 

--- a/versioned_docs/version-v4.20/reference/versioning.md
+++ b/versioned_docs/version-v4.20/reference/versioning.md
@@ -16,10 +16,9 @@ increment the <code>patch</code> version.
 
 ### Major Release
 
-A major release will be published when there is a breaking change introduced in the API. Major releases will occur
-roughly every **6 months** and may contain breaking changes. Release candidates will be published prior to a major
-release in order to get feedback before the final release. An outline of what is changing and why will be included with
-the release candidates.
+A major release will be published when there is a breaking change introduced in the API. Release candidates will
+be published prior to a major release in order to get feedback before the final release. An outline of what is
+changing and why will be included with the release candidates
 
 ### Minor Release
 

--- a/versioned_docs/version-v4.21/reference/versioning.md
+++ b/versioned_docs/version-v4.21/reference/versioning.md
@@ -16,10 +16,9 @@ increment the <code>patch</code> version.
 
 ### Major Release
 
-A major release will be published when there is a breaking change introduced in the API. Major releases will occur
-roughly every **6 months** and may contain breaking changes. Release candidates will be published prior to a major
-release in order to get feedback before the final release. An outline of what is changing and why will be included with
-the release candidates.
+A major release will be published when there is a breaking change introduced in the API. Release candidates will
+be published prior to a major release in order to get feedback before the final release. An outline of what is
+changing and why will be included with the release candidates
 
 ### Minor Release
 

--- a/versioned_docs/version-v4.22/reference/versioning.md
+++ b/versioned_docs/version-v4.22/reference/versioning.md
@@ -16,10 +16,9 @@ increment the <code>patch</code> version.
 
 ### Major Release
 
-A major release will be published when there is a breaking change introduced in the API. Major releases will occur
-roughly every **6 months** and may contain breaking changes. Release candidates will be published prior to a major
-release in order to get feedback before the final release. An outline of what is changing and why will be included with
-the release candidates.
+A major release will be published when there is a breaking change introduced in the API. Release candidates will
+be published prior to a major release in order to get feedback before the final release. An outline of what is
+changing and why will be included with the release candidates
 
 ### Minor Release
 

--- a/versioned_docs/version-v4.23/reference/versioning.md
+++ b/versioned_docs/version-v4.23/reference/versioning.md
@@ -16,10 +16,9 @@ increment the <code>patch</code> version.
 
 ### Major Release
 
-A major release will be published when there is a breaking change introduced in the API. Major releases will occur
-roughly every **6 months** and may contain breaking changes. Release candidates will be published prior to a major
-release in order to get feedback before the final release. An outline of what is changing and why will be included with
-the release candidates.
+A major release will be published when there is a breaking change introduced in the API. Release candidates will
+be published prior to a major release in order to get feedback before the final release. An outline of what is
+changing and why will be included with the release candidates
 
 ### Minor Release
 

--- a/versioned_docs/version-v4.3/reference/versioning.md
+++ b/versioned_docs/version-v4.3/reference/versioning.md
@@ -16,10 +16,9 @@ increment the <code>patch</code> version.
 
 ### Major Release
 
-A major release will be published when there is a breaking change introduced in the API. Major releases will occur
-roughly every **6 months** and may contain breaking changes. Release candidates will be published prior to a major
-release in order to get feedback before the final release. An outline of what is changing and why will be included with
-the release candidates.
+A major release will be published when there is a breaking change introduced in the API. Release candidates will
+be published prior to a major release in order to get feedback before the final release. An outline of what is
+changing and why will be included with the release candidates
 
 ### Minor Release
 

--- a/versioned_docs/version-v4.4/reference/versioning.md
+++ b/versioned_docs/version-v4.4/reference/versioning.md
@@ -16,10 +16,9 @@ increment the <code>patch</code> version.
 
 ### Major Release
 
-A major release will be published when there is a breaking change introduced in the API. Major releases will occur
-roughly every **6 months** and may contain breaking changes. Release candidates will be published prior to a major
-release in order to get feedback before the final release. An outline of what is changing and why will be included with
-the release candidates.
+A major release will be published when there is a breaking change introduced in the API. Release candidates will
+be published prior to a major release in order to get feedback before the final release. An outline of what is
+changing and why will be included with the release candidates
 
 ### Minor Release
 

--- a/versioned_docs/version-v4.5/reference/versioning.md
+++ b/versioned_docs/version-v4.5/reference/versioning.md
@@ -16,10 +16,9 @@ increment the <code>patch</code> version.
 
 ### Major Release
 
-A major release will be published when there is a breaking change introduced in the API. Major releases will occur
-roughly every **6 months** and may contain breaking changes. Release candidates will be published prior to a major
-release in order to get feedback before the final release. An outline of what is changing and why will be included with
-the release candidates.
+A major release will be published when there is a breaking change introduced in the API. Release candidates will
+be published prior to a major release in order to get feedback before the final release. An outline of what is
+changing and why will be included with the release candidates
 
 ### Minor Release
 

--- a/versioned_docs/version-v4.6/reference/versioning.md
+++ b/versioned_docs/version-v4.6/reference/versioning.md
@@ -16,10 +16,9 @@ increment the <code>patch</code> version.
 
 ### Major Release
 
-A major release will be published when there is a breaking change introduced in the API. Major releases will occur
-roughly every **6 months** and may contain breaking changes. Release candidates will be published prior to a major
-release in order to get feedback before the final release. An outline of what is changing and why will be included with
-the release candidates.
+A major release will be published when there is a breaking change introduced in the API. Release candidates will
+be published prior to a major release in order to get feedback before the final release. An outline of what is
+changing and why will be included with the release candidates
 
 ### Minor Release
 

--- a/versioned_docs/version-v4.7/reference/versioning.md
+++ b/versioned_docs/version-v4.7/reference/versioning.md
@@ -16,10 +16,9 @@ increment the <code>patch</code> version.
 
 ### Major Release
 
-A major release will be published when there is a breaking change introduced in the API. Major releases will occur
-roughly every **6 months** and may contain breaking changes. Release candidates will be published prior to a major
-release in order to get feedback before the final release. An outline of what is changing and why will be included with
-the release candidates.
+A major release will be published when there is a breaking change introduced in the API. Release candidates will
+be published prior to a major release in order to get feedback before the final release. An outline of what is
+changing and why will be included with the release candidates
 
 ### Minor Release
 

--- a/versioned_docs/version-v4.8/reference/versioning.md
+++ b/versioned_docs/version-v4.8/reference/versioning.md
@@ -16,10 +16,9 @@ increment the <code>patch</code> version.
 
 ### Major Release
 
-A major release will be published when there is a breaking change introduced in the API. Major releases will occur
-roughly every **6 months** and may contain breaking changes. Release candidates will be published prior to a major
-release in order to get feedback before the final release. An outline of what is changing and why will be included with
-the release candidates.
+A major release will be published when there is a breaking change introduced in the API. Release candidates will
+be published prior to a major release in order to get feedback before the final release. An outline of what is
+changing and why will be included with the release candidates
 
 ### Minor Release
 

--- a/versioned_docs/version-v4.9/reference/versioning.md
+++ b/versioned_docs/version-v4.9/reference/versioning.md
@@ -16,10 +16,9 @@ increment the <code>patch</code> version.
 
 ### Major Release
 
-A major release will be published when there is a breaking change introduced in the API. Major releases will occur
-roughly every **6 months** and may contain breaking changes. Release candidates will be published prior to a major
-release in order to get feedback before the final release. An outline of what is changing and why will be included with
-the release candidates.
+A major release will be published when there is a breaking change introduced in the API. Release candidates will
+be published prior to a major release in order to get feedback before the final release. An outline of what is
+changing and why will be included with the release candidates
 
 ### Minor Release
 


### PR DESCRIPTION
We no longer can guarantee major releases every 6 month, hence removing this statement from our versioning docs.

fixes #1503