### PR TITLE
Update slotChildNodesFix in extras.md

### DIFF
--- a/versioned_docs/version-v4.39/config/extras.md
+++ b/versioned_docs/version-v4.39/config/extras.md
@@ -174,7 +174,7 @@ It is possible to assign data to the actual `<script>` element's `data-opts` pro
 
 ### slotChildNodesFix
 
-For browsers that do not support shadow dom (IE11 and Edge 18 and below), slot is polyfilled to simulate the same behavior. However, the host element's `childNodes` and `children` getters are not patched to only show the child nodes and elements of the default slot. Defaults to `false`.
+For browsers that do not support shadow dom (IE11 and Edge 18 and below), slot is polyfilled to simulate the same behavior. The host element's `childNodes` and `children` getters are patched to only show the child nodes and elements of the default slot. Defaults to `false`.
 
 ### addGlobalStyleToComponents
 


### PR DESCRIPTION
I'm not 100% sure if this is needs updating. However, from my understanding starting around stencil v4.25, when `slotChildNodesFix` is set to true then the `childNodes` and `children` getters for the host element of scoped components only show the elements in the fake slot.  