### PR TITLE
Update react.md

### DIFF
--- a/versioned_docs/version-v4.43/framework-integration/react.md
+++ b/versioned_docs/version-v4.43/framework-integration/react.md
@@ -475,7 +475,7 @@ a time.
 
 **Optional**
 
-**Default: `true`** 
+**Default: `false`** 
 
 **Type: `boolean`**
 


### PR DESCRIPTION
The default type of `esModules` was wrong, as mentioned in its own description below

<img width="779" height="293" alt="Capture d’écran 2026-07-27 à 10 32 47" src="https://github.com/user-attachments/assets/7d460994-b125-4dd0-88f6-699f029223da" />