### PR TITLE
Update styling.md for CSS custom properties clarification

### DIFF
--- a/versioned_docs/version-v4.43/components/styling.md
+++ b/versioned_docs/version-v4.43/components/styling.md
@@ -139,7 +139,7 @@ CSS custom properties can allow the consumers of a component to customize a comp
 ```
 
 :::note
-CSS custom properties must be declared on the `Host` element (`:host`) in order for them to be exposed to the consuming application.
+Declaring a CSS custom property on `:host` provides a default value for the component. A consuming application can set the CSS custom property on the host element whether or not the component declares it on `:host`.
 :::
 
 The `shadow-card` heading will have a default color of `black`, but this can now be changed in the light DOM by selecting the `shadow-card` and changing the value of the `--heading-color` custom property.


### PR DESCRIPTION
I think the current note is a bit confusing/misleading if I understand it correctly.  It indicates that a CSS custom property must first be declared on `:host` to be exposed to the consuming application, but I don't think this is the case.

For example, this works without declaring the CSS custom property on `:host`:

```css
:host {
  display: block;
}

.heading {
  color: var(--heading-color, black);
}
```
Even `color: var(--heading-color);` should work fine too.


Then in consumer:
```css
shadow-card {
  --heading-color: blue;
}
```

Here, `shadow-card` is the host element, and the CSS custom property inherits into the shadow tree without first being declared on `:host`.