### PR TITLE
docs(api): fix Mixin example to use correct factory functions

### DIFF
--- a/docs/components/api.md
+++ b/docs/components/api.md
@@ -292,7 +292,7 @@ Compose multiple classes into a single constructor using factory functions.
   @Component({
     tag: 'its-mixing-time',
   })
-  export class X extends Mixin(aFactory, aFactory, cFactory) {
+  export class X extends Mixin(aFactory, bFactory, cFactory) {
     render() {
       return <div>{this.propA} {this.propB} {this.propC}</div>
     }


### PR DESCRIPTION
## Description
Fixed an error in the Mixin API documentation example where `aFactory` was incorrectly used twice in the composition chain instead of using `bFactory`.